### PR TITLE
fix: allow use of FileEphemeris in constraint calculations

### DIFF
--- a/src/constraints/constraint_wrapper/field_of_regard.rs
+++ b/src/constraints/constraint_wrapper/field_of_regard.rs
@@ -1,5 +1,6 @@
 use crate::constraints::core::ConstraintEvaluator;
 use crate::ephemeris::ephemeris_common::EphemerisBase;
+use crate::ephemeris::FileEphemeris;
 use crate::ephemeris::GroundEphemeris;
 use crate::ephemeris::OEMEphemeris;
 use crate::ephemeris::SPICEEphemeris;
@@ -168,6 +169,8 @@ where
             ephem.get_times()?.len()
         } else if let Ok(ephem) = bound.extract::<PyRef<OEMEphemeris>>() {
             ephem.get_times()?.len()
+        } else if let Ok(ephem) = bound.extract::<PyRef<FileEphemeris>>() {
+            ephem.get_times()?.len()
         } else {
             return Err(pyo3::exceptions::PyTypeError::new_err(
                 "Unsupported ephemeris type. Expected TLEEphemeris, SPICEEphemeris, GroundEphemeris, or OEMEphemeris",
@@ -200,6 +203,8 @@ where
     } else if let Ok(ephem) = bound.extract::<PyRef<GroundEphemeris>>() {
         evaluate_batch(&*ephem as &dyn EphemerisBase)?
     } else if let Ok(ephem) = bound.extract::<PyRef<OEMEphemeris>>() {
+        evaluate_batch(&*ephem as &dyn EphemerisBase)?
+    } else if let Ok(ephem) = bound.extract::<PyRef<FileEphemeris>>() {
         evaluate_batch(&*ephem as &dyn EphemerisBase)?
     } else {
         return Err(pyo3::exceptions::PyTypeError::new_err(

--- a/src/constraints/constraint_wrapper/py_api.rs
+++ b/src/constraints/constraint_wrapper/py_api.rs
@@ -16,6 +16,7 @@ use crate::constraints::orbit_ram::OrbitRamConfig;
 use crate::constraints::saa::SAAConfig;
 use crate::constraints::sun_proximity::SunProximityConfig;
 use crate::ephemeris::ephemeris_common::EphemerisBase;
+use crate::ephemeris::FileEphemeris;
 use crate::ephemeris::GroundEphemeris;
 use crate::ephemeris::OEMEphemeris;
 use crate::ephemeris::SPICEEphemeris;
@@ -242,6 +243,12 @@ impl PyConstraint {
                 target_decs,
             )
         } else if let Ok(ephem) = bound.extract::<PyRef<OEMEphemeris>>() {
+            self.evaluator.in_constraint_batch_diagonal(
+                &*ephem as &dyn EphemerisBase,
+                target_ras,
+                target_decs,
+            )
+        } else if let Ok(ephem) = bound.extract::<PyRef<FileEphemeris>>() {
             self.evaluator.in_constraint_batch_diagonal(
                 &*ephem as &dyn EphemerisBase,
                 target_ras,
@@ -1413,6 +1420,15 @@ impl PyConstraint {
                     time_indices.clone(),
                 );
             }
+            if let Ok(ephem) = bound.extract::<PyRef<FileEphemeris>>() {
+                return self.eval_with_ephemeris(
+                    evaluator,
+                    &*ephem,
+                    target_ra,
+                    target_dec,
+                    time_indices.clone(),
+                );
+            }
 
             Err(pyo3::exceptions::PyTypeError::new_err(
                 "Unsupported ephemeris type. Expected TLEEphemeris, SPICEEphemeris, GroundEphemeris, or OEMEphemeris",
@@ -1501,6 +1517,15 @@ impl PyConstraint {
                         time_indices.clone(),
                     );
                 }
+                if let Ok(ephem) = bound.extract::<PyRef<FileEphemeris>>() {
+                    return self.eval_batch_with_ephemeris(
+                        evaluator,
+                        &*ephem,
+                        &target_ras,
+                        &target_decs,
+                        time_indices.clone(),
+                    );
+                }
 
                 Err(pyo3::exceptions::PyTypeError::new_err(
                     "Unsupported ephemeris type. Expected TLEEphemeris, SPICEEphemeris, GroundEphemeris, or OEMEphemeris",
@@ -1561,6 +1586,15 @@ impl PyConstraint {
                     );
                 }
                 if let Ok(ephem) = bound.extract::<PyRef<OEMEphemeris>>() {
+                    return self.eval_batch_with_ephemeris(
+                        evaluator,
+                        &*ephem,
+                        &group_ras,
+                        &group_decs,
+                        time_indices.clone(),
+                    );
+                }
+                if let Ok(ephem) = bound.extract::<PyRef<FileEphemeris>>() {
                     return self.eval_batch_with_ephemeris(
                         evaluator,
                         &*ephem,
@@ -1708,6 +1742,14 @@ impl PyConstraint {
                         time_indices.as_deref(),
                     );
                 }
+                if let Ok(ephem) = bound.extract::<PyRef<FileEphemeris>>() {
+                    return evaluator.in_constraint_batch(
+                        &*ephem as &dyn EphemerisBase,
+                        &target_ras,
+                        &target_decs,
+                        time_indices.as_deref(),
+                    );
+                }
 
                 Err(pyo3::exceptions::PyTypeError::new_err(
                     "Unsupported ephemeris type. Expected TLEEphemeris, SPICEEphemeris, GroundEphemeris, or OEMEphemeris",
@@ -1763,6 +1805,14 @@ impl PyConstraint {
                     );
                 }
                 if let Ok(ephem) = bound.extract::<PyRef<OEMEphemeris>>() {
+                    return evaluator.in_constraint_batch(
+                        &*ephem as &dyn EphemerisBase,
+                        &group_ras,
+                        &group_decs,
+                        time_indices.as_deref(),
+                    );
+                }
+                if let Ok(ephem) = bound.extract::<PyRef<FileEphemeris>>() {
                     return evaluator.in_constraint_batch(
                         &*ephem as &dyn EphemerisBase,
                         &group_ras,
@@ -1900,6 +1950,8 @@ impl PyConstraint {
             } else if let Ok(ephem) = ephemeris.extract::<PyRef<GroundEphemeris>>() {
                 ephem.data().times.as_ref().cloned()
             } else if let Ok(ephem) = ephemeris.extract::<PyRef<OEMEphemeris>>() {
+                ephem.data().times.as_ref().cloned()
+            } else if let Ok(ephem) = ephemeris.extract::<PyRef<FileEphemeris>>() {
                 ephem.data().times.as_ref().cloned()
             } else {
                 None
@@ -2154,6 +2206,15 @@ impl PyConstraint {
                 time_idx,
             )?
         } else if let Ok(ephem) = bound.extract::<PyRef<OEMEphemeris>>() {
+            run_roll_sweep(
+                &base_config,
+                &target_ras,
+                &target_decs,
+                &rolls,
+                &*ephem as &dyn EphemerisBase,
+                time_idx,
+            )?
+        } else if let Ok(ephem) = bound.extract::<PyRef<FileEphemeris>>() {
             run_roll_sweep(
                 &base_config,
                 &target_ras,


### PR DESCRIPTION
This pull request adds support for the `FileEphemeris` type throughout the constraint wrapper Python API and related logic. The changes ensure that constraints can now accept and operate on `FileEphemeris` objects in the same way as other supported ephemeris types (such as `TLEEphemeris`, `SPICEEphemeris`, `GroundEphemeris`, and `OEMEphemeris`). The most important changes are grouped below.

**Support for FileEphemeris in Constraint Evaluation:**

* Added `FileEphemeris` to the imports and updated all relevant type checks in `field_of_regard.rs` and `py_api.rs` to handle `FileEphemeris` in batch evaluation, single evaluation, and diagonal evaluation functions. [[1]](diffhunk://#diff-4cc90655558264e231bed9c165fe6b8d9985ae9423d433771f5b2e6a9b141c47R3) [[2]](diffhunk://#diff-719cf3da4af36c14bc67d2a34f5626dda464d9fd8685f8144102f463e9ac5d66R19)
* Updated error messages and logic so that `FileEphemeris` is now a recognized and supported type in all relevant constraint evaluation branches. [[1]](diffhunk://#diff-4cc90655558264e231bed9c165fe6b8d9985ae9423d433771f5b2e6a9b141c47R172-R173) [[2]](diffhunk://#diff-4cc90655558264e231bed9c165fe6b8d9985ae9423d433771f5b2e6a9b141c47R207-R208) [[3]](diffhunk://#diff-719cf3da4af36c14bc67d2a34f5626dda464d9fd8685f8144102f463e9ac5d66R251-R256) [[4]](diffhunk://#diff-719cf3da4af36c14bc67d2a34f5626dda464d9fd8685f8144102f463e9ac5d66R1423-R1431) [[5]](diffhunk://#diff-719cf3da4af36c14bc67d2a34f5626dda464d9fd8685f8144102f463e9ac5d66R1520-R1528) [[6]](diffhunk://#diff-719cf3da4af36c14bc67d2a34f5626dda464d9fd8685f8144102f463e9ac5d66R1597-R1605) [[7]](diffhunk://#diff-719cf3da4af36c14bc67d2a34f5626dda464d9fd8685f8144102f463e9ac5d66R1745-R1752) [[8]](diffhunk://#diff-719cf3da4af36c14bc67d2a34f5626dda464d9fd8685f8144102f463e9ac5d66R1815-R1822) [[9]](diffhunk://#diff-719cf3da4af36c14bc67d2a34f5626dda464d9fd8685f8144102f463e9ac5d66R2217-R2225)

**Access to Ephemeris Data:**

* Modified logic to allow extraction of time arrays from `FileEphemeris` objects, enabling time-based queries and operations on this ephemeris type.

Overall, these changes make the constraint system more flexible and extensible by supporting an additional ephemeris data source.