### PR TITLE
fix: use v in tag name

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -3,9 +3,8 @@
     ".": {
       "changelog-path": "CHANGELOG.md",
       "release-type": "rust",
-      "extra-files": [
-        "pyproject.toml"
-      ]
+      "include-v-in-tag": true,
+      "extra-files": ["pyproject.toml"]
     }
   },
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json"


### PR DESCRIPTION
This pull request updates the release configuration to improve version tagging and maintain consistency with release artifacts.

Release process improvements:

* Updated `release-please-config.json` to include a `v` prefix in release tags by setting `"include-v-in-tag": true`. This ensures that all new release tags will be formatted as `vX.Y.Z` instead of `X.Y.Z`.
* Reformatted the `extra-files` array for clarity, but functionality remains unchanged.