### PR TITLE
More Actions Work

### DIFF
--- a/.github/workflows/build-wheels-dev.yml
+++ b/.github/workflows/build-wheels-dev.yml
@@ -1,0 +1,102 @@
+name: Build Dev Wheels
+
+on:
+    push:
+        branches:
+            - main
+    workflow_dispatch:
+        inputs:
+            publish_testpypi:
+                description: "Publish to TestPyPI"
+                required: false
+                default: false
+                type: boolean
+
+permissions:
+    contents: read
+
+jobs:
+    build-linux-x86_64:
+        name: Build Linux x86_64 wheels
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v4
+              with:
+                  fetch-depth: 0
+
+            - name: Set version from git tag
+              run: |
+                  VERSION=$(git describe --tags --abbrev=0 2>/dev/null | sed 's/^v//' || echo "0.1.0")
+                  echo "VERSION=$VERSION" >> $GITHUB_ENV
+                  sed -i.bak "s/^version = \".*\"/version = \"$VERSION\"/" Cargo.toml
+                  rm -f Cargo.toml.bak
+
+            - name: Build wheels
+              uses: PyO3/maturin-action@v1
+              with:
+                  target: x86_64
+                  args: --release --out dist --interpreter 3.10 3.11 3.12 3.13
+                  manylinux: auto
+                  sccache: true
+
+            - name: Upload wheels
+              uses: actions/upload-artifact@v4
+              with:
+                  name: wheels-linux-x86_64
+                  path: dist/*.whl
+
+    build-sdist:
+        name: Build source distribution
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v4
+              with:
+                  fetch-depth: 0
+
+            - name: Set version from git tag
+              run: |
+                  VERSION=$(git describe --tags --abbrev=0 2>/dev/null | sed 's/^v//' || echo "0.1.0")
+                  echo "VERSION=$VERSION" >> $GITHUB_ENV
+                  sed -i.bak "s/^version = \".*\"/version = \"$VERSION\"/" Cargo.toml
+                  rm -f Cargo.toml.bak
+
+            - name: Build sdist
+              uses: PyO3/maturin-action@v1
+              with:
+                  command: sdist
+                  args: --out dist
+
+            - name: Upload sdist
+              uses: actions/upload-artifact@v4
+              with:
+                  name: sdist
+                  path: dist/*.tar.gz
+
+    publish-testpypi:
+        name: Publish to TestPyPI
+        runs-on: ubuntu-latest
+        needs: [build-linux-x86_64, build-sdist]
+        if: github.event_name == 'workflow_dispatch' && inputs.publish_testpypi
+        permissions:
+            id-token: write
+
+        steps:
+            - uses: actions/checkout@v4
+
+            - name: Download all artifacts
+              uses: actions/download-artifact@v4
+              with:
+                  path: dist-artifacts
+
+            - name: Consolidate artifacts
+              run: |
+                  mkdir -p dist
+                  find dist-artifacts -name '*.whl' -exec mv {} dist/ \;
+                  find dist-artifacts -name '*.tar.gz' -exec mv {} dist/ \;
+                  ls -lh dist/
+
+            - name: Publish to TestPyPI
+              uses: pypa/gh-action-pypi-publish@release/v1
+              with:
+                  repository-url: https://test.pypi.org/legacy/
+                  skip-existing: true

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -1,238 +1,201 @@
 name: Build Release Wheels
 
 on:
-    push:
-        branches:
-            - main
-        tags:
-            - "v*"
-    workflow_dispatch:
-        inputs:
-            publish_testpypi:
-                description: "Publish to TestPyPI"
-                required: false
-                default: false
-                type: boolean
+  push:
+    tags:
+      - "v*"
 
 permissions:
-    contents: read
+  contents: read
 
 jobs:
-    build-wheels:
-        name: Build wheels on ${{ matrix.os }} - ${{ matrix.target }}
-        runs-on: ${{ matrix.os }}
-        strategy:
-            fail-fast: false
-            matrix:
-                include:
-                    # Linux x86_64
-                    - os: ubuntu-latest
-                      target: x86_64
+  build-linux-x86_64:
+    name: Build Linux x86_64 wheels
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
-                    # Linux aarch64 - only on release
-                    - os: ubuntu-latest
-                      target: aarch64
-                      release_only: true
+      - name: Set version from git tag
+        run: |
+          VERSION=${GITHUB_REF#refs/tags/v}
+          echo "VERSION=$VERSION" >> $GITHUB_ENV
+          sed -i.bak "s/^version = \".*\"/version = \"$VERSION\"/" Cargo.toml
+          rm -f Cargo.toml.bak
 
-                    # macOS x86_64 (Intel) - only on release
-                    - os: macos-15-intel
-                      target: x86_64-apple-darwin
-                      release_only: true
+      - name: Build wheels
+        uses: PyO3/maturin-action@v1
+        with:
+          target: x86_64
+          args: --release --out dist --interpreter 3.10 3.11 3.12 3.13
+          manylinux: auto
+          sccache: true
 
-                    # macOS aarch64 (Apple Silicon) - only on release
-                    - os: macos-latest
-                      target: aarch64-apple-darwin
-                      release_only: true
+      - name: Upload wheels
+        uses: actions/upload-artifact@v4
+        with:
+          name: wheels-linux-x86_64
+          path: dist/*.whl
 
-                    # Windows x86_64 - temporarily disabled
-                    # - os: windows-latest
-                    #   target: x86_64-pc-windows-msvc
+  build-linux-aarch64:
+    name: Build Linux aarch64 wheels
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
-        steps:
-            - name: Check if should skip build
-              id: skip_check
-              run: |
-                  if [[ "${{ matrix.release_only }}" == "true" ]] && [[ "${{ github.ref }}" != refs/tags/v* ]]; then
-                    echo "skip=true" >> $GITHUB_OUTPUT
-                  else
-                    echo "skip=false" >> $GITHUB_OUTPUT
-                  fi
+      - name: Set version from git tag
+        run: |
+          VERSION=${GITHUB_REF#refs/tags/v}
+          echo "VERSION=$VERSION" >> $GITHUB_ENV
+          sed -i.bak "s/^version = \".*\"/version = \"$VERSION\"/" Cargo.toml
+          rm -f Cargo.toml.bak
 
-            - uses: actions/checkout@v4
-              if: steps.skip_check.outputs.skip != 'true'
-              with:
-                  fetch-depth: 0
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: arm64
 
-            - name: Set version from git tag
-              if: steps.skip_check.outputs.skip != 'true'
-              shell: bash
-              run: |
-                  if [[ "$GITHUB_REF" == refs/tags/v* ]]; then
-                    VERSION=${GITHUB_REF#refs/tags/v}
-                  else
-                    VERSION=$(git describe --tags --abbrev=0 2>/dev/null | sed 's/^v//' || echo "0.1.0")
-                  fi
-                  echo "VERSION=$VERSION" >> $GITHUB_ENV
-                  echo "Building version: $VERSION"
+      - name: Build wheels
+        uses: PyO3/maturin-action@v1
+        with:
+          target: aarch64
+          args: --release --out dist --interpreter 3.10 3.11 3.12 3.13
+          manylinux: auto
+          sccache: true
+        env:
+          CFLAGS_aarch64_unknown_linux_gnu: "-D__ARM_ARCH=8"
 
-                  # Update Cargo.toml with version
-                  if [[ "$RUNNER_OS" == "Windows" ]]; then
-                    sed -i "s/^version = \".*\"/version = \"$VERSION\"/" Cargo.toml
-                  else
-                    sed -i.bak "s/^version = \".*\"/version = \"$VERSION\"/" Cargo.toml
-                    rm -f Cargo.toml.bak
-                  fi
+      - name: Upload wheels
+        uses: actions/upload-artifact@v4
+        with:
+          name: wheels-linux-aarch64
+          path: dist/*.whl
 
-            - name: Set up Python
-              if: steps.skip_check.outputs.skip != 'true'
-              uses: actions/setup-python@v5
-              with:
-                  python-version: "3.11"
+  build-macos-x86_64:
+    name: Build macOS x86_64 wheels
+    runs-on: macos-13
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
-            - name: Install Rust toolchain
-              if: steps.skip_check.outputs.skip != 'true'
-              uses: dtolnay/rust-toolchain@stable
+      - name: Set version from git tag
+        run: |
+          VERSION=${GITHUB_REF#refs/tags/v}
+          echo "VERSION=$VERSION" >> $GITHUB_ENV
+          sed -i.bak "s/^version = \".*\"/version = \"$VERSION\"/" Cargo.toml
+          rm -f Cargo.toml.bak
 
-            - name: Cache Rust dependencies
-              if: steps.skip_check.outputs.skip != 'true'
-              uses: Swatinem/rust-cache@v2
-              with:
-                  key: ${{ matrix.target }}
-                  cache-on-failure: true
-                  workspaces: "."
+      - name: Build wheels
+        uses: PyO3/maturin-action@v1
+        with:
+          target: x86_64-apple-darwin
+          args: --release --out dist --interpreter 3.10 3.11 3.12 3.13
+          sccache: true
 
-            - name: Set up QEMU (for cross-compilation on Linux)
-              if: steps.skip_check.outputs.skip != 'true' && runner.os == 'Linux' && matrix.target == 'aarch64'
-              uses: docker/setup-qemu-action@v3
-              with:
-                  platforms: arm64
+      - name: Upload wheels
+        uses: actions/upload-artifact@v4
+        with:
+          name: wheels-macos-x86_64
+          path: dist/*.whl
 
-            - name: Build wheels (Linux)
-              if: steps.skip_check.outputs.skip != 'true' && runner.os == 'Linux'
-              uses: PyO3/maturin-action@v1
-              with:
-                  target: ${{ matrix.target }}
-                  args: --release --out dist --interpreter 3.10 3.11 3.12 3.13
-                  manylinux: auto
-              env:
-                  # Fix for ring crate ARM64 cross-compilation
-                  CFLAGS_aarch64_unknown_linux_gnu: "-D__ARM_ARCH=8"
+  build-macos-aarch64:
+    name: Build macOS aarch64 wheels
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
-            - name: Build wheels (macOS)
-              if: steps.skip_check.outputs.skip != 'true' && runner.os == 'macOS'
-              uses: PyO3/maturin-action@v1
-              with:
-                  target: ${{ matrix.target }}
-                  args: --release --out dist --interpreter 3.10 3.11 3.12 3.13
+      - name: Set version from git tag
+        run: |
+          VERSION=${GITHUB_REF#refs/tags/v}
+          echo "VERSION=$VERSION" >> $GITHUB_ENV
+          sed -i.bak "s/^version = \".*\"/version = \"$VERSION\"/" Cargo.toml
+          rm -f Cargo.toml.bak
 
-            - name: Build wheels (Windows)
-              if: steps.skip_check.outputs.skip != 'true' && runner.os == 'Windows'
-              uses: PyO3/maturin-action@v1
-              with:
-                  target: ${{ matrix.target }}
-                  args: --release --out dist --interpreter 3.10 3.11 3.12 3.13
+      - name: Build wheels
+        uses: PyO3/maturin-action@v1
+        with:
+          target: aarch64-apple-darwin
+          args: --release --out dist --interpreter 3.10 3.11 3.12 3.13
+          sccache: true
 
-            - name: Upload wheels
-              if: steps.skip_check.outputs.skip != 'true'
-              uses: actions/upload-artifact@v4
-              with:
-                  name: wheels-${{ matrix.os }}-${{ matrix.target }}
-                  path: dist/*.whl
-                  if-no-files-found: error
+      - name: Upload wheels
+        uses: actions/upload-artifact@v4
+        with:
+          name: wheels-macos-aarch64
+          path: dist/*.whl
 
-            - name: List built wheels
-              if: steps.skip_check.outputs.skip != 'true'
-              shell: bash
-              run: |
-                  echo "Built wheels:"
-                  ls -lh dist/
+  build-sdist:
+    name: Build source distribution
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
-    build-sdist:
-        name: Build source distribution
-        runs-on: ubuntu-latest
-        steps:
-            - uses: actions/checkout@v4
-              with:
-                  fetch-depth: 0
+      - name: Set version from git tag
+        run: |
+          VERSION=${GITHUB_REF#refs/tags/v}
+          echo "VERSION=$VERSION" >> $GITHUB_ENV
+          sed -i.bak "s/^version = \".*\"/version = \"$VERSION\"/" Cargo.toml
+          rm -f Cargo.toml.bak
 
-            - name: Set version from git tag
-              run: |
-                  if [[ "$GITHUB_REF" == refs/tags/v* ]]; then
-                    VERSION=${GITHUB_REF#refs/tags/v}
-                  else
-                    VERSION=$(git describe --tags --abbrev=0 2>/dev/null | sed 's/^v//' || echo "0.1.0")
-                  fi
-                  echo "VERSION=$VERSION" >> $GITHUB_ENV
-                  sed -i.bak "s/^version = \".*\"/version = \"$VERSION\"/" Cargo.toml
-                  rm -f Cargo.toml.bak
+      - name: Build sdist
+        uses: PyO3/maturin-action@v1
+        with:
+          command: sdist
+          args: --out dist
 
-            - name: Build sdist
-              uses: PyO3/maturin-action@v1
-              with:
-                  command: sdist
-                  args: --out dist
+      - name: Upload sdist
+        uses: actions/upload-artifact@v4
+        with:
+          name: sdist
+          path: dist/*.tar.gz
 
-            - name: Upload sdist
-              uses: actions/upload-artifact@v4
-              with:
-                  name: sdist
-                  path: dist/*.tar.gz
+  publish:
+    name: Publish to PyPI
+    runs-on: ubuntu-latest
+    needs:
+      [
+        build-linux-x86_64,
+        build-linux-aarch64,
+        build-macos-x86_64,
+        build-macos-aarch64,
+        build-sdist,
+      ]
+    permissions:
+      id-token: write # For trusted publishing
+      contents: write # For creating GitHub releases
 
-    publish-testpypi:
-        name: Publish to TestPyPI
-        runs-on: ubuntu-latest
-        needs: [build-wheels, build-sdist]
-        if: github.event_name == 'workflow_dispatch' && inputs.publish_testpypi
-        permissions:
-            id-token: write
+    steps:
+      - uses: actions/checkout@v4
 
-        steps:
-            - uses: actions/checkout@v4
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: dist-artifacts
 
-            - name: Download all artifacts
-              uses: actions/download-artifact@v4
-              with:
-                  path: dist-artifacts
+      - name: Consolidate artifacts
+        run: |
+          mkdir -p dist
+          find dist-artifacts -name '*.whl' -exec mv {} dist/ \;
+          find dist-artifacts -name '*.tar.gz' -exec mv {} dist/ \;
+          ls -lh dist/
 
-            - name: Consolidate artifacts
-              run: |
-                  mkdir -p dist
-                  find dist-artifacts -name '*.whl' -exec mv {} dist/ \;
-                  find dist-artifacts -name '*.tar.gz' -exec mv {} dist/ \;
-                  ls -lh dist/
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          skip-existing: true
 
-            - name: Publish to TestPyPI
-              uses: pypa/gh-action-pypi-publish@release/v1
-              with:
-                  repository-url: https://test.pypi.org/legacy/
-                  skip-existing: true
-
-    publish:
-        name: Publish to PyPI
-        runs-on: ubuntu-latest
-        needs: [build-wheels, build-sdist]
-        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
-        permissions:
-            id-token: write # For trusted publishing
-            contents: write # For creating GitHub releases
-
-        steps:
-            - uses: actions/checkout@v4
-
-            - name: Download all artifacts
-              uses: actions/download-artifact@v4
-              with:
-                  path: dist-artifacts
-
-            - name: Consolidate artifacts
-              run: |
-                  mkdir -p dist
-                  find dist-artifacts -name '*.whl' -exec mv {} dist/ \;
-                  find dist-artifacts -name '*.tar.gz' -exec mv {} dist/ \;
-                  ls -lh dist/
-
-            - name: Publish to PyPI
-              uses: pypa/gh-action-pypi-publish@release/v1
-              with:
-                  skip-existing: true
-
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v1
+        with:
+          files: dist/*
+          generate_release_notes: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This pull request refactors and improves the GitHub Actions workflows for building and publishing Python wheels and source distributions. The main changes include splitting the build process into more granular jobs per platform and architecture, simplifying version handling, and enhancing the release publishing process. Additionally, the workflow for publishing to TestPyPI is moved out of the release workflow and into a new, dedicated development workflow.

**Workflow restructuring and platform-specific builds:**

* The release build workflow `.github/workflows/build-wheels.yml` now has separate jobs for building wheels for each platform and architecture (`build-linux-x86_64`, `build-linux-aarch64`, `build-macos-x86_64`, and `build-macos-aarch64`), instead of using a matrix strategy. This improves clarity and maintainability.
* The source distribution job (`build-sdist`) remains but is now coordinated with the new platform-specific wheel jobs.

**Version handling simplification:**

* The logic for setting the version from the git tag is simplified and unified across jobs, removing fallback and conditional logic.

**Release and publishing enhancements:**

* The publish job now depends on all platform-specific wheel and sdist jobs, ensuring all artifacts are available before publishing to PyPI.
* A new step creates a GitHub Release with all built distribution files and auto-generated release notes.

**Development workflow separation:**

* A new workflow `.github/workflows/build-wheels-dev.yml` is introduced for building wheels and source distributions on the `main` branch or on manual dispatch, with an option to publish to TestPyPI. This separates development/test publishing from production releases.
* The TestPyPI publishing logic is removed from the release workflow and moved to the new development workflow. [[1]](diffhunk://#diff-14b51e9e6321caf5d23b2253f2415daf475fdaa417c0aa8fe896c3a460f2d023L5-R131) [[2]](diffhunk://#diff-14b51e9e6321caf5d23b2253f2415daf475fdaa417c0aa8fe896c3a460f2d023L183-R170)

These changes make the build and release process more robust, easier to maintain, and clearer for contributors.