### PR TITLE
bugfix: update types on Ephemeris properties

### DIFF
--- a/rust_ephem/_rust_ephem.pyi
+++ b/rust_ephem/_rust_ephem.pyi
@@ -362,12 +362,12 @@ class TLEEphemeris:
         ...
 
     @property
-    def teme_pv(self) -> PositionVelocityData | None:
+    def teme_pv(self) -> PositionVelocityData:
         """Position and velocity data in TEME frame"""
         ...
 
     @property
-    def itrs_pv(self) -> PositionVelocityData | None:
+    def itrs_pv(self) -> PositionVelocityData:
         """Position and velocity data in ITRS (Earth-fixed) frame"""
         ...
 
@@ -397,12 +397,12 @@ class TLEEphemeris:
         ...
 
     @property
-    def gcrs_pv(self) -> PositionVelocityData | None:
+    def gcrs_pv(self) -> PositionVelocityData:
         """Position and velocity data in GCRS frame"""
         ...
 
     @property
-    def timestamp(self) -> npt.NDArray[np.object_] | None:
+    def timestamp(self) -> npt.NDArray[np.object_]:
         """
         Array of timestamps for the ephemeris.
 
@@ -585,12 +585,12 @@ class SPICEEphemeris:
         ...
 
     @property
-    def gcrs_pv(self) -> PositionVelocityData | None:
+    def gcrs_pv(self) -> PositionVelocityData:
         """Position and velocity data in GCRS frame"""
         ...
 
     @property
-    def itrs_pv(self) -> PositionVelocityData | None:
+    def itrs_pv(self) -> PositionVelocityData:
         """Position and velocity data in ITRS (Earth-fixed) frame"""
         ...
 
@@ -620,7 +620,7 @@ class SPICEEphemeris:
         ...
 
     @property
-    def timestamp(self) -> npt.NDArray[np.object_] | None:
+    def timestamp(self) -> npt.NDArray[np.object_]:
         """
         Array of timestamps for the ephemeris.
 
@@ -779,12 +779,12 @@ class GroundEphemeris:
         ...
 
     @property
-    def gcrs_pv(self) -> PositionVelocityData | None:
+    def gcrs_pv(self) -> PositionVelocityData:
         """Position and velocity data in GCRS frame"""
         ...
 
     @property
-    def itrs_pv(self) -> PositionVelocityData | None:
+    def itrs_pv(self) -> PositionVelocityData:
         """Position and velocity data in ITRS (Earth-fixed) frame"""
         ...
 
@@ -814,17 +814,17 @@ class GroundEphemeris:
         ...
 
     @property
-    def sun_pv(self) -> PositionVelocityData | None:
+    def sun_pv(self) -> PositionVelocityData:
         """Position and velocity data for Sun"""
         ...
 
     @property
-    def moon_pv(self) -> PositionVelocityData | None:
+    def moon_pv(self) -> PositionVelocityData:
         """Position and velocity data for Moon"""
         ...
 
     @property
-    def timestamp(self) -> npt.NDArray[np.object_] | None:
+    def timestamp(self) -> npt.NDArray[np.object_]:
         """
         Array of timestamps for the ephemeris.
 
@@ -834,12 +834,12 @@ class GroundEphemeris:
         ...
 
     @property
-    def obsgeoloc(self) -> Any | None:  # Returns astropy quantity array
+    def obsgeoloc(self) -> Any:  # Returns astropy quantity array
         """Observatory geocentric location for astropy"""
         ...
 
     @property
-    def obsgeovel(self) -> Any | None:  # Returns astropy quantity array
+    def obsgeovel(self) -> Any:  # Returns astropy quantity array
         """Observatory geocentric velocity for astropy"""
         ...
 


### PR DESCRIPTION
# Description

This pull request updates the type annotations for several properties in the `TLEEphemeris`, `SPICEEphemeris`, and `GroundEphemeris` classes in the `rust_ephem/_rust_ephem.pyi` file. The main change is the removal of the `| None` option from property return types, indicating that these properties will always return data and not `None`.

## Type annotation consistency and guarantees

* Updated `teme_pv`, `itrs_pv`, and `gcrs_pv` properties in `TLEEphemeris` to always return `PositionVelocityData` instead of possibly `None`. (`rust_ephem/_rust_ephem.pyi`) [[1]](diffhunk://#diff-7ed8034838678ab42bb592e27c3315872651998aec8719d99640b9bdd2ade077L365-R370) [[2]](diffhunk://#diff-7ed8034838678ab42bb592e27c3315872651998aec8719d99640b9bdd2ade077L400-R405)
* Updated `timestamp` property in `TLEEphemeris` to always return an array, not `None`. (`rust_ephem/_rust_ephem.pyi`)
* Updated `gcrs_pv`, `itrs_pv`, and `timestamp` properties in `SPICEEphemeris` to always return data, removing the possibility of `None`. (`rust_ephem/_rust_ephem.pyi`) [[1]](diffhunk://#diff-7ed8034838678ab42bb592e27c3315872651998aec8719d99640b9bdd2ade077L588-R593) [[2]](diffhunk://#diff-7ed8034838678ab42bb592e27c3315872651998aec8719d99640b9bdd2ade077L623-R623)
* Updated `gcrs_pv`, `itrs_pv`, `sun_pv`, `moon_pv`, and `timestamp` properties in `GroundEphemeris` to always return data, removing `None` as a possible return value. (`rust_ephem/_rust_ephem.pyi`) [[1]](diffhunk://#diff-7ed8034838678ab42bb592e27c3315872651998aec8719d99640b9bdd2ade077L782-R787) [[2]](diffhunk://#diff-7ed8034838678ab42bb592e27c3315872651998aec8719d99640b9bdd2ade077L817-R827)
* Updated `obsgeoloc` and `obsgeovel` properties in `GroundEphemeris` to always return the astropy quantity array, not `None`. (`rust_ephem/_rust_ephem.pyi`)