### PR TITLE
fix: don't include name of repo in tag

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -4,6 +4,7 @@
       "changelog-path": "CHANGELOG.md",
       "release-type": "rust",
       "include-v-in-tag": true,
+      "include-component-in-tag": false,
       "extra-files": ["pyproject.toml"]
     }
   },


### PR DESCRIPTION
This pull request makes a small configuration update to the release process for the Rust package. The change disables the inclusion of the component name in the generated tag during releases.

- Updated `release-please-config.json` to set `"include-component-in-tag": false` for the Rust package, ensuring release tags do not include the component name.