### PR TITLE
More github action work

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -204,10 +204,10 @@ jobs:
                   ls -lh dist/
 
             - name: Publish to TestPyPI
-              uses: PyO3/maturin-action@v1
+              uses: pypa/gh-action-pypi-publish@release/v1
               with:
-                  command: upload
-                  args: --non-interactive --skip-existing --repository-url https://test.pypi.org/legacy/ dist/*
+                  repository-url: https://test.pypi.org/legacy/
+                  skip-existing: true
 
     publish:
         name: Publish to PyPI
@@ -234,16 +234,7 @@ jobs:
                   ls -lh dist/
 
             - name: Publish to PyPI
-              uses: PyO3/maturin-action@v1
+              uses: pypa/gh-action-pypi-publish@release/v1
               with:
-                  command: upload
-                  args: --non-interactive --skip-existing dist/*
+                  skip-existing: true
 
-            - name: Create GitHub Release
-              uses: softprops/action-gh-release@v1
-              if: startsWith(github.ref, 'refs/tags/v')
-              with:
-                  files: dist/*
-                  generate_release_notes: true
-              env:
-                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This pull request updates the build workflow in `.github/workflows/build-wheels.yml` to ensure that certain platform builds (Linux aarch64, macOS x86_64, and macOS aarch64) only run for release builds, optimizing CI resources and reducing unnecessary builds. The workflow now conditionally skips steps for these platforms unless a release tag is detected, and applies this skip logic consistently across all build and setup steps.

Conditional build logic for release-only platforms:

* Added a `release_only: true` flag to Linux aarch64, macOS x86_64, and macOS aarch64 build matrix entries, so these builds only run on release tags.
* Introduced a "Check if should skip build" step that sets a skip flag based on the `release_only` property and the current git ref, controlling subsequent workflow steps.

Consistent application of skip logic across workflow steps:

* Updated all build and setup steps (`actions/checkout`, version setting, Python setup, Rust toolchain, caching, QEMU setup, wheel builds, artifact upload, and wheel listing) to conditionally run only if the skip flag is not set, ensuring resources are only used when needed. [[1]](diffhunk://#diff-14b51e9e6321caf5d23b2253f2415daf475fdaa417c0aa8fe896c3a460f2d023R89-R113) [[2]](diffhunk://#diff-14b51e9e6321caf5d23b2253f2415daf475fdaa417c0aa8fe896c3a460f2d023L108-R146)

These changes help streamline CI, saving time and compute by avoiding non-release builds for platforms where wheels are only needed for releases.