### PR TITLE
Fix typing issue on `fetch_tle` `enforce_source` argument

### DIFF
--- a/rust_ephem/_rust_ephem.pyi
+++ b/rust_ephem/_rust_ephem.pyi
@@ -1931,6 +1931,7 @@ def fetch_tle(
     spacetrack_username: str | None = None,
     spacetrack_password: str | None = None,
     epoch_tolerance_days: float | None = None,
+    enforce_source: str | None = None,
 ) -> dict[str, Any]:
     """
     Fetch a TLE from various sources (file, URL, Celestrak, Space-Track.org).
@@ -1950,6 +1951,8 @@ def fetch_tle(
         spacetrack_password: Space-Track.org password (or use SPACETRACK_PASSWORD env var)
         epoch_tolerance_days: For Space-Track cache: how many days TLE epoch can
             differ from target epoch (default: 4.0 days)
+        enforce_source: Enforce use of specific source without failover.
+            Must be "celestrak", "spacetrack", or None (default behavior with failover)
 
     Returns:
         Dict with keys: line1, line2, name (optional), epoch (datetime), source


### PR DESCRIPTION
This pull request introduces a new parameter to the `fetch_tle` function in `rust_ephem/_rust_ephem.pyi`, allowing callers to enforce the use of a specific TLE source instead of relying on the default failover behavior.

Enhancement to TLE fetching:

* Added the `enforce_source` parameter to the `fetch_tle` function signature, enabling users to specify a required source ("celestrak", "spacetrack", or None) for TLE data retrieval.
* Updated the function docstring to document the new `enforce_source` parameter and clarify its usage.