### PR TITLE
feat: add pre-commit to repo

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,60 @@
+repos:
+  - repo: https://github.com/FeryET/pre-commit-rust
+    rev: v1.2.1
+    hooks:
+      - id: fmt
+      - id: cargo-check
+      - id: clippy
+        args: ["--", "-D", "warnings"]
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v6.0.0
+    hooks:
+      - id: no-commit-to-branch
+        name: Prevent main branch commits
+        description: Prevent the user from committing directly to the primary branch.
+      - id: check-added-large-files
+        name: Check for large files
+        description: Prevent the user from committing very large files.
+        args: ["--maxkb=500"]
+  - repo: https://github.com/abravalheri/validate-pyproject
+    rev: v0.24.1
+    hooks:
+      - id: validate-pyproject
+        name: Validate pyproject.toml
+        description: Verify that pyproject.toml adheres to the established schema.
+    # Verify that GitHub workflows are well formed
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    # Ruff version.
+    rev: v0.14.4
+    hooks:
+      - id: ruff-check
+        name: Lint code using ruff; sort and organize imports
+        types_or: [python, pyi]
+        args: [--extend-select, "I", --fixable, "I,F", --fix]
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    # Ruff version.
+    rev: v0.14.4
+    hooks:
+      # Run the linter.
+      - id: ruff-format
+  - repo: local
+    hooks:
+      - id: sphinx-build
+        name: Build documentation with Sphinx
+        entry: sphinx-build
+        language: system
+        always_run: true
+        exclude_types: [file, symlink]
+        args: [
+            "-M", # Run sphinx in make mode, so we can use -D flag later
+            # Note: -M requires next 3 args to be builder, source, output
+            "html", # Specify builder
+            "./docs", # Source directory of documents
+            "./_readthedocs", # Output directory for rendered documents
+            "-T", # Show full trace back on exception
+            "-E", # Don't use saved env; always read all files
+            "-d", # Flag for cached environment and doctrees
+            "./docs/_build/doctrees", # Directory
+            "-D", # Flag to override settings in conf.py
+            "exclude_patterns=notebooks/*", # Exclude our notebooks from pre-commit
+          ]


### PR DESCRIPTION
This pull request introduces a comprehensive `.pre-commit-config.yaml` to enforce code quality and workflow standards across Python and Rust files. The configuration sets up multiple pre-commit hooks for formatting, linting, validation, and documentation building.

Pre-commit hook setup:

* Added Rust hooks for formatting (`fmt`), static analysis (`clippy` with warnings as errors), and build checks (`cargo-check`) to improve Rust code quality.
* Included Python hooks for linting and import organization using `ruff`, as well as validation of `pyproject.toml` files to ensure compliance with schema standards.
* Added generic hooks to prevent commits to the main branch and block large files from being committed, enhancing repository safety and maintainability.

Documentation and workflow validation:

* Configured a local hook to build documentation with Sphinx, excluding notebooks from the build process and ensuring docs are always up-to-date before commits.