### PR TITLE
fix: make fetch_tle error message clearer to user

### DIFF
--- a/rust_ephem/tle.py
+++ b/rust_ephem/tle.py
@@ -163,7 +163,7 @@ def fetch_tle(
                 "The satellite may not exist, may not have public TLE data, or the upstream "
                 "service may be temporarily unavailable."
             )
-            raise ValueError(f"{hint}") from exc
+            raise ValueError(hint) from exc
 
         raise
 


### PR DESCRIPTION
This pull request improves error handling in the `fetch_tle` function of `rust_ephem/tle.py` by providing clearer error messages when no usable TLE data is returned from upstream sources. The main focus is on surfacing more informative exceptions to help users understand why TLE data retrieval may have failed.

Improved error handling and messaging:

* Wrapped the call to `_fetch_tle` in a `try` block and added specific handling for `ValueError` exceptions to detect TLE parse failures.
* When a parse failure is detected, the code now constructs a detailed error message including context such as NORAD ID, satellite name, or TLE source, and provides a user-friendly explanation of why no TLE data was returned.