### PR TITLE
fix(types): fix mismatched types in _rust_ephem.pyi

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -6,3 +6,4 @@ exclude = (?x)(
     # Exclude docs directory
     docs/.*
     )
+strict = True

--- a/rust_ephem/_rust_ephem.pyi
+++ b/rust_ephem/_rust_ephem.pyi
@@ -612,7 +612,7 @@ class TLEEphemeris(Ephemeris):
         ...
 
     @property
-    def timestamp(self) -> npt.NDArray[np.object_]:
+    def timestamp(self) -> npt.NDArray[np.datetime64]:
         """
         Array of timestamps for the ephemeris.
 
@@ -926,7 +926,7 @@ class SPICEEphemeris(Ephemeris):
         ...
 
     @property
-    def timestamp(self) -> npt.NDArray[np.object_]:
+    def timestamp(self) -> npt.NDArray[np.datetime64]:
         """
         Array of timestamps for the ephemeris.
 
@@ -1231,7 +1231,7 @@ class OEMEphemeris(Ephemeris):
         ...
 
     @property
-    def timestamp(self) -> npt.NDArray[np.object_]:
+    def timestamp(self) -> npt.NDArray[np.datetime64]:
         """
         Array of timestamps for the ephemeris.
 
@@ -1518,7 +1518,7 @@ class GroundEphemeris(Ephemeris):
         ...
 
     @property
-    def timestamp(self) -> npt.NDArray[np.object_]:
+    def timestamp(self) -> npt.NDArray[np.datetime64]:
         """
         Array of timestamps for the ephemeris.
 


### PR DESCRIPTION
This pull request improves type safety in the codebase by enforcing strict type checking and refining the type annotations for ephemeris timestamp properties. The changes ensure that timestamp arrays are explicitly typed as `np.datetime64`, which clarifies intent and helps prevent subtle bugs related to time handling.

Type annotation improvements:

* Updated the `timestamp` property return type from `npt.NDArray[np.object_]` to `npt.NDArray[np.datetime64]` in the following classes in `rust_ephem/_rust_ephem.pyi`:
  - `TLEEphemeris`
  - `SPICEEphemeris`
  - `OEMEphemeris`
  - `GroundEphemeris`

Configuration changes:

* Enabled strict type checking by adding `strict = True` to `mypy.ini`, which will enforce more rigorous type checking throughout the project.