### PR TITLE
feat(constraints): Add evaluate_batch and fix roll constraint calculation

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -409,18 +409,25 @@ Classes
       - ``indices`` — Optional: specific time index/indices to evaluate
       - Returns: ``ConstraintResult`` object
 
-    * ``evaluate_batch(ephemeris, target_ras, target_decs, times=None, indices=None)`` — Convenience batch API returning one ``ConstraintResult`` per target
+    * ``evaluate_batch(ephemeris, target_ras, target_decs, times=None, indices=None, target_rolls=None)`` — Convenience batch API returning one ``ConstraintResult`` per target
 
-      - Returns: list of ``ConstraintResult`` objects
+      - ``ephemeris`` — TLEEphemeris, SPICEEphemeris, GroundEphemeris, or OEMEphemeris object
+      - ``target_ras`` — List of target right ascensions in degrees (ICRS/J2000)
+      - ``target_decs`` — List of target declinations in degrees (ICRS/J2000)
+      - ``times`` — Optional: specific datetime(s) to evaluate (must exist in ephemeris)
+      - ``indices`` — Optional: specific time index/indices to evaluate
+      - ``target_rolls`` — Optional: per-target spacecraft roll angles in degrees, one value per target. Each entry may be ``None`` to evaluate that target without a fixed spacecraft roll (default: ``None`` for all targets)
+      - Returns: list of ``ConstraintResult`` objects, one per target
       - Best when you want the same per-target summary shape as ``evaluate()`` without writing the loop yourself
 
-    * ``in_constraint_batch(ephemeris, target_ras, target_decs, times=None, indices=None)`` — **[Recommended]** Vectorized batch evaluation for multiple targets
+    * ``in_constraint_batch(ephemeris, target_ras, target_decs, times=None, indices=None, target_rolls=None)`` — **[Recommended]** Vectorized batch evaluation for multiple targets
 
       - ``ephemeris`` — TLEEphemeris, SPICEEphemeris, GroundEphemeris, or OEMEphemeris object
       - ``target_ras`` — List/array of target right ascensions in degrees (ICRS/J2000)
       - ``target_decs`` — List/array of target declinations in degrees (ICRS/J2000)
       - ``times`` — Optional: specific datetime(s) to evaluate (must exist in ephemeris)
       - ``indices`` — Optional: specific time index/indices to evaluate
+      - ``target_rolls`` — Optional: per-target spacecraft roll angles in degrees, one value per target. Each entry may be ``None`` to evaluate that target without a fixed spacecraft roll. When an entry is ``None`` and the constraint has boresight offsets with non-zero pitch/yaw, evaluates the target as violated only if it violates at every possible roll angle (default: ``None`` for all targets)
       - Returns: 2D NumPy boolean array of shape (n_targets, n_times) where True indicates constraint violation
       - **Performance**: 3-50x faster than calling ``evaluate()`` in a loop
       - **Optimized**: Uses vectorized operations for batch RA/Dec conversion and constraint evaluation

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -409,6 +409,11 @@ Classes
       - ``indices`` — Optional: specific time index/indices to evaluate
       - Returns: ``ConstraintResult`` object
 
+    * ``evaluate_batch(ephemeris, target_ras, target_decs, times=None, indices=None)`` — Convenience batch API returning one ``ConstraintResult`` per target
+
+      - Returns: list of ``ConstraintResult`` objects
+      - Best when you want the same per-target summary shape as ``evaluate()`` without writing the loop yourself
+
     * ``in_constraint_batch(ephemeris, target_ras, target_decs, times=None, indices=None)`` — **[Recommended]** Vectorized batch evaluation for multiple targets
 
       - ``ephemeris`` — TLEEphemeris, SPICEEphemeris, GroundEphemeris, or OEMEphemeris object

--- a/docs/constraints_api.rst
+++ b/docs/constraints_api.rst
@@ -57,8 +57,9 @@ Constraint Class (Rust Backend)
 -------------------------------
 
 The low-level ``Constraint`` class provides direct access to Rust constraint evaluation
-for maximum performance. However, **this class has limited features** (single ``target_roll``,
-no per-target roll angles, no roll-sweeping). Most users should use the
+for maximum performance. However, **this class still has limited roll support**:
+single-target methods use a single ``target_roll`` value, while batch methods support
+per-target ``target_rolls``. Roll-sweeping is not supported at this layer. Most users should use the
 **Pydantic configuration models** (``SunConstraint``, ``MoonConstraint``, etc.) instead,
 which wrap ``Constraint`` with full support for per-target rolls and roll-sweeping via ``target_rolls``
 and ``n_roll_samples`` parameters.

--- a/docs/constraints_api.rst
+++ b/docs/constraints_api.rst
@@ -559,22 +559,24 @@ Evaluation Methods
       # Evaluate at specific indices
       result = constraint.evaluate(ephem, 83.63, 22.01, indices=[0, 10, 20])
 
-.. py:method:: Constraint.in_constraint_batch(ephemeris, target_ras, target_decs, times=None, indices=None, target_roll=None)
+.. py:method:: Constraint.in_constraint_batch(ephemeris, target_ras, target_decs, times=None, indices=None, target_rolls=None)
 
    Check if targets are in-constraint for multiple RA/Dec positions (vectorized).
 
-   This low-level method evaluates the same constraint with the same roll angle against multiple
-   target positions. **For per-target roll angles and roll-sweeping** (``target_rolls`` and ``n_roll_samples``),
-   use the Pydantic constraint models (e.g., ``SunConstraint``) which wrap this API
-   with ``RustConstraintMixin.in_constraint_batch()`` instead.
+   This low-level method evaluates the constraint against multiple target positions.
+   **For roll-sweeping** (``n_roll_samples``), use the Pydantic constraint models
+   (e.g., ``SunConstraint``) which wrap this API with
+   ``RustConstraintMixin.in_constraint_batch()`` instead.
 
    :param ephemeris: One of TLEEphemeris, SPICEEphemeris, GroundEphemeris, or OEMEphemeris
    :param list target_ras: List of target right ascensions in degrees (ICRS/J2000)
    :param list target_decs: List of target declinations in degrees (ICRS/J2000)
    :param times: Optional specific time(s) to evaluate
    :param indices: Optional specific time index/indices to evaluate
-   :param target_roll: Optional spacecraft roll angle in degrees to apply uniformly to all targets
-   :type target_roll: float or None
+   :param target_rolls: Optional per-target spacecraft roll angles in degrees.
+      Must be a list of the same length as ``target_ras``. Pass ``None`` to evaluate
+      without any fixed spacecraft roll.
+   :type target_rolls: list[float] or None
    :returns: 2D numpy boolean array of shape (n_targets, n_times)
    :rtype: numpy.ndarray
 
@@ -605,23 +607,25 @@ Evaluation Methods
       # Find targets that never violate
       always_visible = np.where(violation_counts == 0)[0]
 
-.. py:method:: Constraint.evaluate_batch(ephemeris, target_ras, target_decs, times=None, indices=None, target_roll=None)
+.. py:method:: Constraint.evaluate_batch(ephemeris, target_ras, target_decs, times=None, indices=None, target_rolls=None)
 
    Evaluate a constraint for multiple targets and return one :class:`ConstraintResult`
    per target.
 
-   This low-level method evaluates the same constraint with the same roll angle against multiple
-   target positions. The returned list has one result per target. **For per-target roll angles and roll-sweeping**
-   (``target_rolls`` and ``n_roll_samples``), use the Pydantic constraint models (e.g., ``SunConstraint``)
-   which wrap this API with ``RustConstraintMixin.evaluate_batch()`` instead.
+   This low-level method evaluates the constraint against multiple target positions.
+   The returned list has one result per target. **For roll-sweeping** (``n_roll_samples``),
+   use the Pydantic constraint models (e.g., ``SunConstraint``) which wrap this API
+   with ``RustConstraintMixin.evaluate_batch()`` instead.
 
    :param ephemeris: One of TLEEphemeris, SPICEEphemeris, GroundEphemeris, or OEMEphemeris
    :param list target_ras: List of target right ascensions in degrees (ICRS/J2000)
    :param list target_decs: List of target declinations in degrees (ICRS/J2000)
    :param times: Optional specific time(s) to evaluate
    :param indices: Optional specific time index/indices to evaluate
-   :param target_roll: Optional spacecraft roll angle in degrees to apply uniformly to all targets
-   :type target_roll: float or None
+   :param target_rolls: Optional per-target spacecraft roll angles in degrees.
+      Must be a list of the same length as ``target_ras``. Pass ``None`` to evaluate
+      without any fixed spacecraft roll.
+   :type target_rolls: list[float] or None
    :returns: List of :class:`ConstraintResult` objects, one per input target
    :rtype: list[ConstraintResult]
 

--- a/docs/constraints_api.rst
+++ b/docs/constraints_api.rst
@@ -56,8 +56,12 @@ Quick Start
 Constraint Class (Rust Backend)
 -------------------------------
 
-The ``Constraint`` class provides the core constraint evaluation functionality
-implemented in Rust for maximum performance.
+The low-level ``Constraint`` class provides direct access to Rust constraint evaluation
+for maximum performance. However, **this class has limited features** (single ``target_roll``,
+no per-target roll angles, no roll-sweeping). Most users should use the
+**Pydantic configuration models** (``SunConstraint``, ``MoonConstraint``, etc.) instead,
+which wrap ``Constraint`` with full support for per-target rolls and roll-sweeping via ``target_rolls``
+and ``n_roll_samples`` parameters.
 
 Factory Methods
 ^^^^^^^^^^^^^^^
@@ -555,27 +559,22 @@ Evaluation Methods
       # Evaluate at specific indices
       result = constraint.evaluate(ephem, 83.63, 22.01, indices=[0, 10, 20])
 
-.. py:method:: Constraint.in_constraint_batch(ephemeris, target_ras, target_decs, times=None, indices=None, target_roll=None, n_roll_samples=DEFAULT_N_ROLL_SAMPLES)
+.. py:method:: Constraint.in_constraint_batch(ephemeris, target_ras, target_decs, times=None, indices=None, target_roll=None)
 
    Check if targets are in-constraint for multiple RA/Dec positions (vectorized).
 
-   This method is **3-50x faster** than calling ``evaluate()`` in a loop when
-   you need to check many target positions.
+   This low-level method evaluates the same constraint with the same roll angle against multiple
+   target positions. **For per-target roll angles and roll-sweeping** (``target_rolls`` and ``n_roll_samples``),
+   use the Pydantic constraint models (e.g., ``SunConstraint``) which wrap this API
+   with ``RustConstraintMixin.in_constraint_batch()`` instead.
 
    :param ephemeris: One of TLEEphemeris, SPICEEphemeris, GroundEphemeris, or OEMEphemeris
    :param list target_ras: List of target right ascensions in degrees (ICRS/J2000)
    :param list target_decs: List of target declinations in degrees (ICRS/J2000)
    :param times: Optional specific time(s) to evaluate
    :param indices: Optional specific time index/indices to evaluate
-   :param target_roll: Spacecraft roll angle (degrees).  When ``None`` (default) and the
-      constraint contains a boresight offset with non-zero pitch/yaw, sweeps
-      ``n_roll_samples`` roll angles and returns ``True`` only when all
-      rolls are blocked (no valid spacecraft orientation exists).  Pass an explicit
-      float to evaluate at a fixed roll.
+   :param target_roll: Optional spacecraft roll angle in degrees to apply uniformly to all targets
    :type target_roll: float or None
-   :param int n_roll_samples: Number of roll angles to sweep when ``target_roll`` is ``None``
-      and the constraint is roll-dependent.  Default :data:`DEFAULT_N_ROLL_SAMPLES`.
-      Ignored when ``target_roll`` is given or no pitch/yaw offset is present.
    :returns: 2D numpy boolean array of shape (n_targets, n_times)
    :rtype: numpy.ndarray
 
@@ -606,22 +605,23 @@ Evaluation Methods
       # Find targets that never violate
       always_visible = np.where(violation_counts == 0)[0]
 
-.. py:method:: Constraint.evaluate_batch(ephemeris, target_ras, target_decs, times=None, indices=None, target_roll=None, n_roll_samples=DEFAULT_N_ROLL_SAMPLES)
+.. py:method:: Constraint.evaluate_batch(ephemeris, target_ras, target_decs, times=None, indices=None, target_roll=None)
 
    Evaluate a constraint for multiple targets and return one :class:`ConstraintResult`
    per target.
 
-   This is a convenience API for callers that want the richer ``evaluate()`` result
-   structure for each target, without manually looping over targets.
+   This low-level method evaluates the same constraint with the same roll angle against multiple
+   target positions. The returned list has one result per target. **For per-target roll angles and roll-sweeping**
+   (``target_rolls`` and ``n_roll_samples``), use the Pydantic constraint models (e.g., ``SunConstraint``)
+   which wrap this API with ``RustConstraintMixin.evaluate_batch()`` instead.
 
    :param ephemeris: One of TLEEphemeris, SPICEEphemeris, GroundEphemeris, or OEMEphemeris
    :param list target_ras: List of target right ascensions in degrees (ICRS/J2000)
    :param list target_decs: List of target declinations in degrees (ICRS/J2000)
    :param times: Optional specific time(s) to evaluate
    :param indices: Optional specific time index/indices to evaluate
-   :param target_roll: Optional spacecraft roll angle in degrees
+   :param target_roll: Optional spacecraft roll angle in degrees to apply uniformly to all targets
    :type target_roll: float or None
-   :param int n_roll_samples: Number of roll angles to sweep for roll-dependent constraints
    :returns: List of :class:`ConstraintResult` objects, one per input target
    :rtype: list[ConstraintResult]
 
@@ -1384,27 +1384,64 @@ All Pydantic constraint models inherit these methods:
    :returns: ConstraintResult containing violation windows
    :rtype: ConstraintResult
 
-.. py:method:: in_constraint_batch(ephemeris, target_ras, target_decs, times=None, indices=None, target_roll=None, n_roll_samples=DEFAULT_N_ROLL_SAMPLES)
+.. py:method:: evaluate_batch(ephemeris, target_ras, target_decs, times=None, indices=None, target_rolls=None, n_roll_samples=DEFAULT_N_ROLL_SAMPLES)
+
+   Evaluate the constraint for multiple targets and return one ``ConstraintResult`` per target.
+
+   This is the **recommended high-level API** for batch constraint evaluation. Supports per-target
+   roll angles and automatic roll-sweeping for roll-dependent constraints.
+
+   :param ephemeris: One of TLEEphemeris, SPICEEphemeris, GroundEphemeris, or OEMEphemeris
+   :param list target_ras: List of target right ascensions in degrees (ICRS/J2000)
+   :param list target_decs: List of target declinations in degrees (ICRS/J2000)
+   :param times: Optional specific time(s) to evaluate
+   :param indices: Optional specific time index/indices to evaluate
+   :param target_rolls: Optional per-target spacecraft roll angles in degrees. List of length
+      equal to ``target_ras``. Each entry may be ``None`` to auto-sweep that target's roll.
+      When ``None`` for a target and the constraint is roll-dependent, sweeps ``n_roll_samples``
+      roll angles and marks violated only if **all** rolls are blocked.
+   :type target_rolls: list[float | None] or None
+   :param int n_roll_samples: Number of roll angles to sweep when a target has ``target_roll=None``
+      and the constraint is roll-dependent. Default
+      :data:`~rust_ephem.constraints.DEFAULT_N_ROLL_SAMPLES` (72 ≈ 5° resolution).
+   :returns: List of ``ConstraintResult`` objects, one per input target
+   :rtype: list[ConstraintResult]
+
+.. py:method:: in_constraint_batch(ephemeris, target_ras, target_decs, times=None, indices=None, target_rolls=None, n_roll_samples=DEFAULT_N_ROLL_SAMPLES)
 
    Check if targets are in-constraint for multiple RA/Dec positions (vectorized).
+
+   Supports per-target roll angles and automatic roll-sweeping for roll-dependent constraints.
 
    :param ephemeris: One of TLEEphemeris, SPICEEphemeris, GroundEphemeris, or OEMEphemeris
    :param list target_ras: List of target right ascensions in degrees
    :param list target_decs: List of target declinations in degrees
    :param times: Optional specific time(s) to evaluate
    :param indices: Optional specific time index/indices to evaluate
-   :param target_roll: Spacecraft roll angle (degrees).  When ``None`` (default) and the
-      constraint contains a boresight offset with non-zero pitch/yaw, sweeps
-      ``n_roll_samples`` roll angles and returns ``True`` only when all
-      rolls are blocked (no valid spacecraft orientation exists).  Pass an explicit
-      float to evaluate at a fixed roll.
-   :type target_roll: float or None
-   :param int n_roll_samples: Number of roll angles to sweep when ``target_roll`` is ``None``
-      and the constraint is roll-dependent.  Default
-      :data:`~rust_ephem.constraints.DEFAULT_N_ROLL_SAMPLES`.  Ignored when ``target_roll``
-      is given or no pitch/yaw offset is present.
+   :param target_rolls: Optional per-target spacecraft roll angles in degrees. List of length
+      equal to ``target_ras``. Each entry may be ``None`` to auto-sweep that target's roll.
+      When ``None`` for a target and the constraint is roll-dependent, sweeps ``n_roll_samples``
+      roll angles and returns ``True`` only when **all** rolls are blocked.
+   :type target_rolls: list[float | None] or None
+   :param int n_roll_samples: Number of roll angles to sweep when a target has ``target_roll=None``
+      and the constraint is roll-dependent. Default
+      :data:`~rust_ephem.constraints.DEFAULT_N_ROLL_SAMPLES`. Ignored when all ``target_rolls`` are
+      fixed floats or no pitch/yaw offset is present.
    :returns: 2D numpy array of shape (n_targets, n_times) with boolean violation status
    :rtype: numpy.ndarray
+
+   **Example:**
+
+   .. code-block:: python
+
+      # Evaluate multiple targets, some with fixed rolls, some with auto-sweep
+      violations = constraint.in_constraint_batch(
+          ephem,
+          target_ras=[0.0, 90.0, 180.0],
+          target_decs=[0.0, 45.0, -30.0],
+          target_rolls=[0.0, None, 90.0]  # First: fixed 0°, Second: sweep all, Third: fixed 90°
+      )
+      print(violations.shape)  # (3, n_times)
 
 .. py:method:: in_constraint(time, ephemeris, target_ra, target_dec, target_roll=None, n_roll_samples=DEFAULT_N_ROLL_SAMPLES)
 

--- a/docs/constraints_api.rst
+++ b/docs/constraints_api.rst
@@ -606,6 +606,25 @@ Evaluation Methods
       # Find targets that never violate
       always_visible = np.where(violation_counts == 0)[0]
 
+.. py:method:: Constraint.evaluate_batch(ephemeris, target_ras, target_decs, times=None, indices=None, target_roll=None, n_roll_samples=DEFAULT_N_ROLL_SAMPLES)
+
+   Evaluate a constraint for multiple targets and return one :class:`ConstraintResult`
+   per target.
+
+   This is a convenience API for callers that want the richer ``evaluate()`` result
+   structure for each target, without manually looping over targets.
+
+   :param ephemeris: One of TLEEphemeris, SPICEEphemeris, GroundEphemeris, or OEMEphemeris
+   :param list target_ras: List of target right ascensions in degrees (ICRS/J2000)
+   :param list target_decs: List of target declinations in degrees (ICRS/J2000)
+   :param times: Optional specific time(s) to evaluate
+   :param indices: Optional specific time index/indices to evaluate
+   :param target_roll: Optional spacecraft roll angle in degrees
+   :type target_roll: float or None
+   :param int n_roll_samples: Number of roll angles to sweep for roll-dependent constraints
+   :returns: List of :class:`ConstraintResult` objects, one per input target
+   :rtype: list[ConstraintResult]
+
 .. py:method:: Constraint.in_constraint(time, ephemeris, target_ra, target_dec, target_roll=None, n_roll_samples=DEFAULT_N_ROLL_SAMPLES)
 
    Check if the target satisfies the constraint at given time(s).

--- a/mypy.ini
+++ b/mypy.ini
@@ -10,7 +10,3 @@ exclude = (?x)(
 # Enforce strictness for the rust_ephem package
 [mypy-rust_ephem.*]
 strict = True
-
-# Strict checking for tests too
-[mypy-tests.*]
-strict = True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ classifiers = [
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
 
-dependencies = ["numpy>=1.16,<2.3", "pydantic>=2.12.4"]
+dependencies = ["numpy>=1.16", "pydantic>=2.12.4"]
 
 [project.optional-dependencies]
 test = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ classifiers = [
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
 
-dependencies = ["numpy>=1.16", "pydantic>=2.12.4"]
+dependencies = ["numpy>=1.16,<2.3", "pydantic>=2.12.4"]
 
 [project.optional-dependencies]
 test = [

--- a/rust_ephem/_rust_ephem.pyi
+++ b/rust_ephem/_rust_ephem.pyi
@@ -568,7 +568,7 @@ class Constraint:
         target_decs: list[float],
         times: datetime | list[datetime] | None = None,
         indices: int | list[int] | None = None,
-        target_rolls: list[float | None] | None = None,
+        target_rolls: list[float] | None = None,
     ) -> list[Any]:
         """
         Evaluate constraint against multiple targets and return one result per target.

--- a/rust_ephem/_rust_ephem.pyi
+++ b/rust_ephem/_rust_ephem.pyi
@@ -583,8 +583,7 @@ class Constraint:
             indices: Optional specific time index/indices to evaluate. Can be a
                      single index or list of indices into the ephemeris timestamp array.
             target_rolls: Optional per-target spacecraft roll angles in degrees.
-                         List of length equal to target_ras. Each entry may be None
-                         to evaluate without a fixed roll.
+                         List of length equal to target_ras.
 
         Returns:
             List of ConstraintResult objects, one per input target.
@@ -616,8 +615,7 @@ class Constraint:
             indices: Optional specific time index/indices to evaluate. Can be a
                      single index or list of indices into the ephemeris timestamp array.
             target_rolls: Optional per-target spacecraft roll angles in degrees.
-                         List of length equal to target_ras. Each entry may be None
-                         to evaluate without a fixed roll.
+                         List of length equal to target_ras.
 
         Returns:
             2D numpy boolean array of shape (n_targets, n_times) where True indicates

--- a/rust_ephem/_rust_ephem.pyi
+++ b/rust_ephem/_rust_ephem.pyi
@@ -561,6 +561,35 @@ class Constraint:
         """
         ...
 
+    def evaluate_batch(
+        self,
+        ephemeris: Ephemeris,
+        target_ras: list[float],
+        target_decs: list[float],
+        times: datetime | list[datetime] | None = None,
+        indices: int | list[int] | None = None,
+        target_roll: float | None = None,
+    ) -> list[Any]:
+        """
+        Evaluate constraint against multiple targets and return one result per target.
+
+        Args:
+            ephemeris: One of TLEEphemeris, SPICEEphemeris, OEMEphemeris, or GroundEphemeris
+            target_ras: List of target right ascensions in degrees (ICRS/J2000)
+            target_decs: List of target declinations in degrees (ICRS/J2000)
+            times: Optional specific time(s) to evaluate. Can be a single datetime
+                   or list of datetimes. If provided, only these times will be
+                   evaluated (must exist in the ephemeris).
+            indices: Optional specific time index/indices to evaluate. Can be a
+                     single index or list of indices into the ephemeris timestamp array.
+            target_roll: Optional spacecraft roll angle about +X in degrees,
+                         applied at evaluation time.
+
+        Returns:
+            List of ConstraintResult objects, one per input target.
+        """
+        ...
+
     def in_constraint_batch(
         self,
         ephemeris: Ephemeris,

--- a/rust_ephem/_rust_ephem.pyi
+++ b/rust_ephem/_rust_ephem.pyi
@@ -568,7 +568,7 @@ class Constraint:
         target_decs: list[float],
         times: datetime | list[datetime] | None = None,
         indices: int | list[int] | None = None,
-        target_roll: float | None = None,
+        target_rolls: list[float | None] | None = None,
     ) -> list[Any]:
         """
         Evaluate constraint against multiple targets and return one result per target.
@@ -582,8 +582,9 @@ class Constraint:
                    evaluated (must exist in the ephemeris).
             indices: Optional specific time index/indices to evaluate. Can be a
                      single index or list of indices into the ephemeris timestamp array.
-            target_roll: Optional spacecraft roll angle about +X in degrees,
-                         applied at evaluation time.
+            target_rolls: Optional per-target spacecraft roll angles in degrees.
+                         List of length equal to target_ras. Each entry may be None
+                         to evaluate without a fixed roll.
 
         Returns:
             List of ConstraintResult objects, one per input target.
@@ -597,7 +598,7 @@ class Constraint:
         target_decs: list[float],
         times: datetime | list[datetime] | None = None,
         indices: int | list[int] | None = None,
-        target_roll: float | None = None,
+        target_rolls: list[float] | None = None,
     ) -> npt.NDArray[np.bool_]:
         """
         Check if targets are in-constraint for multiple RA/Dec positions (vectorized).
@@ -614,8 +615,9 @@ class Constraint:
                    evaluated (must exist in the ephemeris).
             indices: Optional specific time index/indices to evaluate. Can be a
                      single index or list of indices into the ephemeris timestamp array.
-            target_roll: Optional spacecraft roll angle about +X in degrees,
-                         applied at evaluation time.
+            target_rolls: Optional per-target spacecraft roll angles in degrees.
+                         List of length equal to target_ras. Each entry may be None
+                         to evaluate without a fixed roll.
 
         Returns:
             2D numpy boolean array of shape (n_targets, n_times) where True indicates

--- a/rust_ephem/constraints.py
+++ b/rust_ephem/constraints.py
@@ -158,6 +158,220 @@ class RollReference(str, Enum):
 class RustConstraintMixin(BaseModel):
     """Base class for Rust constraint configurations"""
 
+    @staticmethod
+    def _coerce_datetime(value: Any) -> datetime:
+        """Convert supported timestamp values to Python datetime."""
+        if isinstance(value, datetime):
+            return value
+        if isinstance(value, np.datetime64):
+            coerced = value.astype("datetime64[us]").tolist()
+            if isinstance(coerced, datetime):
+                return coerced
+        raise TypeError(f"Unsupported timestamp type: {type(value)!r}")
+
+    @classmethod
+    def _coerce_timestamps(
+        cls,
+        values: npt.NDArray[np.datetime64] | list[datetime],
+    ) -> list[datetime]:
+        """Convert timestamp arrays/sequences to Python datetimes."""
+        return [cls._coerce_datetime(value) for value in values]
+
+    @staticmethod
+    def _build_constraint_result(
+        constraint_name: str,
+        timestamps: list[datetime],
+        violated: npt.NDArray[np.bool_] | list[bool],
+    ) -> ConstraintResult:
+        """Build a ConstraintResult from a boolean violation mask."""
+        violation_flags = np.asarray(violated, dtype=bool)
+        violations: list[ConstraintViolation] = []
+        in_viol = False
+        viol_start: datetime | None = None
+
+        for dt, flag in zip(timestamps, violation_flags):
+            if flag and not in_viol:
+                in_viol = True
+                viol_start = dt
+            elif not flag and in_viol:
+                in_viol = False
+                violations.append(
+                    ConstraintViolation(
+                        start_time=cast(datetime, viol_start),
+                        end_time=dt,
+                        max_severity=1.0,
+                        description=constraint_name,
+                    )
+                )
+
+        if in_viol and viol_start is not None and timestamps:
+            violations.append(
+                ConstraintViolation(
+                    start_time=viol_start,
+                    end_time=timestamps[-1],
+                    max_severity=1.0,
+                    description=constraint_name,
+                )
+            )
+
+        return ConstraintResult(
+            violations=violations,
+            all_satisfied=not bool(violation_flags.any()),
+            constraint_name=constraint_name,
+            _swept_timestamps=timestamps,
+            _swept_array=violation_flags.tolist(),
+        )
+
+    @staticmethod
+    def _normalize_target_rolls(
+        target_ras: list[float],
+        target_decs: list[float],
+        target_rolls: list[float | None] | None,
+    ) -> list[float | None] | None:
+        """Validate per-target roll inputs for batch APIs."""
+        if len(target_ras) != len(target_decs):
+            raise ValueError("target_ras and target_decs must have the same length")
+        if target_rolls is None:
+            return None
+        if len(target_rolls) != len(target_ras):
+            raise ValueError(
+                "target_rolls must have the same length as target_ras and target_decs"
+            )
+        return target_rolls
+
+    @staticmethod
+    def _group_target_roll_indices(
+        target_rolls: list[float | None],
+    ) -> list[tuple[float | None, list[int]]]:
+        """Group target indices by shared roll values while preserving order."""
+        grouped: dict[float | None, list[int]] = {}
+        order: list[float | None] = []
+        for index, target_roll in enumerate(target_rolls):
+            if target_roll not in grouped:
+                grouped[target_roll] = []
+                order.append(target_roll)
+            grouped[target_roll].append(index)
+        return [(target_roll, grouped[target_roll]) for target_roll in order]
+
+    def _evaluate_batch_uniform(
+        self,
+        ephemeris: Ephemeris,
+        target_ras: list[float],
+        target_decs: list[float],
+        times: datetime | list[datetime] | None = None,
+        indices: int | list[int] | None = None,
+        target_roll: float | None = None,
+        n_roll_samples: int = DEFAULT_N_ROLL_SAMPLES,
+    ) -> list[ConstraintResult]:
+        """Evaluate a batch where all targets share the same roll semantics."""
+        if target_roll is None and self._is_roll_dependent():
+            if not target_ras:
+                return []
+
+            batch = self._in_constraint_batch_uniform(
+                ephemeris,
+                target_ras,
+                target_decs,
+                times=times,
+                indices=indices,
+                target_roll=target_roll,
+                n_roll_samples=n_roll_samples,
+            )
+            first_result = self.evaluate(
+                ephemeris,
+                target_ras[0],
+                target_decs[0],
+                times=times,
+                indices=indices,
+                target_roll=target_roll,
+                n_roll_samples=n_roll_samples,
+            )
+            timestamps = self._coerce_timestamps(first_result.timestamps)
+            constraint_name = first_result.constraint_name
+
+            return [
+                self._build_constraint_result(constraint_name, timestamps, row)
+                for row in np.asarray(batch, dtype=bool)
+            ]
+
+        rust_constraint = self._resolve_rust_constraint(
+            target_roll=target_roll,
+        )
+        rust_results = rust_constraint.evaluate_batch(
+            ephemeris,
+            target_ras,
+            target_decs,
+            times,
+            indices,
+        )
+        return [
+            ConstraintResult(
+                violations=[
+                    ConstraintViolation(
+                        start_time=v.start_time,
+                        end_time=v.end_time,
+                        max_severity=v.max_severity,
+                        description=v.description,
+                    )
+                    for v in rust_result.violations
+                ],
+                all_satisfied=rust_result.all_satisfied,
+                constraint_name=rust_result.constraint_name,
+                _rust_result_ref=rust_result,
+            )
+            for rust_result in rust_results
+        ]
+
+    def _in_constraint_batch_uniform(
+        self,
+        ephemeris: Ephemeris,
+        target_ras: list[float],
+        target_decs: list[float],
+        times: datetime | list[datetime] | None = None,
+        indices: int | list[int] | None = None,
+        target_roll: float | None = None,
+        n_roll_samples: int = DEFAULT_N_ROLL_SAMPLES,
+    ) -> npt.NDArray[np.bool_]:
+        """Evaluate a batch where all targets share the same roll semantics."""
+        if target_roll is None and self._is_roll_dependent():
+            # Sweep all spacecraft roll angles; a cell is violated only if blocked at
+            # every roll (AND across the sweep).
+            roll_step = 360.0 / n_roll_samples
+            combined: npt.NDArray[np.bool_] | None = None
+            for i in range(n_roll_samples):
+                r = i * roll_step
+                arr = np.asarray(
+                    self._resolve_rust_constraint(target_roll=r).in_constraint_batch(
+                        ephemeris, target_ras, target_decs, times, indices
+                    ),
+                    dtype=bool,
+                )
+                combined = (
+                    arr
+                    if combined is None
+                    else cast(npt.NDArray[np.bool_], combined & arr)
+                )
+            return cast(
+                npt.NDArray[np.bool_],
+                combined
+                if combined is not None
+                else np.ones((len(target_ras), 0), dtype=bool),
+            )
+
+        rust_constraint = self._resolve_rust_constraint(
+            target_roll=target_roll,
+        )
+        return cast(
+            npt.NDArray[np.bool_],
+            rust_constraint.in_constraint_batch(
+                ephemeris,
+                target_ras,
+                target_decs,
+                times,
+                indices,
+            ),
+        )
+
     def _get_cached_rust_constraint(self) -> Any:
         """Return lazily cached Rust backend constraint for definition-only config."""
         if getattr(self, "_rust_constraint", None) is None:
@@ -329,40 +543,10 @@ class RustConstraintMixin(BaseModel):
             for arr in arrays[1:]:
                 combined &= arr
             swept_timestamps = list(rust_results[0].timestamp)
-            constraint_name = rust_results[0].constraint_name
-            # Reconstruct violation windows from the AND'd boolean array.
-            violations: list[ConstraintViolation] = []
-            in_viol = False
-            viol_start: datetime | None = None
-            for dt, flag in zip(swept_timestamps, combined):
-                if flag and not in_viol:
-                    in_viol = True
-                    viol_start = dt
-                elif not flag and in_viol:
-                    in_viol = False
-                    violations.append(
-                        ConstraintViolation(
-                            start_time=cast(datetime, viol_start),
-                            end_time=dt,
-                            max_severity=1.0,
-                            description=constraint_name,
-                        )
-                    )
-            if in_viol and viol_start is not None and swept_timestamps:
-                violations.append(
-                    ConstraintViolation(
-                        start_time=viol_start,
-                        end_time=swept_timestamps[-1],
-                        max_severity=1.0,
-                        description=constraint_name,
-                    )
-                )
-            return ConstraintResult(
-                violations=violations,
-                all_satisfied=not bool(combined.any()),
-                constraint_name=constraint_name,
-                _swept_timestamps=swept_timestamps,
-                _swept_array=combined.tolist(),
+            return self._build_constraint_result(
+                rust_results[0].constraint_name,
+                swept_timestamps,
+                combined,
             )
 
         rust_constraint = self._resolve_rust_constraint(
@@ -394,6 +578,54 @@ class RustConstraintMixin(BaseModel):
             _rust_result_ref=rust_result,
         )
 
+    def evaluate_batch(
+        self,
+        ephemeris: Ephemeris,
+        target_ras: list[float],
+        target_decs: list[float],
+        times: datetime | list[datetime] | None = None,
+        indices: int | list[int] | None = None,
+        target_rolls: list[float | None] | None = None,
+        n_roll_samples: int = DEFAULT_N_ROLL_SAMPLES,
+    ) -> list[ConstraintResult]:
+        """Evaluate the constraint for multiple targets and return one result per target."""
+        if n_roll_samples <= 0:
+            raise ValueError("n_roll_samples must be a positive integer")
+        normalized_target_rolls = self._normalize_target_rolls(
+            target_ras,
+            target_decs,
+            target_rolls,
+        )
+
+        if normalized_target_rolls is None:
+            return self._evaluate_batch_uniform(
+                ephemeris,
+                target_ras,
+                target_decs,
+                times=times,
+                indices=indices,
+                target_roll=None,
+                n_roll_samples=n_roll_samples,
+            )
+
+        results: list[ConstraintResult | None] = [None] * len(target_ras)
+        for target_roll, batch_indices in self._group_target_roll_indices(
+            normalized_target_rolls
+        ):
+            batch_results = self._evaluate_batch_uniform(
+                ephemeris,
+                [target_ras[i] for i in batch_indices],
+                [target_decs[i] for i in batch_indices],
+                times=times,
+                indices=indices,
+                target_roll=target_roll,
+                n_roll_samples=n_roll_samples,
+            )
+            for source_index, result in zip(batch_indices, batch_results):
+                results[source_index] = result
+
+        return [cast(ConstraintResult, result) for result in results]
+
     def in_constraint_batch(
         self,
         ephemeris: Ephemeris,
@@ -401,7 +633,7 @@ class RustConstraintMixin(BaseModel):
         target_decs: list[float],
         times: datetime | list[datetime] | None = None,
         indices: int | list[int] | None = None,
-        target_roll: float | None = None,
+        target_rolls: list[float | None] | None = None,
         n_roll_samples: int = DEFAULT_N_ROLL_SAMPLES,
     ) -> npt.NDArray[np.bool_]:
         """
@@ -416,10 +648,12 @@ class RustConstraintMixin(BaseModel):
             target_decs: List of target declinations in degrees (ICRS/J2000)
             times: Optional specific time(s) to evaluate
             indices: Optional specific time index/indices to evaluate
-            target_roll: Spacecraft roll angle (degrees).  When ``None`` (default) and
-                the constraint has a boresight offset with non-zero pitch/yaw, sweeps
-                ``n_roll_samples`` roll angles and returns ``True`` (violated)
-                only if violated at **every** possible roll (i.e. no valid roll exists).
+            target_rolls: Optional per-target spacecraft roll angles (degrees), one
+                value per target. Each entry may be ``None`` to evaluate that target
+                without a fixed spacecraft roll, using only the target coordinates.
+                When an entry is ``None`` and the constraint has a boresight offset with
+                non-zero pitch/yaw, sweeps ``n_roll_samples`` roll angles and returns
+                ``True`` (violated) only if violated at **every** possible roll.
             n_roll_samples: Number of roll angles to sweep when ``target_roll`` is ``None``
                 and the constraint is roll-dependent.  Uniformly spaced over [0°, 360°).
                 Default :data:`DEFAULT_N_ROLL_SAMPLES` (360 ≈ 1° resolution).
@@ -429,44 +663,46 @@ class RustConstraintMixin(BaseModel):
         """
         if n_roll_samples <= 0:
             raise ValueError("n_roll_samples must be a positive integer")
-
-        if target_roll is None and self._is_roll_dependent():
-            # Sweep all spacecraft roll angles; a cell is violated only if blocked at
-            # every roll (AND across the sweep).
-            roll_step = 360.0 / n_roll_samples
-            combined: npt.NDArray[np.bool_] | None = None
-            for i in range(n_roll_samples):
-                r = i * roll_step
-                arr = np.asarray(
-                    self._resolve_rust_constraint(target_roll=r).in_constraint_batch(
-                        ephemeris, target_ras, target_decs, times, indices
-                    ),
-                    dtype=bool,
-                )
-                combined = (
-                    arr
-                    if combined is None
-                    else cast(npt.NDArray[np.bool_], combined & arr)
-                )
-            return cast(
-                npt.NDArray[np.bool_],
-                combined
-                if combined is not None
-                else np.ones((len(target_ras), 0), dtype=bool),
-            )
-
-        rust_constraint = self._resolve_rust_constraint(
-            target_roll=target_roll,
+        normalized_target_rolls = self._normalize_target_rolls(
+            target_ras,
+            target_decs,
+            target_rolls,
         )
-        return cast(
-            npt.NDArray[np.bool_],
-            rust_constraint.in_constraint_batch(
+
+        if normalized_target_rolls is None:
+            return self._in_constraint_batch_uniform(
                 ephemeris,
                 target_ras,
                 target_decs,
-                times,
-                indices,
-            ),
+                times=times,
+                indices=indices,
+                target_roll=None,
+                n_roll_samples=n_roll_samples,
+            )
+
+        result: npt.NDArray[np.bool_] | None = None
+        for target_roll, batch_indices in self._group_target_roll_indices(
+            normalized_target_rolls
+        ):
+            batch_result = self._in_constraint_batch_uniform(
+                ephemeris,
+                [target_ras[i] for i in batch_indices],
+                [target_decs[i] for i in batch_indices],
+                times=times,
+                indices=indices,
+                target_roll=target_roll,
+                n_roll_samples=n_roll_samples,
+            )
+            if result is None:
+                result = np.empty(
+                    (len(target_ras), batch_result.shape[1]),
+                    dtype=bool,
+                )
+            result[batch_indices, :] = batch_result
+
+        return cast(
+            npt.NDArray[np.bool_],
+            result if result is not None else np.ones((0, 0), dtype=bool),
         )
 
     def in_constraint(
@@ -522,7 +758,7 @@ class RustConstraintMixin(BaseModel):
             if isinstance(parts[0], bool):
                 return all(parts)
             arr = np.array(parts, dtype=bool)  # (n_rolls, n_times)
-            return list(arr.all(axis=0))
+            return cast(list[bool], arr.all(axis=0).tolist())
 
         rust_constraint = self._resolve_rust_constraint(
             target_roll=target_roll,
@@ -565,8 +801,11 @@ class RustConstraintMixin(BaseModel):
         """
         if n_roll_samples <= 0:
             raise ValueError("n_roll_samples must be a positive integer")
-        return self._get_cached_rust_constraint().roll_range(
-            time, ephemeris, target_ra, target_dec, n_roll_samples
+        return cast(
+            list[tuple[float, float]],
+            self._get_cached_rust_constraint().roll_range(
+                time, ephemeris, target_ra, target_dec, n_roll_samples
+            ),
         )
 
     def instantaneous_field_of_regard(

--- a/rust_ephem/constraints.py
+++ b/rust_ephem/constraints.py
@@ -226,8 +226,8 @@ class RustConstraintMixin(BaseModel):
     def _normalize_target_rolls(
         target_ras: list[float],
         target_decs: list[float],
-        target_rolls: list[float | None] | None,
-    ) -> list[float | None] | None:
+        target_rolls: list[float] | None,
+    ) -> list[float] | None:
         """Validate per-target roll inputs for batch APIs."""
         if len(target_ras) != len(target_decs):
             raise ValueError("target_ras and target_decs must have the same length")
@@ -241,11 +241,11 @@ class RustConstraintMixin(BaseModel):
 
     @staticmethod
     def _group_target_roll_indices(
-        target_rolls: list[float | None],
-    ) -> list[tuple[float | None, list[int]]]:
+        target_rolls: list[float],
+    ) -> list[tuple[float, list[int]]]:
         """Group target indices by shared roll values while preserving order."""
-        grouped: dict[float | None, list[int]] = {}
-        order: list[float | None] = []
+        grouped: dict[float, list[int]] = {}
+        order: list[float] = []
         for index, target_roll in enumerate(target_rolls):
             if target_roll not in grouped:
                 grouped[target_roll] = []
@@ -585,10 +585,17 @@ class RustConstraintMixin(BaseModel):
         target_decs: list[float],
         times: datetime | list[datetime] | None = None,
         indices: int | list[int] | None = None,
-        target_rolls: list[float | None] | None = None,
+        target_rolls: list[float] | None = None,
         n_roll_samples: int = DEFAULT_N_ROLL_SAMPLES,
     ) -> list[ConstraintResult]:
-        """Evaluate the constraint for multiple targets and return one result per target."""
+        """Evaluate the constraint for multiple targets and return one result per target.
+
+        Args:
+            target_rolls: Optional per-target spacecraft roll angles (degrees). Must have
+                the same length as ``target_ras`` and ``target_decs``. Each entry may be
+                ``None`` to sweep all rolls for that target, or a float for a fixed roll.
+                Pass ``None`` (not a list) to sweep rolls for all targets uniformly.
+        """
         if n_roll_samples <= 0:
             raise ValueError("n_roll_samples must be a positive integer")
         normalized_target_rolls = self._normalize_target_rolls(
@@ -633,7 +640,7 @@ class RustConstraintMixin(BaseModel):
         target_decs: list[float],
         times: datetime | list[datetime] | None = None,
         indices: int | list[int] | None = None,
-        target_rolls: list[float | None] | None = None,
+        target_rolls: list[float] | None = None,
         n_roll_samples: int = DEFAULT_N_ROLL_SAMPLES,
     ) -> npt.NDArray[np.bool_]:
         """
@@ -654,6 +661,8 @@ class RustConstraintMixin(BaseModel):
                 When an entry is ``None`` and the constraint has a boresight offset with
                 non-zero pitch/yaw, sweeps ``n_roll_samples`` roll angles and returns
                 ``True`` (violated) only if violated at **every** possible roll.
+                Must have the same length as ``target_ras`` and ``target_decs``.
+                If you want to sweep rolls for all targets, pass ``None`` instead.
             n_roll_samples: Number of roll angles to sweep when ``target_roll`` is ``None``
                 and the constraint is roll-dependent.  Uniformly spaced over [0°, 360°).
                 Default :data:`DEFAULT_N_ROLL_SAMPLES` (360 ≈ 1° resolution).
@@ -674,6 +683,18 @@ class RustConstraintMixin(BaseModel):
                 ephemeris,
                 target_ras,
                 target_decs,
+                times=times,
+                indices=indices,
+                target_roll=None,
+                n_roll_samples=n_roll_samples,
+            )
+
+        # Special case: empty target list should still return proper (0, n_times) shape
+        if len(target_ras) == 0:
+            return self._in_constraint_batch_uniform(
+                ephemeris,
+                [],
+                [],
                 times=times,
                 indices=indices,
                 target_roll=None,

--- a/rust_ephem/constraints.py
+++ b/rust_ephem/constraints.py
@@ -277,16 +277,16 @@ class RustConstraintMixin(BaseModel):
                 target_roll=target_roll,
                 n_roll_samples=n_roll_samples,
             )
-            first_result = self.evaluate(
+            # Get timestamps/constraint_name from a single fixed roll (0°) to avoid
+            # redundant roll sweep. The metadata is the same regardless of roll.
+            first_result = self._resolve_rust_constraint(target_roll=0.0).evaluate(
                 ephemeris,
                 target_ras[0],
                 target_decs[0],
                 times=times,
                 indices=indices,
-                target_roll=target_roll,
-                n_roll_samples=n_roll_samples,
             )
-            timestamps = self._coerce_timestamps(first_result.timestamps)
+            timestamps = self._coerce_timestamps(first_result.timestamp)
             constraint_name = first_result.constraint_name
 
             return [

--- a/rust_ephem/constraints.pyi
+++ b/rust_ephem/constraints.pyi
@@ -90,7 +90,7 @@ class RustConstraintMixin(BaseModel):
         target_decs: list[float],
         times: datetime | list[datetime] | None = None,
         indices: int | list[int] | None = None,
-        target_rolls: list[float | None] | None = None,
+        target_rolls: list[float] | None = None,
         n_roll_samples: int = DEFAULT_N_ROLL_SAMPLES,
     ) -> list[ConstraintResult]: ...
     def in_constraint_batch(
@@ -100,7 +100,7 @@ class RustConstraintMixin(BaseModel):
         target_decs: list[float],
         times: datetime | list[datetime] | None = None,
         indices: int | list[int] | None = None,
-        target_rolls: list[float | None] | None = None,
+        target_rolls: list[float] | None = None,
         n_roll_samples: int = DEFAULT_N_ROLL_SAMPLES,
     ) -> npt.NDArray[np.bool_]: ...
     def in_constraint(

--- a/rust_ephem/constraints.pyi
+++ b/rust_ephem/constraints.pyi
@@ -83,6 +83,16 @@ class RustConstraintMixin(BaseModel):
         target_roll: float | None = None,
         n_roll_samples: int = DEFAULT_N_ROLL_SAMPLES,
     ) -> ConstraintResult: ...
+    def evaluate_batch(
+        self,
+        ephemeris: Ephemeris,
+        target_ras: list[float],
+        target_decs: list[float],
+        times: datetime | list[datetime] | None = None,
+        indices: int | list[int] | None = None,
+        target_rolls: list[float | None] | None = None,
+        n_roll_samples: int = DEFAULT_N_ROLL_SAMPLES,
+    ) -> list[ConstraintResult]: ...
     def in_constraint_batch(
         self,
         ephemeris: Ephemeris,
@@ -90,7 +100,7 @@ class RustConstraintMixin(BaseModel):
         target_decs: list[float],
         times: datetime | list[datetime] | None = None,
         indices: int | list[int] | None = None,
-        target_roll: float | None = None,
+        target_rolls: list[float | None] | None = None,
         n_roll_samples: int = DEFAULT_N_ROLL_SAMPLES,
     ) -> npt.NDArray[np.bool_]: ...
     def in_constraint(

--- a/rust_ephem/ephemeris.py
+++ b/rust_ephem/ephemeris.py
@@ -1,11 +1,14 @@
 # Create a type alias that supports isinstance checks
 import abc
 from datetime import datetime
+from typing import TYPE_CHECKING
 
 import numpy as np
 import numpy.typing as npt
-from astropy.coordinates import SkyCoord  # type: ignore[import-untyped]
-from astropy.units import Quantity  # type: ignore[import-untyped]
+
+if TYPE_CHECKING:
+    from astropy.coordinates import SkyCoord  # type: ignore[import-untyped]
+    from astropy.units import Quantity  # type: ignore[import-untyped]
 
 from ._rust_ephem import (
     GroundEphemeris,

--- a/rust_ephem/tle.py
+++ b/rust_ephem/tle.py
@@ -7,9 +7,9 @@ that can retrieve TLEs from various sources (files, URLs, Celestrak, Space-Track
 
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import datetime, timedelta
 
-from pydantic import BaseModel, Field, computed_field
+from pydantic import BaseModel, Field, computed_field, model_validator
 
 from ._rust_ephem import fetch_tle as _fetch_tle
 
@@ -34,6 +34,33 @@ class TLERecord(BaseModel):
     name: str | None = Field(None, description="Optional satellite name")
     epoch: datetime = Field(..., description="TLE epoch timestamp")
     source: str | None = Field(None, description="Source of the TLE data")
+
+    @model_validator(mode="before")
+    def _validate_tle_lines(cls, values: dict) -> dict:
+        """Validate that line1 and line2 conform to TLE format."""
+        line1 = values.get("line1", "")
+        line2 = values.get("line2", "")
+
+        if not (line1.startswith("1 ") and line2.startswith("2 ")):
+            raise ValueError(
+                "Invalid TLE format: line1 must start with '1 ' and line2 with '2 '"
+            )
+
+        if not values.get("epoch") and len(line1) >= 19:
+            # Extract epoch from line1 if not provided
+            epoch_str = line1[18:32].strip()
+            try:
+                epoch_year = int(epoch_str[:2])
+                epoch_day = float(epoch_str[2:])
+                epoch_year += 2000 if epoch_year < 57 else 1900  # TLE epoch year cutoff
+                epoch_datetime = datetime(epoch_year, 1, 1) + timedelta(
+                    days=epoch_day - 1
+                )
+                values["epoch"] = epoch_datetime
+            except Exception as exc:
+                raise ValueError(f"Failed to parse epoch from line1: {exc}") from exc
+
+        return values
 
     @computed_field  # type: ignore[prop-decorator]
     @property

--- a/rust_ephem/tle.py
+++ b/rust_ephem/tle.py
@@ -8,6 +8,7 @@ that can retrieve TLEs from various sources (files, URLs, Celestrak, Space-Track
 from __future__ import annotations
 
 from datetime import datetime, timedelta
+from typing import Any
 
 from pydantic import BaseModel, Field, computed_field, model_validator
 
@@ -36,7 +37,7 @@ class TLERecord(BaseModel):
     source: str | None = Field(None, description="Source of the TLE data")
 
     @model_validator(mode="before")
-    def _validate_tle_lines(cls, values: dict) -> dict:
+    def _validate_tle_lines(cls, values: dict[str, Any]) -> dict[str, Any]:
         """Validate that line1 and line2 conform to TLE format."""
         line1 = values.get("line1", "")
         line2 = values.get("line2", "")

--- a/rust_ephem/tle.py
+++ b/rust_ephem/tle.py
@@ -30,8 +30,12 @@ class TLERecord(BaseModel):
         source: Source of the TLE data (e.g., 'celestrak', 'spacetrack', 'file', 'url')
     """
 
-    line1: str = Field(..., description="First line of the TLE")
-    line2: str = Field(..., description="Second line of the TLE")
+    line1: str = Field(
+        ..., description="First line of the TLE", min_length=69, max_length=69
+    )
+    line2: str = Field(
+        ..., description="Second line of the TLE", min_length=69, max_length=69
+    )
     name: str | None = Field(None, description="Optional satellite name")
     epoch: datetime = Field(..., description="TLE epoch timestamp")
     source: str | None = Field(None, description="Source of the TLE data")

--- a/src/constraints/constraint_wrapper/py_api.rs
+++ b/src/constraints/constraint_wrapper/py_api.rs
@@ -1432,7 +1432,7 @@ impl PyConstraint {
         target_decs: Vec<f64>,
         times: Option<&Bound<PyAny>>,
         indices: Option<&Bound<PyAny>>,
-        target_rolls: Option<Vec<Option<f64>>>,
+        target_rolls: Option<Vec<f64>>,
     ) -> PyResult<Vec<ConstraintResult>> {
         if target_ras.len() != target_decs.len() {
             return Err(pyo3::exceptions::PyValueError::new_err(
@@ -1514,7 +1514,7 @@ impl PyConstraint {
         let mut roll_map: std::collections::BTreeMap<String, Vec<usize>> =
             std::collections::BTreeMap::new();
         for (idx, roll) in rolls.iter().enumerate() {
-            let key = format!("{:?}", roll);
+            let key = format!("{}", roll);
             roll_map.entry(key).or_default().push(idx);
         }
 
@@ -1533,7 +1533,7 @@ impl PyConstraint {
             let group_ras: Vec<f64> = group_indices.iter().map(|&i| target_ras[i]).collect();
             let group_decs: Vec<f64> = group_indices.iter().map(|&i| target_decs[i]).collect();
 
-            let group_results = self.with_effective_evaluator(target_roll, |evaluator| {
+            let group_results = self.with_effective_evaluator(Some(target_roll), |evaluator| {
                 if let Ok(ephem) = bound.extract::<PyRef<TLEEphemeris>>() {
                     return self.eval_batch_with_ephemeris(
                         evaluator,
@@ -1600,7 +1600,7 @@ impl PyConstraint {
     ///     target_decs (array-like): Array of declinations in degrees (ICRS/J2000)
     ///     times (datetime or list[datetime], optional): Specific times to evaluate
     ///     indices (int or list[int], optional): Specific time index/indices to evaluate
-    ///     target_rolls (list[float|None], optional): Per-target spacecraft roll angles in degrees
+    ///     target_rolls (list[float], optional): Per-target spacecraft roll angles in degrees
     ///
     /// Returns:
     ///     numpy.ndarray: 2D boolean array of shape (n_targets, n_times) where True
@@ -1622,7 +1622,7 @@ impl PyConstraint {
         target_decs: Vec<f64>,
         times: Option<&Bound<PyAny>>,
         indices: Option<&Bound<PyAny>>,
-        target_rolls: Option<Vec<Option<f64>>>,
+        target_rolls: Option<Vec<f64>>,
     ) -> PyResult<Py<PyAny>> {
         if target_ras.len() != target_decs.len() {
             return Err(pyo3::exceptions::PyValueError::new_err(
@@ -1705,7 +1705,7 @@ impl PyConstraint {
         let mut roll_map: std::collections::BTreeMap<String, Vec<usize>> =
             std::collections::BTreeMap::new();
         for (idx, roll) in rolls.iter().enumerate() {
-            let key = format!("{:?}", roll);
+            let key = format!("{}", roll);
             roll_map.entry(key).or_default().push(idx);
         }
 
@@ -1718,7 +1718,7 @@ impl PyConstraint {
             let group_ras: Vec<f64> = group_indices.iter().map(|&i| target_ras[i]).collect();
             let group_decs: Vec<f64> = group_indices.iter().map(|&i| target_decs[i]).collect();
 
-            let group_array = self.with_effective_evaluator(target_roll, |evaluator| {
+            let group_array = self.with_effective_evaluator(Some(target_roll), |evaluator| {
                 if let Ok(ephem) = bound.extract::<PyRef<TLEEphemeris>>() {
                     return evaluator.in_constraint_batch(
                         &*ephem as &dyn EphemerisBase,
@@ -2025,7 +2025,7 @@ impl PyConstraint {
 
         // Call the batch method with the time parameter as is
         // Convert target_roll to target_rolls (per-target list with single element)
-        let target_rolls = target_roll.map(|roll| vec![Some(roll)]);
+        let target_rolls = target_roll.map(|roll| vec![roll]);
         let result_array = self.in_constraint_batch(
             py,
             ephemeris,

--- a/src/constraints/constraint_wrapper/py_api.rs
+++ b/src/constraints/constraint_wrapper/py_api.rs
@@ -21,7 +21,6 @@ use crate::ephemeris::OEMEphemeris;
 use crate::ephemeris::SPICEEphemeris;
 use crate::ephemeris::TLEEphemeris;
 use chrono::{DateTime, Utc};
-use ndarray;
 use numpy::{PyArray2, PyArrayMethods};
 use pyo3::prelude::*;
 use pyo3::types::{PyBool, PyList};

--- a/src/constraints/constraint_wrapper/py_api.rs
+++ b/src/constraints/constraint_wrapper/py_api.rs
@@ -1575,6 +1575,14 @@ impl PyConstraint {
                 ))
             })?;
 
+            if group_results.len() != group_indices.len() {
+                return Err(pyo3::exceptions::PyRuntimeError::new_err(format!(
+                    "Batch evaluation returned {} results for {} targets",
+                    group_results.len(),
+                    group_indices.len()
+                )));
+            }
+
             // Place results back in original order
             // Convert group_results into an iterator and zip with group_indices
             for (result, &original_idx) in group_results.into_iter().zip(group_indices.iter()) {
@@ -1582,8 +1590,20 @@ impl PyConstraint {
             }
         }
 
-        // Convert Option results to owned results
-        let final_results: Vec<ConstraintResult> = results.into_iter().flatten().collect();
+        // Convert Option results to owned results, preserving the invariant that
+        // every input target produces exactly one result.
+        let final_results: Vec<ConstraintResult> = results
+            .into_iter()
+            .enumerate()
+            .map(|(index, result)| {
+                result.ok_or_else(|| {
+                    pyo3::exceptions::PyRuntimeError::new_err(format!(
+                        "Batch evaluation did not produce a result for target index {}",
+                        index
+                    ))
+                })
+            })
+            .collect::<PyResult<Vec<_>>>()?;
         Ok(final_results)
     }
 

--- a/src/constraints/constraint_wrapper/py_api.rs
+++ b/src/constraints/constraint_wrapper/py_api.rs
@@ -192,9 +192,10 @@ impl PyConstraint {
                 |_i, _is_open| evaluator.name(),
             );
 
+            let all_satisfied = violations.is_empty();
             results.push(ConstraintResult::new(
-                violations.clone(),
-                violations.is_empty(),
+                violations,
+                all_satisfied,
                 evaluator.name(),
                 times.clone(),
             ));

--- a/src/constraints/constraint_wrapper/py_api.rs
+++ b/src/constraints/constraint_wrapper/py_api.rs
@@ -21,6 +21,7 @@ use crate::ephemeris::OEMEphemeris;
 use crate::ephemeris::SPICEEphemeris;
 use crate::ephemeris::TLEEphemeris;
 use chrono::{DateTime, Utc};
+use ndarray;
 use numpy::{PyArray2, PyArrayMethods};
 use pyo3::prelude::*;
 use pyo3::types::{PyBool, PyList};
@@ -1421,7 +1422,7 @@ impl PyConstraint {
 
     /// Evaluate constraint for multiple targets and return one result per target.
     #[allow(clippy::too_many_arguments)]
-    #[pyo3(signature = (ephemeris, target_ras, target_decs, times=None, indices=None, target_roll=None))]
+    #[pyo3(signature = (ephemeris, target_ras, target_decs, times=None, indices=None, target_rolls=None))]
     fn evaluate_batch(
         &self,
         py: Python,
@@ -1430,12 +1431,21 @@ impl PyConstraint {
         target_decs: Vec<f64>,
         times: Option<&Bound<PyAny>>,
         indices: Option<&Bound<PyAny>>,
-        target_roll: Option<f64>,
+        target_rolls: Option<Vec<Option<f64>>>,
     ) -> PyResult<Vec<ConstraintResult>> {
         if target_ras.len() != target_decs.len() {
             return Err(pyo3::exceptions::PyValueError::new_err(
                 "target_ras and target_decs must have the same length",
             ));
+        }
+
+        // Validate target_rolls if provided
+        if let Some(ref rolls) = target_rolls {
+            if rolls.len() != target_ras.len() {
+                return Err(pyo3::exceptions::PyValueError::new_err(
+                    "target_rolls must have the same length as target_ras and target_decs",
+                ));
+            }
         }
 
         let bound = ephemeris.bind(py);
@@ -1452,48 +1462,129 @@ impl PyConstraint {
             None
         };
 
-        self.with_effective_evaluator(target_roll, |evaluator| {
-            if let Ok(ephem) = bound.extract::<PyRef<TLEEphemeris>>() {
-                return self.eval_batch_with_ephemeris(
-                    evaluator,
-                    &*ephem,
-                    &target_ras,
-                    &target_decs,
-                    time_indices.clone(),
-                );
-            }
-            if let Ok(ephem) = bound.extract::<PyRef<SPICEEphemeris>>() {
-                return self.eval_batch_with_ephemeris(
-                    evaluator,
-                    &*ephem,
-                    &target_ras,
-                    &target_decs,
-                    time_indices.clone(),
-                );
-            }
-            if let Ok(ephem) = bound.extract::<PyRef<GroundEphemeris>>() {
-                return self.eval_batch_with_ephemeris(
-                    evaluator,
-                    &*ephem,
-                    &target_ras,
-                    &target_decs,
-                    time_indices.clone(),
-                );
-            }
-            if let Ok(ephem) = bound.extract::<PyRef<OEMEphemeris>>() {
-                return self.eval_batch_with_ephemeris(
-                    evaluator,
-                    &*ephem,
-                    &target_ras,
-                    &target_decs,
-                    time_indices.clone(),
-                );
-            }
+        // If no per-target rolls, use uniform None roll for all targets
+        if target_rolls.is_none() {
+            return self.with_effective_evaluator(None, |evaluator| {
+                if let Ok(ephem) = bound.extract::<PyRef<TLEEphemeris>>() {
+                    return self.eval_batch_with_ephemeris(
+                        evaluator,
+                        &*ephem,
+                        &target_ras,
+                        &target_decs,
+                        time_indices.clone(),
+                    );
+                }
+                if let Ok(ephem) = bound.extract::<PyRef<SPICEEphemeris>>() {
+                    return self.eval_batch_with_ephemeris(
+                        evaluator,
+                        &*ephem,
+                        &target_ras,
+                        &target_decs,
+                        time_indices.clone(),
+                    );
+                }
+                if let Ok(ephem) = bound.extract::<PyRef<GroundEphemeris>>() {
+                    return self.eval_batch_with_ephemeris(
+                        evaluator,
+                        &*ephem,
+                        &target_ras,
+                        &target_decs,
+                        time_indices.clone(),
+                    );
+                }
+                if let Ok(ephem) = bound.extract::<PyRef<OEMEphemeris>>() {
+                    return self.eval_batch_with_ephemeris(
+                        evaluator,
+                        &*ephem,
+                        &target_ras,
+                        &target_decs,
+                        time_indices.clone(),
+                    );
+                }
 
-            Err(pyo3::exceptions::PyTypeError::new_err(
-                "Unsupported ephemeris type. Expected TLEEphemeris, SPICEEphemeris, GroundEphemeris, or OEMEphemeris",
-            ))
-        })
+                Err(pyo3::exceptions::PyTypeError::new_err(
+                    "Unsupported ephemeris type. Expected TLEEphemeris, SPICEEphemeris, GroundEphemeris, or OEMEphemeris",
+                ))
+            });
+        }
+
+        // Group targets by roll value for efficient evaluation
+        let rolls = target_rolls.unwrap();
+        let mut roll_map: std::collections::BTreeMap<String, Vec<usize>> =
+            std::collections::BTreeMap::new();
+        for (idx, roll) in rolls.iter().enumerate() {
+            let key = format!("{:?}", roll);
+            roll_map.entry(key).or_default().push(idx);
+        }
+
+        // Create a result vector with capacity for all targets
+        let mut results: Vec<Option<ConstraintResult>> = Vec::with_capacity(target_ras.len());
+        for _ in 0..target_ras.len() {
+            results.push(None);
+        }
+
+        // Evaluate each roll group
+        for (_, group_indices) in roll_map {
+            // Get the roll value from the first index in the group
+            let target_roll = rolls[group_indices[0]];
+
+            // Extract targets for this group
+            let group_ras: Vec<f64> = group_indices.iter().map(|&i| target_ras[i]).collect();
+            let group_decs: Vec<f64> = group_indices.iter().map(|&i| target_decs[i]).collect();
+
+            let group_results = self.with_effective_evaluator(target_roll, |evaluator| {
+                if let Ok(ephem) = bound.extract::<PyRef<TLEEphemeris>>() {
+                    return self.eval_batch_with_ephemeris(
+                        evaluator,
+                        &*ephem,
+                        &group_ras,
+                        &group_decs,
+                        time_indices.clone(),
+                    );
+                }
+                if let Ok(ephem) = bound.extract::<PyRef<SPICEEphemeris>>() {
+                    return self.eval_batch_with_ephemeris(
+                        evaluator,
+                        &*ephem,
+                        &group_ras,
+                        &group_decs,
+                        time_indices.clone(),
+                    );
+                }
+                if let Ok(ephem) = bound.extract::<PyRef<GroundEphemeris>>() {
+                    return self.eval_batch_with_ephemeris(
+                        evaluator,
+                        &*ephem,
+                        &group_ras,
+                        &group_decs,
+                        time_indices.clone(),
+                    );
+                }
+                if let Ok(ephem) = bound.extract::<PyRef<OEMEphemeris>>() {
+                    return self.eval_batch_with_ephemeris(
+                        evaluator,
+                        &*ephem,
+                        &group_ras,
+                        &group_decs,
+                        time_indices.clone(),
+                    );
+                }
+
+                Err(pyo3::exceptions::PyTypeError::new_err(
+                    "Unsupported ephemeris type. Expected TLEEphemeris, SPICEEphemeris, GroundEphemeris, or OEMEphemeris",
+                ))
+            })?;
+
+            // Place results back in original order
+            // Convert group_results into an iterator and zip with group_indices
+            for (result, &original_idx) in group_results.into_iter().zip(group_indices.iter()) {
+                results[original_idx] = Some(result);
+            }
+        }
+
+        // Convert Option results to owned results
+        let final_results: Vec<ConstraintResult> = results.into_iter().flatten().collect();
+        Ok(final_results)
     }
 
     /// Check if targets are in-constraint for multiple RA/Dec positions (vectorized)
@@ -1508,6 +1599,7 @@ impl PyConstraint {
     ///     target_decs (array-like): Array of declinations in degrees (ICRS/J2000)
     ///     times (datetime or list[datetime], optional): Specific times to evaluate
     ///     indices (int or list[int], optional): Specific time index/indices to evaluate
+    ///     target_rolls (list[float|None], optional): Per-target spacecraft roll angles in degrees
     ///
     /// Returns:
     ///     numpy.ndarray: 2D boolean array of shape (n_targets, n_times) where True
@@ -1520,7 +1612,7 @@ impl PyConstraint {
     ///     >>> violations.shape  # (3, n_times)
     ///     >>> violations[0, :]  # Violations for first target across all times
     #[allow(clippy::too_many_arguments)]
-    #[pyo3(signature = (ephemeris, target_ras, target_decs, times=None, indices=None, target_roll=None))]
+    #[pyo3(signature = (ephemeris, target_ras, target_decs, times=None, indices=None, target_rolls=None))]
     fn in_constraint_batch(
         &self,
         py: Python,
@@ -1529,12 +1621,21 @@ impl PyConstraint {
         target_decs: Vec<f64>,
         times: Option<&Bound<PyAny>>,
         indices: Option<&Bound<PyAny>>,
-        target_roll: Option<f64>,
+        target_rolls: Option<Vec<Option<f64>>>,
     ) -> PyResult<Py<PyAny>> {
         if target_ras.len() != target_decs.len() {
             return Err(pyo3::exceptions::PyValueError::new_err(
                 "target_ras and target_decs must have the same length",
             ));
+        }
+
+        // Validate target_rolls if provided
+        if let Some(ref rolls) = target_rolls {
+            if rolls.len() != target_ras.len() {
+                return Err(pyo3::exceptions::PyValueError::new_err(
+                    "target_rolls must have the same length as target_ras and target_decs",
+                ));
+            }
         }
 
         // Parse time filtering options
@@ -1552,49 +1653,137 @@ impl PyConstraint {
             None
         };
 
-        // Call batch evaluation with ephemeris based on type
-        let result_array = self.with_effective_evaluator(target_roll, |evaluator| {
-            if let Ok(ephem) = bound.extract::<PyRef<TLEEphemeris>>() {
-                return evaluator.in_constraint_batch(
-                    &*ephem as &dyn EphemerisBase,
-                    &target_ras,
-                    &target_decs,
-                    time_indices.as_deref(),
-                );
-            }
-            if let Ok(ephem) = bound.extract::<PyRef<SPICEEphemeris>>() {
-                return evaluator.in_constraint_batch(
-                    &*ephem as &dyn EphemerisBase,
-                    &target_ras,
-                    &target_decs,
-                    time_indices.as_deref(),
-                );
-            }
-            if let Ok(ephem) = bound.extract::<PyRef<GroundEphemeris>>() {
-                return evaluator.in_constraint_batch(
-                    &*ephem as &dyn EphemerisBase,
-                    &target_ras,
-                    &target_decs,
-                    time_indices.as_deref(),
-                );
-            }
-            if let Ok(ephem) = bound.extract::<PyRef<OEMEphemeris>>() {
-                return evaluator.in_constraint_batch(
-                    &*ephem as &dyn EphemerisBase,
-                    &target_ras,
-                    &target_decs,
-                    time_indices.as_deref(),
-                );
+        // If no per-target rolls, use uniform None roll for all targets
+        if target_rolls.is_none() {
+            let result_array = self.with_effective_evaluator(None, |evaluator| {
+                if let Ok(ephem) = bound.extract::<PyRef<TLEEphemeris>>() {
+                    return evaluator.in_constraint_batch(
+                        &*ephem as &dyn EphemerisBase,
+                        &target_ras,
+                        &target_decs,
+                        time_indices.as_deref(),
+                    );
+                }
+                if let Ok(ephem) = bound.extract::<PyRef<SPICEEphemeris>>() {
+                    return evaluator.in_constraint_batch(
+                        &*ephem as &dyn EphemerisBase,
+                        &target_ras,
+                        &target_decs,
+                        time_indices.as_deref(),
+                    );
+                }
+                if let Ok(ephem) = bound.extract::<PyRef<GroundEphemeris>>() {
+                    return evaluator.in_constraint_batch(
+                        &*ephem as &dyn EphemerisBase,
+                        &target_ras,
+                        &target_decs,
+                        time_indices.as_deref(),
+                    );
+                }
+                if let Ok(ephem) = bound.extract::<PyRef<OEMEphemeris>>() {
+                    return evaluator.in_constraint_batch(
+                        &*ephem as &dyn EphemerisBase,
+                        &target_ras,
+                        &target_decs,
+                        time_indices.as_deref(),
+                    );
+                }
+
+                Err(pyo3::exceptions::PyTypeError::new_err(
+                    "Unsupported ephemeris type. Expected TLEEphemeris, SPICEEphemeris, GroundEphemeris, or OEMEphemeris",
+                ))
+            })?;
+
+            // Convert to numpy array
+            use numpy::IntoPyArray;
+            return Ok(result_array.into_pyarray(py).into());
+        }
+
+        // Handle per-target rolls: group targets by roll and stack results
+        let rolls = target_rolls.unwrap();
+        let mut roll_map: std::collections::BTreeMap<String, Vec<usize>> =
+            std::collections::BTreeMap::new();
+        for (idx, roll) in rolls.iter().enumerate() {
+            let key = format!("{:?}", roll);
+            roll_map.entry(key).or_default().push(idx);
+        }
+
+        // First pass: get dimensions and collect results
+        let mut all_groups: Vec<(Vec<usize>, numpy::ndarray::Array2<bool>)> = Vec::new();
+        let mut n_times = 0;
+
+        for (_, group_indices) in roll_map {
+            let target_roll = rolls[group_indices[0]];
+            let group_ras: Vec<f64> = group_indices.iter().map(|&i| target_ras[i]).collect();
+            let group_decs: Vec<f64> = group_indices.iter().map(|&i| target_decs[i]).collect();
+
+            let group_array = self.with_effective_evaluator(target_roll, |evaluator| {
+                if let Ok(ephem) = bound.extract::<PyRef<TLEEphemeris>>() {
+                    return evaluator.in_constraint_batch(
+                        &*ephem as &dyn EphemerisBase,
+                        &group_ras,
+                        &group_decs,
+                        time_indices.as_deref(),
+                    );
+                }
+                if let Ok(ephem) = bound.extract::<PyRef<SPICEEphemeris>>() {
+                    return evaluator.in_constraint_batch(
+                        &*ephem as &dyn EphemerisBase,
+                        &group_ras,
+                        &group_decs,
+                        time_indices.as_deref(),
+                    );
+                }
+                if let Ok(ephem) = bound.extract::<PyRef<GroundEphemeris>>() {
+                    return evaluator.in_constraint_batch(
+                        &*ephem as &dyn EphemerisBase,
+                        &group_ras,
+                        &group_decs,
+                        time_indices.as_deref(),
+                    );
+                }
+                if let Ok(ephem) = bound.extract::<PyRef<OEMEphemeris>>() {
+                    return evaluator.in_constraint_batch(
+                        &*ephem as &dyn EphemerisBase,
+                        &group_ras,
+                        &group_decs,
+                        time_indices.as_deref(),
+                    );
+                }
+
+                Err(pyo3::exceptions::PyTypeError::new_err(
+                    "Unsupported ephemeris type. Expected TLEEphemeris, SPICEEphemeris, GroundEphemeris, or OEMEphemeris",
+                ))
+            })?;
+
+            if n_times == 0 {
+                n_times = group_array.len_of(ndarray::Axis(1));
             }
 
-            Err(pyo3::exceptions::PyTypeError::new_err(
-                "Unsupported ephemeris type. Expected TLEEphemeris, SPICEEphemeris, GroundEphemeris, or OEMEphemeris",
-            ))
-        })?;
+            all_groups.push((group_indices, group_array));
+        }
+
+        // Reconstruct results in original order
+        let mut final_results: Vec<Vec<bool>> = vec![vec![false; n_times]; target_ras.len()];
+
+        for (group_indices, group_array) in all_groups {
+            for (row_in_group, &orig_idx) in group_indices.iter().enumerate() {
+                for col in 0..n_times {
+                    final_results[orig_idx][col] = group_array[[row_in_group, col]];
+                }
+            }
+        }
 
         // Convert to numpy array
         use numpy::IntoPyArray;
-        Ok(result_array.into_pyarray(py).into())
+        let arr: numpy::ndarray::Array2<bool> = numpy::ndarray::Array2::from_shape_vec(
+            (target_ras.len(), n_times),
+            final_results.into_iter().flatten().collect(),
+        )
+        .map_err(|e| {
+            pyo3::exceptions::PyValueError::new_err(format!("Failed to create array: {}", e))
+        })?;
+        Ok(arr.into_pyarray(py).into())
     }
 
     /// Compute instantaneous field of regard for this constraint in steradians.
@@ -1834,6 +2023,8 @@ impl PyConstraint {
         let target_decs = vec![target_dec; num_times];
 
         // Call the batch method with the time parameter as is
+        // Convert target_roll to target_rolls (per-target list with single element)
+        let target_rolls = target_roll.map(|roll| vec![Some(roll)]);
         let result_array = self.in_constraint_batch(
             py,
             ephemeris,
@@ -1841,7 +2032,7 @@ impl PyConstraint {
             target_decs,
             Some(bound_time),
             None,
-            target_roll,
+            target_rolls,
         )?;
 
         // Extract the results for the single target (first row)

--- a/src/constraints/constraint_wrapper/py_api.rs
+++ b/src/constraints/constraint_wrapper/py_api.rs
@@ -157,6 +157,51 @@ impl PyConstraint {
         ))
     }
 
+    fn eval_batch_with_ephemeris<E: EphemerisBase>(
+        &self,
+        evaluator: &dyn ConstraintEvaluator,
+        ephemeris: &E,
+        target_ras: &[f64],
+        target_decs: &[f64],
+        time_indices: Option<Vec<usize>>,
+    ) -> PyResult<Vec<ConstraintResult>> {
+        let violation_array = evaluator.in_constraint_batch(
+            ephemeris,
+            target_ras,
+            target_decs,
+            time_indices.as_deref(),
+        )?;
+
+        let all_times = ephemeris.get_times()?;
+        let times: Vec<_> = if let Some(ref indices) = time_indices {
+            indices.iter().map(|&i| all_times[i]).collect()
+        } else {
+            all_times.to_vec()
+        };
+
+        let mut results = Vec::with_capacity(target_ras.len());
+        for target_index in 0..target_ras.len() {
+            let violated: Vec<bool> = (0..violation_array.ncols())
+                .map(|i| violation_array[[target_index, i]])
+                .collect();
+
+            let violations = crate::constraints::core::track_violations(
+                &times,
+                |i| (violated[i], if violated[i] { 1.0 } else { 0.0 }),
+                |_i, _is_open| evaluator.name(),
+            );
+
+            results.push(ConstraintResult::new(
+                violations.clone(),
+                violations.is_empty(),
+                evaluator.name(),
+                times.clone(),
+            ));
+        }
+
+        Ok(results)
+    }
+
     /// Vectorized evaluation for moving bodies - evaluates all targets at their corresponding times
     ///
     /// For N targets at N times, this calls in_constraint_batch once with all N targets
@@ -1364,6 +1409,83 @@ impl PyConstraint {
                     &*ephem,
                     target_ra,
                     target_dec,
+                    time_indices.clone(),
+                );
+            }
+
+            Err(pyo3::exceptions::PyTypeError::new_err(
+                "Unsupported ephemeris type. Expected TLEEphemeris, SPICEEphemeris, GroundEphemeris, or OEMEphemeris",
+            ))
+        })
+    }
+
+    /// Evaluate constraint for multiple targets and return one result per target.
+    #[allow(clippy::too_many_arguments)]
+    #[pyo3(signature = (ephemeris, target_ras, target_decs, times=None, indices=None, target_roll=None))]
+    fn evaluate_batch(
+        &self,
+        py: Python,
+        ephemeris: Py<PyAny>,
+        target_ras: Vec<f64>,
+        target_decs: Vec<f64>,
+        times: Option<&Bound<PyAny>>,
+        indices: Option<&Bound<PyAny>>,
+        target_roll: Option<f64>,
+    ) -> PyResult<Vec<ConstraintResult>> {
+        if target_ras.len() != target_decs.len() {
+            return Err(pyo3::exceptions::PyValueError::new_err(
+                "target_ras and target_decs must have the same length",
+            ));
+        }
+
+        let bound = ephemeris.bind(py);
+        let time_indices = if let Some(times_arg) = times {
+            if indices.is_some() {
+                return Err(pyo3::exceptions::PyValueError::new_err(
+                    "Cannot specify both 'times' and 'indices' parameters",
+                ));
+            }
+            Some(self.parse_times_to_indices(bound, times_arg)?)
+        } else if let Some(indices_arg) = indices {
+            Some(self.parse_indices(indices_arg)?)
+        } else {
+            None
+        };
+
+        self.with_effective_evaluator(target_roll, |evaluator| {
+            if let Ok(ephem) = bound.extract::<PyRef<TLEEphemeris>>() {
+                return self.eval_batch_with_ephemeris(
+                    evaluator,
+                    &*ephem,
+                    &target_ras,
+                    &target_decs,
+                    time_indices.clone(),
+                );
+            }
+            if let Ok(ephem) = bound.extract::<PyRef<SPICEEphemeris>>() {
+                return self.eval_batch_with_ephemeris(
+                    evaluator,
+                    &*ephem,
+                    &target_ras,
+                    &target_decs,
+                    time_indices.clone(),
+                );
+            }
+            if let Ok(ephem) = bound.extract::<PyRef<GroundEphemeris>>() {
+                return self.eval_batch_with_ephemeris(
+                    evaluator,
+                    &*ephem,
+                    &target_ras,
+                    &target_decs,
+                    time_indices.clone(),
+                );
+            }
+            if let Ok(ephem) = bound.extract::<PyRef<OEMEphemeris>>() {
+                return self.eval_batch_with_ephemeris(
+                    evaluator,
+                    &*ephem,
+                    &target_ras,
+                    &target_decs,
                     time_indices.clone(),
                 );
             }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -103,7 +103,7 @@ def pytest_collection_modifyitems(config: Config, items: list[Any]) -> None:
         import astropy  # type: ignore[import-untyped]  # noqa: F401
 
         has_astropy = True
-    except ImportError:
+    except Exception:
         has_astropy = False
 
     # Check for rust_ephem
@@ -111,7 +111,7 @@ def pytest_collection_modifyitems(config: Config, items: list[Any]) -> None:
         import rust_ephem  # noqa: F401
 
         has_rust_ephem = True
-    except ImportError:
+    except Exception:
         has_rust_ephem = False
 
     # Mark tests based on module imports

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -111,7 +111,7 @@ def pytest_collection_modifyitems(config: Config, items: list[Any]) -> None:
         import rust_ephem  # noqa: F401
 
         has_rust_ephem = True
-    except Exception:
+    except ImportError:
         has_rust_ephem = False
 
     # Mark tests based on module imports

--- a/tests/constraints/boresight_offset_constraint/test_boresight_offset_constraint.py
+++ b/tests/constraints/boresight_offset_constraint/test_boresight_offset_constraint.py
@@ -192,7 +192,7 @@ def test_batch_target_rolls_matches_per_target_calls(
 
     target_ras = [10.0, 25.0, 40.0, 55.0]
     target_decs = [5.0, -10.0, 15.0, -20.0]
-    target_rolls = [None, 12.0, None, 30.0]
+    target_rolls = [1.0, 12.0, 15.0, 30.0]
 
     batch = config.in_constraint_batch(
         tle_ephem,
@@ -222,7 +222,7 @@ def test_evaluate_batch_target_rolls_matches_per_target_calls(
 
     target_ras = [10.0, 25.0, 40.0, 55.0]
     target_decs = [5.0, -10.0, 15.0, -20.0]
-    target_rolls = [None, 12.0, None, 30.0]
+    target_rolls = [1.0, 12.0, 15.0, 30.0]
 
     batch = config.evaluate_batch(
         tle_ephem,
@@ -260,7 +260,7 @@ def test_batch_target_rolls_length_validation(
             tle_ephem,
             [10.0, 25.0],
             [5.0, -10.0],
-            target_rolls=[None],
+            target_rolls=[1.0],  # Incorrect length
         )
 
 

--- a/tests/constraints/boresight_offset_constraint/test_boresight_offset_constraint.py
+++ b/tests/constraints/boresight_offset_constraint/test_boresight_offset_constraint.py
@@ -159,11 +159,13 @@ def test_low_level_constraint_api_accepts_target_roll(
         yaw_deg=-1.5,
     )
 
+    # Per-target rolls with same value for all targets
+    target_rolls = [12.0] * len(target_ras)
     via_target_roll = base.in_constraint_batch(
         ephem,
         target_ras,
         target_decs,
-        target_roll=12.0,
+        target_rolls=target_rolls,
     )
 
     # With clockwise=True, target_roll is added with opposite sign.

--- a/tests/constraints/boresight_offset_constraint/test_boresight_offset_constraint.py
+++ b/tests/constraints/boresight_offset_constraint/test_boresight_offset_constraint.py
@@ -179,6 +179,89 @@ def test_low_level_constraint_api_accepts_target_roll(
     assert np.array_equal(via_target_roll, expected)
 
 
+def test_batch_target_rolls_matches_per_target_calls(
+    tle_ephem: rust_ephem.TLEEphemeris,
+) -> None:
+    config = SunConstraint(min_angle=45.0).boresight_offset(
+        pitch_deg=1.5,
+        yaw_deg=-0.7,
+        roll_reference=RollReference.NORTH,
+    )
+
+    target_ras = [10.0, 25.0, 40.0, 55.0]
+    target_decs = [5.0, -10.0, 15.0, -20.0]
+    target_rolls = [None, 12.0, None, 30.0]
+
+    batch = config.in_constraint_batch(
+        tle_ephem,
+        target_ras,
+        target_decs,
+        target_rolls=target_rolls,
+    )
+
+    for i, target_roll in enumerate(target_rolls):
+        single = config.evaluate(
+            tle_ephem,
+            target_ras[i],
+            target_decs[i],
+            target_roll=target_roll,
+        )
+        np.testing.assert_array_equal(batch[i, :], single.constraint_array)
+
+
+def test_evaluate_batch_target_rolls_matches_per_target_calls(
+    tle_ephem: rust_ephem.TLEEphemeris,
+) -> None:
+    config = SunConstraint(min_angle=45.0).boresight_offset(
+        pitch_deg=1.5,
+        yaw_deg=-0.7,
+        roll_reference=RollReference.NORTH,
+    )
+
+    target_ras = [10.0, 25.0, 40.0, 55.0]
+    target_decs = [5.0, -10.0, 15.0, -20.0]
+    target_rolls = [None, 12.0, None, 30.0]
+
+    batch = config.evaluate_batch(
+        tle_ephem,
+        target_ras,
+        target_decs,
+        target_rolls=target_rolls,
+    )
+
+    for i, target_roll in enumerate(target_rolls):
+        single = config.evaluate(
+            tle_ephem,
+            target_ras[i],
+            target_decs[i],
+            target_roll=target_roll,
+        )
+        np.testing.assert_array_equal(
+            batch[i].constraint_array, single.constraint_array
+        )
+
+
+def test_batch_target_rolls_length_validation(
+    tle_ephem: rust_ephem.TLEEphemeris,
+) -> None:
+    config = SunConstraint(min_angle=45.0).boresight_offset(
+        pitch_deg=1.5,
+        yaw_deg=-0.7,
+        roll_reference=RollReference.NORTH,
+    )
+
+    with pytest.raises(
+        ValueError,
+        match="target_rolls must have the same length as target_ras and target_decs",
+    ):
+        config.in_constraint_batch(
+            tle_ephem,
+            [10.0, 25.0],
+            [5.0, -10.0],
+            target_rolls=[None],
+        )
+
+
 def test_free_roll_for_gte_fixed_roll_for(
     tle_ephem: rust_ephem.TLEEphemeris,
 ) -> None:

--- a/tests/constraints/conftest.py
+++ b/tests/constraints/conftest.py
@@ -126,6 +126,7 @@ class DummyConstraintBackend:
     def __init__(self) -> None:
         DummyConstraintBackend.created += 1
         self.evaluate_calls: list[Any] = []
+        self.evaluate_batch_calls: list[Any] = []
         self.batch_calls: list[Any] = []
         self.single_calls: list[Any] = []
         self.evaluate_moving_body_calls: list[Any] = []
@@ -144,6 +145,19 @@ class DummyConstraintBackend:
     ) -> DummyRustResult:
         self.evaluate_calls.append((ephemeris, target_ra, target_dec, times, indices))
         return DummyRustResult()
+
+    def evaluate_batch(
+        self,
+        ephemeris: object,
+        target_ras: list[object],
+        target_decs: list[object],
+        times: object,
+        indices: object,
+    ) -> list[DummyRustResult]:
+        self.evaluate_batch_calls.append(
+            (ephemeris, target_ras, target_decs, times, indices)
+        )
+        return [DummyRustResult() for _ in target_ras]
 
     def in_constraint_batch(
         self,

--- a/tests/constraints/constraint_batch/test_constraint_batch.py
+++ b/tests/constraints/constraint_batch/test_constraint_batch.py
@@ -142,6 +142,57 @@ def test_batch_single_target(
     np.testing.assert_array_equal(batch_result[0, :], single_result)
 
 
+def test_evaluate_batch_matches_single_evaluate(
+    ground_ephem_2h: GroundEphemeris, sun_constraint_45: SunConstraint
+) -> None:
+    """Test evaluate_batch returns one ConstraintResult per target."""
+    ephem = ground_ephem_2h
+    constraint = sun_constraint_45
+
+    target_ras = [0.0, 90.0, 180.0]
+    target_decs = [0.0, 30.0, -30.0]
+
+    batch_results = constraint.evaluate_batch(ephem, target_ras, target_decs)
+
+    assert len(batch_results) == len(target_ras)
+
+    for i, batch_result in enumerate(batch_results):
+        single_result = constraint.evaluate(ephem, target_ras[i], target_decs[i])
+
+        np.testing.assert_array_equal(
+            batch_result.constraint_array,
+            single_result.constraint_array,
+            err_msg=f"evaluate_batch result {i} does not match single evaluate()",
+        )
+        assert batch_result.all_satisfied == single_result.all_satisfied
+        assert batch_result.constraint_name == single_result.constraint_name
+
+
+def test_rust_constraint_evaluate_batch_matches_single_evaluate(
+    ground_ephem_2h: GroundEphemeris,
+) -> None:
+    """Test rust_ephem.Constraint exposes evaluate_batch convenience API."""
+    import rust_ephem
+
+    ephem = ground_ephem_2h
+    constraint = rust_ephem.Constraint.sun_proximity(45.0)
+    target_ras = [0.0, 90.0]
+    target_decs = [0.0, 30.0]
+
+    batch_results = constraint.evaluate_batch(ephem, target_ras, target_decs)
+
+    assert len(batch_results) == len(target_ras)
+
+    for i, batch_result in enumerate(batch_results):
+        single_result = constraint.evaluate(ephem, target_ras[i], target_decs[i])
+
+        np.testing.assert_array_equal(
+            batch_result.constraint_array,
+            single_result.constraint_array,
+            err_msg=f"rust evaluate_batch result {i} does not match single evaluate()",
+        )
+
+
 def test_earth_limb_batch(
     ground_ephem_earth_limb: GroundEphemeris,
     earth_limb_constraint_20: EarthLimbConstraint,

--- a/tests/constraints/rust_constraint_mixin/test_rust_constraint_mixin.py
+++ b/tests/constraints/rust_constraint_mixin/test_rust_constraint_mixin.py
@@ -12,6 +12,33 @@ from rust_ephem.constraints import (
 
 
 class TestRustConstraintMixin:
+    def test_evaluate_batch_returns_constraint_results(
+        self, patched_constraint: Any, dummy_ephemeris: Any
+    ) -> None:
+        constraint: Any = SunConstraint(min_angle=10.0)
+        results = constraint.evaluate_batch(
+            dummy_ephemeris,
+            target_ras=[1.0, 3.0],
+            target_decs=[2.0, 4.0],
+        )
+
+        assert len(results) == 2
+        assert all(isinstance(result, ConstraintResult) for result in results)
+
+    def test_evaluate_batch_reuses_cached_backend(
+        self, patched_constraint: Any, dummy_ephemeris: Any
+    ) -> None:
+        constraint: Any = SunConstraint(min_angle=10.0)
+        _ = constraint.evaluate_batch(
+            dummy_ephemeris,
+            target_ras=[1.0, 3.0],
+            target_decs=[2.0, 4.0],
+        )
+
+        assert patched_constraint.created == 1
+        backend = constraint._rust_constraint
+        assert len(backend.evaluate_batch_calls) == 1
+
     def test_evaluate_creates_backend_once_created_count(
         self, patched_constraint: Any, dummy_ephemeris: Any
     ) -> None:

--- a/tests/constraints/sun_moon_angle_constraint/test_sun_moon_angle_constraint.py
+++ b/tests/constraints/sun_moon_angle_constraint/test_sun_moon_angle_constraint.py
@@ -52,6 +52,9 @@ class TestSunConstraints:
         else:
             assert not_vis is False, "Sun should not be Sun Constrained"
 
+    @pytest.mark.filterwarnings(
+        "ignore::astropy.coordinates.NonRotationTransformationWarning"
+    )
     def test_or_constraints_sun_angle_greater_than_90(self, sun: Any) -> None:
         sun_angle = sun.separation(SkyCoord(10, 0, unit="deg")).deg
         assert sun_angle > 90, f"Sun is too close, {sun.ra} {sun.dec}"


### PR DESCRIPTION
This pull request introduces a new batch evaluation API for constraints, allowing users to efficiently evaluate multiple targets at once and obtain a per-target summary result. It also generalizes batch methods to support per-target spacecraft roll angles, improves internal code structure, and updates documentation and type hints accordingly.

**New batch evaluation API and per-target roll support:**

* Added a new `evaluate_batch` method to the `Constraint` class, which allows evaluating multiple targets in a single call and returns a list of `ConstraintResult` objects, one per target. This method supports per-target roll angles and is exposed in both the Python and Rust-backed APIs. [[1]](diffhunk://#diff-3dba367a5f087cea43ad0c5fbf3566683f951c8c54401173472d5b6bf22c07b3R581-R636) [[2]](diffhunk://#diff-7ed8034838678ab42bb592e27c3315872651998aec8719d99640b9bdd2ade077R564-R592) [[3]](diffhunk://#diff-5a41ff46843312c1bbeebbea63a22a87f5b99c7a96f464279697e3a2f5a2c888R86-R103) [[4]](diffhunk://#diff-0ee295c29def16f570f86378eff8ba37315e464d415e731d5d8ea2e67ce16f68R412-R416) [[5]](diffhunk://#diff-a7488628cf251be8ef7295e1006d7543b58fa88ed5f95460609fe41895b87ef1R609-R627)
* Generalized the `in_constraint_batch` method to accept an optional list of per-target roll angles (`target_rolls`), enabling batch evaluation where each target can have a different roll angle or use roll sweeping as needed. [[1]](diffhunk://#diff-3dba367a5f087cea43ad0c5fbf3566683f951c8c54401173472d5b6bf22c07b3L419-R656) [[2]](diffhunk://#diff-5a41ff46843312c1bbeebbea63a22a87f5b99c7a96f464279697e3a2f5a2c888R86-R103)

**Internal code structure and utility improvements:**

* Refactored and centralized logic for coercing timestamps, building `ConstraintResult` objects from boolean masks, validating and grouping per-target roll inputs, and handling batch evaluation with mixed roll semantics.
* Simplified and reused logic for reconstructing violation windows in both single-target and batch evaluation paths.

**Documentation and type hint updates:**

* Updated API documentation (`docs/api.rst`, `docs/constraints_api.rst`) to describe the new `evaluate_batch` method and clarify the behavior of per-target roll angles in batch methods. [[1]](diffhunk://#diff-0ee295c29def16f570f86378eff8ba37315e464d415e731d5d8ea2e67ce16f68R412-R416) [[2]](diffhunk://#diff-a7488628cf251be8ef7295e1006d7543b58fa88ed5f95460609fe41895b87ef1R609-R627)
* Updated type hints and interface files (`.pyi`) to reflect the new method signatures and argument changes. [[1]](diffhunk://#diff-5a41ff46843312c1bbeebbea63a22a87f5b99c7a96f464279697e3a2f5a2c888R86-R103) [[2]](diffhunk://#diff-7ed8034838678ab42bb592e27c3315872651998aec8719d99640b9bdd2ade077R564-R592)

**Other improvements:**

* Improved type safety and clarity in methods such as `roll_range` and boolean array handling. [[1]](diffhunk://#diff-3dba367a5f087cea43ad0c5fbf3566683f951c8c54401173472d5b6bf22c07b3L525-R761) [[2]](diffhunk://#diff-3dba367a5f087cea43ad0c5fbf3566683f951c8c54401173472d5b6bf22c07b3L568-R808)
* Removed strict mypy checking for tests in `mypy.ini` for flexibility.