### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/python-lint.yml
+++ b/.github/workflows/python-lint.yml
@@ -2,6 +2,8 @@
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python
 
 name: Python Lint
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/CosmicFrontierLabs/rust-ephem/security/code-scanning/1](https://github.com/CosmicFrontierLabs/rust-ephem/security/code-scanning/1)

To fix this problem, we should explicitly add a `permissions` block with the minimal required permissions to the workflow. Since both jobs only need to read repository contents (`actions/checkout` for code, `ruff-action` for linting/formatting), the least-privilege required permission is `contents: read`. The most maintainable fix is to add this `permissions` block at the workflow level (directly under the workflow’s name and before `on:`), so it applies to all jobs unless a job overrides it. No edits to imports, methods, or additional definitions are required, just the insertion of the `permissions` block in the YAML.

This involves editing `.github/workflows/python-lint.yml` to insert the following lines after the `name: Python Lint` line and before the `on:` block:

```yaml
permissions:
  contents: read
```

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
