### PR TITLE
fix: Fix GroundEphemeris ITRS velocity semantics

### DIFF
--- a/docs/ephemeris_ground.rst
+++ b/docs/ephemeris_ground.rst
@@ -52,7 +52,7 @@ fixed location on Earth's surface.
 
     # Observatory position and velocity
     print("ITRS position (km):", pv_itrs.position[0])  # First timestep
-    print("ITRS velocity (km/s):", pv_itrs.velocity[0])  # Due to Earth rotation
+    print("ITRS velocity (km/s):", pv_itrs.velocity[0])  # Zero for fixed site
     print("GCRS position (km):", pv_gcrs.position[0])
 
     # Sun and Moon positions
@@ -80,7 +80,7 @@ GroundEphemeris Use Cases
 GroundEphemeris Notes
 ---------------------
 - The observatory position is fixed in ITRS (Earth-fixed frame)
-- Velocity in ITRS is due to Earth's rotation
+- Velocity in ITRS is zero for fixed sites; GCRS velocity reflects Earth's rotation
 - Position in GCRS changes over time due to Earth's rotation and precession
 - The ``polar_motion`` parameter enables polar motion corrections (requires EOP data)
 - Use ``re.init_eop_provider()`` to load EOP data for polar motion corrections

--- a/tests/test_ground_ephemeris.py
+++ b/tests/test_ground_ephemeris.py
@@ -137,10 +137,9 @@ class TestGroundEphemerisITRS:
         assert np.abs(vel[0, 0]) < 0.001
 
     def test_velocity_y_at_equator(self, equator_obs):
-        """Test ITRS Y velocity at equator (Earth rotation)."""
+        """Test ITRS Y velocity at equator."""
         vel = equator_obs.itrs_pv.velocity
-        expected_vy = 7.292115e-5 * 6378.137  # ~0.465 km/s
-        assert np.abs(vel[0, 1] - expected_vy) < 0.001
+        assert np.abs(vel[0, 1]) < 0.001
 
     def test_velocity_z_at_equator(self, equator_obs):
         """Test ITRS Z velocity at equator."""


### PR DESCRIPTION
## Summary
- treat GroundEphemeris ITRS velocity as zero for fixed ground sites
- rely on the ITRS→GCRS conversion to introduce Earth rotation velocity
- update ground ephemeris docs and tests to match the frame convention

## Why
- ITRS is Earth-fixed; a stationary site has zero velocity in that frame
- we were embedding ω×r in ITRS and then adding rotation again during conversion, which risks double-counting when deriving GCRS velocity
- tests and docs described the old (incorrect) ITRS velocity semantics

## How
- set the ITRS velocity components to zero in `compute_itrs_position`
- adjust GroundEphemeris tests to expect zero ITRS velocity
- update `docs/ephemeris_ground.rst` wording and example comment