### PR TITLE
Bright star avoidance constraint

### DIFF
--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -54,7 +54,7 @@ jobs:
         run: uv pip install maturin
 
       - name: Install test dependencies
-        run: uv pip install pytest numpy astropy pydantic mypy
+        run: uv pip compile pyproject.toml --extra=test -o requirements.txt ; uv pip install -r requirements.txt
 
       - name: Build and install rust-ephem
         run: |

--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -50,11 +50,8 @@ jobs:
           # Optional: additional cache key prefix for manual cache invalidation
           prefix-key: "v1-rust"
 
-      - name: Install maturin
-        run: uv pip install maturin
-
       - name: Install test dependencies
-        run: uv pip compile pyproject.toml --extra=test -o requirements.txt ; uv pip install -r requirements.txt
+        run: uv pip compile pyproject.toml --extra=test,dev -o requirements.txt ; uv pip install -r requirements.txt
 
       - name: Build and install rust-ephem
         run: |

--- a/docs/constraints_api.rst
+++ b/docs/constraints_api.rst
@@ -1201,6 +1201,151 @@ Orbit pole direction constraint ensuring target maintains minimum angular separa
       # Target must be between 10° and 80° from orbital pole
       orbit_pole = OrbitPoleConstraint(min_angle=10.0, max_angle=80.0)
 
+BrightStarConstraint
+^^^^^^^^^^^^^^^^^^^^
+
+Bright star avoidance constraint — violated when any catalog star falls within
+the telescope field of view.  Useful for preventing stray light or detector
+saturation from bright stars.
+
+Stars are supplied by the caller as ``(ra_deg, dec_deg)`` pairs; use
+:func:`get_bright_stars` to obtain a ready-to-use list from the Hipparcos
+catalog.
+
+Two FoV shapes are supported:
+
+- **Circular** (``fov_radius``) — roll-independent; a star is inside whenever
+  its angular separation from the boresight is less than ``fov_radius``.
+- **Polygon** (``fov_polygon``) — the polygon is defined in instrument frame
+  coordinates and rotates with spacecraft roll.  At roll = 0° the +v axis
+  points north and the +u axis points east on the sky.  When ``roll_deg`` is
+  ``None``, all roll angles are swept (72 samples, ≈5° resolution) and the
+  constraint is violated only if every roll has a star inside the polygon.
+
+.. py:class:: BrightStarConstraint(stars, *, fov_radius=None, fov_polygon=None, roll_deg=None)
+
+   :param list stars: Stars to avoid as a list of ``(ra_deg, dec_deg)`` pairs (ICRS/J2000, required).
+   :param float fov_radius: Circular FoV radius in degrees (0–180). Mutually exclusive with ``fov_polygon``.
+   :param list fov_polygon: Polygon FoV as a list of ``(u_deg, v_deg)`` vertices in instrument frame.
+       At roll = 0° the +u axis points east and the +v axis points north.
+       Mutually exclusive with ``fov_radius``.  Minimum 3 vertices.
+   :param float roll_deg: Position angle (degrees east of north) of the instrument +v axis.
+       ``None`` (default) sweeps all roll angles — the constraint is violated only
+       when no clear roll exists.  Only meaningful with ``fov_polygon``.
+
+   **Attributes:**
+
+   - ``type`` — Always ``"bright_star"`` (Literal)
+   - ``stars`` — List of ``(ra_deg, dec_deg)`` catalog entries
+   - ``fov_radius`` — Circular FoV radius in degrees (or ``None``)
+   - ``fov_polygon`` — Polygon vertices in instrument frame (or ``None``)
+   - ``roll_deg`` — Fixed roll angle (or ``None`` for roll sweep)
+
+   **Coordinate frame for polygon vertices:**
+
+   Vertices are in degrees relative to the boresight in the *instrument frame*:
+
+   - ``u = 0, v = 0`` — boresight
+   - At roll = 0°: +u points east, +v points north
+   - Roll is the position angle of +v from north, measured east of north
+
+   A star at sky tangent-plane offset (Δeast, Δnorth) maps to instrument
+   coordinates ``(u, v)`` at roll θ as:
+
+   .. math::
+
+      u = \Delta_\text{east} \cos\theta - \Delta_\text{north} \sin\theta
+
+      v = \Delta_\text{east} \sin\theta + \Delta_\text{north} \cos\theta
+
+   **Example — circular FoV:**
+
+   .. code-block:: python
+
+      from rust_ephem import get_bright_stars, Constraint
+      from rust_ephem.constraints import BrightStarConstraint
+
+      stars = get_bright_stars(mag_limit=7.0)
+
+      # Pydantic model (JSON-serialisable)
+      c = BrightStarConstraint(stars=stars, fov_radius=0.5)
+
+      # Or build the Rust evaluator directly
+      c = Constraint.bright_star(stars=stars, fov_radius=0.5)
+      result = c.evaluate(ephem, target_ra, target_dec)
+
+   **Example — polygon FoV with roll sweep:**
+
+   .. code-block:: python
+
+      # 0.5° × 0.3° rectangular detector; check all rolls
+      c = BrightStarConstraint(
+          stars=stars,
+          fov_polygon=[(-0.25, -0.15), (0.25, -0.15), (0.25, 0.15), (-0.25, 0.15)],
+      )
+
+      # Violated only when no spacecraft roll avoids all stars
+      result = c.evaluate(ephem, target_ra, target_dec)
+
+      # Evaluate at a specific roll (position angle in degrees, east of north)
+      result = c.evaluate(ephem, target_ra, target_dec, target_roll=45.0)
+
+
+Catalog Utilities
+-----------------
+
+.. py:function:: get_bright_stars(mag_limit=7.0, cache_mag_limit=None, *, refresh=False)
+
+   Return bright stars from the Hipparcos catalog suitable for use with
+   :py:class:`BrightStarConstraint` and :py:meth:`Constraint.bright_star`.
+
+   Stars brighter than *mag_limit* (Johnson V magnitude) are returned as
+   ``(ra_deg, dec_deg)`` pairs in ICRS / J2000 coordinates.  The catalog is
+   downloaded from `VizieR <https://vizier.cds.unistra.fr>`_ on the first call
+   and cached to disk; subsequent calls with a compatible magnitude limit are
+   served from cache with no network access.
+
+   **Cache reuse:** a cache file covers all stars up to a given magnitude limit.
+   Requesting a tighter limit from an existing broader cache never triggers a
+   re-download.  Use ``cache_mag_limit`` to pre-download a wider dataset:
+
+   .. code-block:: python
+
+      from rust_ephem import get_bright_stars
+
+      # Download stars brighter than V = 8 once, return the V < 6 subset
+      stars = get_bright_stars(mag_limit=6.0, cache_mag_limit=8.0)
+
+      # Future calls for any limit ≤ 8 reuse the cached file instantly
+      stars_7 = get_bright_stars(mag_limit=7.0)   # no network call
+
+   :param float mag_limit: Return stars brighter than this V magnitude
+       (lower value = brighter).  Default ``7.0`` yields roughly 4 000 stars.
+   :param float cache_mag_limit: Magnitude limit used when writing the on-disk
+       cache.  Defaults to *mag_limit*.  Must be ≥ *mag_limit*.
+   :param bool refresh: If ``True``, ignore any existing cache and re-download
+       from VizieR.  Default ``False``.
+   :returns: List of ``(ra_deg, dec_deg)`` tuples for stars brighter than
+       *mag_limit*.
+   :raises ImportError: If *astroquery* is not installed.
+   :raises ValueError: If *cache_mag_limit* < *mag_limit*, or VizieR returns no rows.
+
+   **Cache location:** ``{rust_ephem.get_cache_dir()}/hipparcos_vmag_<limit>.npy``
+
+   **Requires:** ``astroquery`` (``pip install astroquery``)
+
+   .. code-block:: python
+
+      import rust_ephem as re
+      from rust_ephem import get_bright_stars, Constraint
+
+      # Typical workflow
+      stars = get_bright_stars(mag_limit=7.0)
+      c = Constraint.bright_star(stars=stars, fov_radius=0.5)
+      result = c.evaluate(ephem, target_ra, target_dec)
+      print(f"All satisfied: {result.all_satisfied}")
+
+
 AndConstraint
 ^^^^^^^^^^^^^
 
@@ -1763,12 +1908,12 @@ Time window when the observation target is not constrained (visible).
 
    * ``target_ras``/``target_decs`` must have the same length as ephemeris timestamps.
    * When ``body`` is set, timestamps come from the ephemeris.
-    * Body positions use the planetary ephemeris kernel (default ``de440s.bsp``). To override for a specific
-       body lookup, call ``ephemeris.get_body(body, spice_kernel="path_or_url", use_horizons=True)`` (local file or URL). Downloads
-       are cached under ``~/.cache/rust_ephem``; reuse the cached path to avoid re-fetching.
-    * If you already have a planetary kernel on disk, point ``spice_kernel`` at that path; this does not affect
-       telescope/observer geometry — only body positions.
-    * Use ``use_horizons=True`` for bodies not available in your SPICE kernels; JPL Horizons covers all major and many minor solar system bodies.
+   * Body positions use the planetary ephemeris kernel (default ``de440s.bsp``). To override for a specific
+     body lookup, call ``ephemeris.get_body(body, spice_kernel="path_or_url", use_horizons=True)`` (local file or URL). Downloads
+     are cached under ``~/.cache/rust_ephem``; reuse the cached path to avoid re-fetching.
+   * If you already have a planetary kernel on disk, point ``spice_kernel`` at that path; this does not affect
+     telescope/observer geometry — only body positions.
+   * Use ``use_horizons=True`` for bodies not available in your SPICE kernels; JPL Horizons covers all major and many minor solar system bodies.
 
 
 Type Aliases

--- a/docs/planning_constraints.rst
+++ b/docs/planning_constraints.rst
@@ -122,6 +122,64 @@ Working with Results
 Available Constraint Types
 --------------------------
 
+**Bright Star Avoidance**
+
+Use :py:class:`~rust_ephem.constraints.BrightStarConstraint` to prevent bright
+stars from entering the telescope field of view (e.g. stray-light or detector
+saturation avoidance).  Stars are supplied by the user as ``(ra_deg, dec_deg)``
+pairs; the :func:`~rust_ephem.get_bright_stars` helper fetches and caches the
+Hipparcos catalog so you do not have to manage the catalog yourself.
+
+Two FoV shapes are supported:
+
+- **Circular** — any star within ``fov_radius`` degrees of the boresight violates
+  the constraint.  Roll is irrelevant.
+- **Polygon** — a convex or non-convex polygon defined in *instrument frame*
+  coordinates ``(u_deg, v_deg)``.  At roll = 0° the +v axis points north and the
+  +u axis points east.  The polygon rotates rigidly with spacecraft roll.
+
+.. code-block:: python
+
+    import rust_ephem as re
+    from rust_ephem import get_bright_stars, Constraint
+
+    # Fetch Hipparcos stars brighter than V = 7 (cached after first call)
+    stars = get_bright_stars(mag_limit=7.0)
+
+    # Circular FoV: violated if any star is within 0.5° of the boresight
+    c_circle = Constraint.bright_star(stars=stars, fov_radius=0.5)
+    result = c_circle.evaluate(ephem, target_ra, target_dec)
+
+    # Rectangular detector FoV (0.5° × 0.3°), checking all roll angles
+    c_poly = Constraint.bright_star(
+        stars=stars,
+        fov_polygon=[(-0.25, -0.15), (0.25, -0.15), (0.25, 0.15), (-0.25, 0.15)],
+    )
+    result = c_poly.evaluate(ephem, target_ra, target_dec)
+
+    # Evaluate at a specific spacecraft roll (position angle in degrees, east of north)
+    result = c_poly.evaluate(ephem, target_ra, target_dec, target_roll=45.0)
+
+When ``target_roll`` is omitted (or ``None``) for a polygon FoV, the evaluator
+sweeps 72 roll angles (5° resolution) across [0°, 360°).  The constraint is
+violated only when **every** roll has at least one star inside the polygon — i.e.
+it returns ``False`` as soon as a clear roll exists.  This answers the scheduling
+question *"is there any valid roll for this pointing?"*.
+
+For a broader catalog that serves multiple magnitude limits without re-downloading:
+
+.. code-block:: python
+
+    # Download all stars brighter than V = 8 once; return the V < 6 subset now
+    stars_tight = get_bright_stars(mag_limit=6.0, cache_mag_limit=8.0)
+
+    # Later calls for any mag_limit ≤ 8 reuse the on-disk cache instantly
+    stars_7 = get_bright_stars(mag_limit=7.0)   # no network call
+
+The cache is stored as a numpy array in the rust_ephem cache directory
+(``rust_ephem.get_cache_dir()``), keyed by magnitude limit.  Pass
+``refresh=True`` to force a re-download.
+
 **Proximity Constraints**
 
 .. code-block:: python
@@ -206,7 +264,7 @@ Threshold semantics:
 - ``min_violated=len(constraints)`` is equivalent to AND over violations.
 
 Shared-Axis Multi-Instrument Planning
-------------------------------------
+--------------------------------------
 
 Use boresight offsets when multiple instruments share the same mount axis but
 have different fixed pointing directions relative to the primary boresight.

--- a/mypy.ini
+++ b/mypy.ini
@@ -8,5 +8,4 @@ exclude = (?x)(
     )
 
 # Enforce strictness for the rust_ephem package
-[mypy-rust_ephem.*]
 strict = True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,11 @@ classifiers = [
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
 
-dependencies = ["numpy>=1.16", "pydantic>=2.12.4"]
+dependencies = [
+    "astroquery>=0.4.11",
+    "numpy>=1.16",
+    "pydantic>=2.12.4",
+]
 
 [project.optional-dependencies]
 test = ["pytest>=7.0", "astropy>=5.0", "pytest-cov>=7.0.0"]

--- a/rust_ephem/__init__.py
+++ b/rust_ephem/__init__.py
@@ -21,6 +21,7 @@ from ._rust_ephem import (
     is_planetary_ephemeris_initialized,
     is_ut1_available,
 )
+from .bright_stars import get_bright_stars
 from .constraints import (
     AirmassConstraint,
     AltAzConstraint,
@@ -28,6 +29,7 @@ from .constraints import (
     AtLeastConstraint,
     BodyConstraint,
     BoresightOffsetConstraint,
+    BrightStarConstraint,
     CombinedConstraintConfig,
     ConstraintConfig,
     ConstraintResult,
@@ -98,4 +100,6 @@ __all__ = [
     "get_cache_dir",
     "TLERecord",
     "fetch_tle",
+    "BrightStarConstraint",
+    "get_bright_stars",
 ]

--- a/rust_ephem/__init__.pyi
+++ b/rust_ephem/__init__.pyi
@@ -64,6 +64,9 @@ from rust_ephem._rust_ephem import (
 from rust_ephem._rust_ephem import (
     is_ut1_available as is_ut1_available,
 )
+from rust_ephem.bright_stars import (
+    get_bright_stars as get_bright_stars,
+)
 from rust_ephem.constraints import (
     AirmassConstraint as AirmassConstraint,
 )
@@ -81,6 +84,9 @@ from rust_ephem.constraints import (
 )
 from rust_ephem.constraints import (
     BoresightOffsetConstraint as BoresightOffsetConstraint,
+)
+from rust_ephem.constraints import (
+    BrightStarConstraint as BrightStarConstraint,
 )
 from rust_ephem.constraints import (
     CombinedConstraintConfig as CombinedConstraintConfig,
@@ -185,4 +191,6 @@ __all__ = [
     "is_eop_available",
     "init_eop_provider",
     "get_cache_dir",
+    "BrightStarConstraint",
+    "get_bright_stars",
 ]

--- a/rust_ephem/_rust_ephem.pyi
+++ b/rust_ephem/_rust_ephem.pyi
@@ -226,6 +226,37 @@ class Constraint:
         ...
 
     @staticmethod
+    def bright_star(
+        stars: list[tuple[float, float]],
+        fov_radius: float | None = None,
+        fov_polygon: list[tuple[float, float]] | None = None,
+        roll_deg: float | None = None,
+    ) -> Constraint:
+        """
+        Create a bright star avoidance constraint.
+
+        Violated when any catalog star falls within the telescope field of view.
+
+        Args:
+            stars: Stars to avoid as (ra_deg, dec_deg) pairs.
+            fov_radius: Circular FoV radius in degrees. Mutually exclusive with fov_polygon.
+            fov_polygon: Polygon FoV vertices in instrument frame (u_deg, v_deg).
+                At roll=0, +u points east and +v points north. Mutually exclusive
+                with fov_radius.
+            roll_deg: Position angle (degrees east of north) of the instrument +v axis.
+                Only valid with fov_polygon. When None (default), all roll angles are
+                swept and the constraint is violated only if every roll has a star inside
+                the FoV.
+
+        Returns:
+            A new Constraint instance
+
+        Raises:
+            ValueError: If arguments are invalid or inconsistent.
+        """
+        ...
+
+    @staticmethod
     def eclipse(umbra_only: bool = True) -> Constraint:
         """
         Create an eclipse constraint.

--- a/rust_ephem/_rust_ephem.pyi
+++ b/rust_ephem/_rust_ephem.pyi
@@ -204,21 +204,34 @@ class Constraint:
 
     @staticmethod
     def body_proximity(
-        body: str, min_angle: float, max_angle: float | None = None
+        body: str,
+        min_angle: float | None = None,
+        max_angle: float | None = None,
+        fov_polygon: list[tuple[float, float]] | None = None,
+        roll_deg: float | None = None,
     ) -> Constraint:
         """
         Create a generic solar system body avoidance constraint.
 
+        The exclusion zone is defined either as a circular angular separation
+        (min_angle) or as a polygon in the instrument frame (fov_polygon).
+        These are mutually exclusive.
+
         Args:
             body: Body identifier - NAIF ID or name (e.g., "Jupiter", "499", "Mars")
-            min_angle: Minimum allowed angular separation in degrees (0-180)
-            max_angle: Maximum allowed angular separation in degrees (optional)
+            min_angle: Minimum allowed angular separation in degrees (circle mode)
+            max_angle: Maximum allowed angular separation in degrees (circle mode only)
+            fov_polygon: Polygon FoV as (u_deg, v_deg) vertices in the instrument frame.
+                At roll=0, +u points east and +v points north. Mutually exclusive with min_angle.
+            roll_deg: Position angle of instrument +v from north (degrees east of north).
+                Only used with fov_polygon. None sweeps all roll angles: violated only when
+                every roll has the body inside the polygon.
 
         Returns:
             A new Constraint instance
 
         Raises:
-            ValueError: If angles are out of valid range
+            ValueError: If the configuration is invalid
 
         Note:
             Supported bodies depend on the ephemeris type and loaded kernels.

--- a/rust_ephem/bright_stars.py
+++ b/rust_ephem/bright_stars.py
@@ -26,7 +26,7 @@ from astroquery.vizier import Vizier  # type: ignore[import-untyped]
 __all__ = ["get_bright_stars"]
 
 _CATALOG_ID = "I/239/hip_main"
-_COLUMNS = ["RAJ2000", "DEJ2000", "Vmag"]
+_COLUMNS = ["_RA.icrs", "_DE.icrs", "Vmag"]
 _CACHE_PREFIX = "hipparcos_vmag_"
 
 
@@ -93,8 +93,8 @@ def _download(cache_mag_limit: float) -> np.ndarray:
     table = result[0]
 
     # astropy Table columns may be MaskedColumns; convert safely to plain float arrays.
-    ra = np.asarray(table["RAJ2000"], dtype=float)
-    dec = np.asarray(table["DEJ2000"], dtype=float)
+    ra = np.asarray(table["_RA.icrs"], dtype=float)
+    dec = np.asarray(table["_DE.icrs"], dtype=float)
     vmag = np.asarray(table["Vmag"], dtype=float)
 
     valid = np.isfinite(ra) & np.isfinite(dec) & np.isfinite(vmag)

--- a/rust_ephem/bright_stars.py
+++ b/rust_ephem/bright_stars.py
@@ -22,6 +22,7 @@ from pathlib import Path
 
 import numpy as np
 from astroquery.vizier import Vizier  # type: ignore[import-untyped]
+from numpy.typing import NDArray
 
 __all__ = ["get_bright_stars"]
 
@@ -72,7 +73,7 @@ def _find_usable_cache(mag_limit: float) -> Path | None:
 # ── Download ───────────────────────────────────────────────────────────────────
 
 
-def _download(cache_mag_limit: float) -> np.ndarray:
+def _download(cache_mag_limit: float) -> NDArray[np.float64]:
     """Fetch Hipparcos stars brighter than *cache_mag_limit* from VizieR.
 
     Returns an (N, 3) float64 array with columns [ra_deg, dec_deg, vmag].

--- a/rust_ephem/bright_stars.py
+++ b/rust_ephem/bright_stars.py
@@ -1,0 +1,176 @@
+"""Utilities for fetching and caching bright star catalogs.
+
+Stars are sourced from the Hipparcos catalog (ESA 1997) via VizieR using
+astroquery.  The full table for a given magnitude limit is saved to disk as a
+numpy array so subsequent calls are instant without network access.
+
+Typical usage::
+
+    from rust_ephem import get_bright_stars, Constraint
+
+    stars = get_bright_stars(mag_limit=7.0)
+    c = Constraint.bright_star(
+        stars=stars,
+        fov_polygon=[(-0.25, -0.15), (0.25, -0.15), (0.25, 0.15), (-0.25, 0.15)],
+    )
+"""
+
+from __future__ import annotations
+
+import glob
+from pathlib import Path
+
+import numpy as np
+from astroquery.vizier import Vizier  # type: ignore[import-untyped]
+
+__all__ = ["get_bright_stars"]
+
+_CATALOG_ID = "I/239/hip_main"
+_COLUMNS = ["RAJ2000", "DEJ2000", "Vmag"]
+_CACHE_PREFIX = "hipparcos_vmag_"
+
+
+# ── Cache helpers ──────────────────────────────────────────────────────────────
+
+
+def _cache_dir() -> Path:
+    import rust_ephem
+
+    return Path(rust_ephem.get_cache_dir())
+
+
+def _cache_path(mag_limit: float) -> Path:
+    return _cache_dir() / f"{_CACHE_PREFIX}{mag_limit:.2f}.npy"
+
+
+def _find_usable_cache(mag_limit: float) -> Path | None:
+    """Return the path of the smallest cached file whose magnitude limit covers mag_limit.
+
+    A cache file at limit L covers a request for limit M when L >= M, because
+    all stars brighter than M are a subset of stars brighter than L.
+    We prefer the smallest qualifying L to minimise the cost of the in-memory
+    filter step.
+    """
+    pattern = str(_cache_dir() / f"{_CACHE_PREFIX}*.npy")
+    candidates: list[tuple[float, Path]] = []
+    for p in glob.glob(pattern):
+        stem = Path(p).stem
+        if not stem.startswith(_CACHE_PREFIX):
+            continue
+        try:
+            limit = float(stem[len(_CACHE_PREFIX) :])
+        except ValueError:
+            continue
+        if limit >= mag_limit:
+            candidates.append((limit, Path(p)))
+    if not candidates:
+        return None
+    candidates.sort(key=lambda x: x[0])
+    return candidates[0][1]
+
+
+# ── Download ───────────────────────────────────────────────────────────────────
+
+
+def _download(cache_mag_limit: float) -> np.ndarray:
+    """Fetch Hipparcos stars brighter than *cache_mag_limit* from VizieR.
+
+    Returns an (N, 3) float64 array with columns [ra_deg, dec_deg, vmag].
+    """
+
+    v = Vizier(columns=_COLUMNS, row_limit=-1)
+    result = v.query_constraints(
+        catalog=_CATALOG_ID,
+        Vmag=f"<{cache_mag_limit}",
+    )
+
+    if not result or len(result) == 0:
+        raise ValueError(
+            f"VizieR returned no stars for Vmag < {cache_mag_limit}. "
+            "Check your network connection and that astroquery can reach CDS."
+        )
+
+    table = result[0]
+
+    # astropy Table columns may be MaskedColumns; convert safely to plain float arrays.
+    ra = np.asarray(table["RAJ2000"], dtype=float)
+    dec = np.asarray(table["DEJ2000"], dtype=float)
+    vmag = np.asarray(table["Vmag"], dtype=float)
+
+    valid = np.isfinite(ra) & np.isfinite(dec) & np.isfinite(vmag)
+    return np.column_stack([ra[valid], dec[valid], vmag[valid]])
+
+
+# ── Public API ─────────────────────────────────────────────────────────────────
+
+
+def get_bright_stars(
+    mag_limit: float = 7.0,
+    cache_mag_limit: float | None = None,
+    *,
+    refresh: bool = False,
+) -> list[tuple[float, float]]:
+    """Return Hipparcos bright stars suitable for use with ``Constraint.bright_star``.
+
+    Stars brighter than *mag_limit* (Johnson V magnitude) are returned as
+    ``(ra_deg, dec_deg)`` pairs in ICRS / J2000 coordinates.
+
+    The catalog is downloaded from VizieR on the first call and cached to disk
+    so subsequent calls are instant.  A cache file covers all stars up to a
+    given magnitude; requesting a tighter limit from an existing broader cache
+    never triggers a download.
+
+    Parameters
+    ----------
+    mag_limit:
+        Return only stars brighter than this V magnitude (lower = brighter).
+        Default ``7.0`` gives roughly 4 000 stars.
+    cache_mag_limit:
+        Magnitude limit used when writing the on-disk cache.  Defaults to
+        *mag_limit*.  Set this larger than *mag_limit* to download a broader
+        dataset that can serve future calls with tighter limits without another
+        network round-trip.  For example::
+
+            # Downloads all stars brighter than 8.0, caches them, then
+            # returns only those brighter than 6.0.
+            stars = get_bright_stars(6.0, cache_mag_limit=8.0)
+
+    refresh:
+        If ``True``, ignore any existing on-disk cache and re-download from
+        VizieR, then update the cache.  Default ``False``.
+
+    Returns
+    -------
+    list[tuple[float, float]]
+        ``(ra_deg, dec_deg)`` pairs for every star brighter than *mag_limit*.
+
+    Raises
+    ------
+    ImportError
+        If *astroquery* is not installed and no suitable cache exists.
+    ValueError
+        If *cache_mag_limit* < *mag_limit*, or VizieR returns no rows.
+    """
+    if cache_mag_limit is None:
+        cache_mag_limit = mag_limit
+    if cache_mag_limit < mag_limit:
+        raise ValueError(
+            f"cache_mag_limit ({cache_mag_limit}) must be >= mag_limit ({mag_limit})"
+        )
+
+    cache_path: Path | None = None if refresh else _find_usable_cache(mag_limit)
+
+    if cache_path is None:
+        data = _download(cache_mag_limit)
+        dest = _cache_path(cache_mag_limit)
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        np.save(dest, data)
+        cache_path = dest
+
+    data = np.load(cache_path)
+
+    # Filter to the actually requested magnitude limit
+    mask = data[:, 2] <= mag_limit
+    filtered = data[mask]
+
+    return [(float(row[0]), float(row[1])) for row in filtered]

--- a/rust_ephem/constraints.py
+++ b/rust_ephem/constraints.py
@@ -1601,6 +1601,57 @@ class OrbitPoleConstraint(RustConstraintMixin):
     )
 
 
+class BrightStarConstraint(RustConstraintMixin):
+    """Bright star avoidance constraint
+
+    Violated when any star from the supplied catalog falls within the telescope
+    field of view.  The FoV is defined either as a circle (radius around boresight)
+    or as a polygon in instrument frame coordinates that rotates with spacecraft roll.
+
+    Attributes:
+        type: Always "bright_star"
+        stars: List of (ra_deg, dec_deg) pairs for stars to avoid.
+        fov_radius: Circular FoV radius in degrees. Mutually exclusive with fov_polygon.
+        fov_polygon: Polygon FoV as a list of (u_deg, v_deg) vertices in the instrument
+            frame. At roll=0, +u points east and +v points north on the sky.
+            Mutually exclusive with fov_radius.
+        roll_deg: Position angle (degrees east of north) of the instrument +v axis.
+            Only applicable with fov_polygon. None (default) means sweep all roll
+            angles: the constraint is violated only when every roll has a star inside
+            the FoV.
+    """
+
+    type: Literal["bright_star"] = "bright_star"
+    stars: list[tuple[float, float]] = Field(
+        ..., description="Stars to avoid as (ra_deg, dec_deg) pairs"
+    )
+    fov_radius: float | None = Field(
+        default=None, ge=0.0, le=180.0, description="Circular FoV radius in degrees"
+    )
+    fov_polygon: list[tuple[float, float]] | None = Field(
+        default=None,
+        description="Polygon FoV vertices in instrument frame (u_deg, v_deg)",
+    )
+    roll_deg: float | None = Field(
+        default=None,
+        description="Roll angle (PA of instrument +v from north). None = sweep all rolls.",
+    )
+
+    @model_validator(mode="after")
+    def check_fov(self) -> "BrightStarConstraint":
+        has_radius = self.fov_radius is not None
+        has_polygon = self.fov_polygon is not None
+        if not has_radius and not has_polygon:
+            raise ValueError("either fov_radius or fov_polygon must be specified")
+        if has_radius and has_polygon:
+            raise ValueError("fov_radius and fov_polygon are mutually exclusive")
+        if has_polygon and self.fov_polygon is not None and len(self.fov_polygon) < 3:
+            raise ValueError("fov_polygon must have at least 3 vertices")
+        if has_radius and self.roll_deg is not None:
+            raise ValueError("roll_deg has no effect with fov_radius")
+        return self
+
+
 # Union type for all constraints
 ConstraintConfig = Union[
     SunConstraint,
@@ -1615,6 +1666,7 @@ ConstraintConfig = Union[
     OrbitPoleConstraint,
     SAAConstraint,
     AltAzConstraint,
+    BrightStarConstraint,
     AndConstraint,
     OrConstraint,
     XorConstraint,

--- a/rust_ephem/constraints.py
+++ b/rust_ephem/constraints.py
@@ -1195,23 +1195,59 @@ class EarthLimbConstraint(RustConstraintMixin):
 class BodyConstraint(RustConstraintMixin):
     """Solar system body proximity constraint
 
-    Ensures target maintains minimum angular separation from specified body.
+    Ensures the body does not enter the specified exclusion zone. The zone may be
+    defined as a circular angular separation (min_angle) or as a polygon in the
+    instrument frame (fov_polygon). These are mutually exclusive.
 
     Attributes:
         type: Always "body"
         body: Name of the solar system body (e.g., "Mars", "Jupiter")
-        min_angle: Minimum allowed angular separation in degrees (0-180)
-        max_angle: Maximum allowed angular separation in degrees (0-180), optional
+        min_angle: Minimum allowed angular separation in degrees (0-180). Circle mode.
+        max_angle: Maximum allowed angular separation in degrees (0-180). Circle mode only.
+        fov_polygon: Polygon FoV vertices in instrument frame (u_deg, v_deg). At roll=0,
+            +u points east and +v points north on the sky. Mutually exclusive with min_angle.
+        roll_deg: Position angle (degrees east of north) of the instrument +v axis.
+            Only applicable with fov_polygon. None (default) sweeps all roll angles.
     """
 
     type: Literal["body"] = "body"
     body: str = Field(..., description="Name of the solar system body")
-    min_angle: float = Field(
-        ..., ge=0.0, le=180.0, description="Minimum angle from body in degrees"
+    min_angle: float | None = Field(
+        default=None,
+        ge=0.0,
+        le=180.0,
+        description="Minimum angle from body in degrees (circle mode)",
     )
     max_angle: float | None = Field(
-        default=None, ge=0.0, le=180.0, description="Maximum angle from body in degrees"
+        default=None,
+        ge=0.0,
+        le=180.0,
+        description="Maximum angle from body in degrees (circle mode only)",
     )
+    fov_polygon: list[tuple[float, float]] | None = Field(
+        default=None,
+        description="Polygon FoV vertices in instrument frame (u_deg, v_deg)",
+    )
+    roll_deg: float | None = Field(
+        default=None,
+        description="Roll angle (PA of instrument +v from north). None = sweep all rolls.",
+    )
+
+    @model_validator(mode="after")
+    def check_fov(self) -> "BodyConstraint":
+        has_angle = self.min_angle is not None
+        has_polygon = self.fov_polygon is not None
+        if not has_angle and not has_polygon:
+            raise ValueError("either min_angle or fov_polygon must be specified")
+        if has_angle and has_polygon:
+            raise ValueError("min_angle and fov_polygon are mutually exclusive")
+        if has_polygon and self.fov_polygon is not None and len(self.fov_polygon) < 3:
+            raise ValueError("fov_polygon must have at least 3 vertices")
+        if has_angle and self.roll_deg is not None:
+            raise ValueError("roll_deg has no effect with min_angle")
+        if has_polygon and self.max_angle is not None:
+            raise ValueError("max_angle has no effect with fov_polygon")
+        return self
 
 
 class MoonConstraint(RustConstraintMixin):

--- a/rust_ephem/constraints.pyi
+++ b/rust_ephem/constraints.pyi
@@ -277,6 +277,13 @@ class BoresightOffsetConstraint(RustConstraintMixin):
     pitch_deg: float = 0.0
     yaw_deg: float = 0.0
 
+class BrightStarConstraint(RustConstraintMixin):
+    type: Literal["bright_star"] = "bright_star"
+    stars: list[tuple[float, float]]
+    fov_radius: float | None = None
+    fov_polygon: list[tuple[float, float]] | None = None
+    roll_deg: float | None = None
+
 ConstraintConfig = (
     SunConstraint
     | MoonConstraint
@@ -296,5 +303,6 @@ ConstraintConfig = (
     | AtLeastConstraint
     | NotConstraint
     | BoresightOffsetConstraint
+    | BrightStarConstraint
 )
 CombinedConstraintConfig: TypeAdapter[ConstraintConfig]

--- a/rust_ephem/constraints.pyi
+++ b/rust_ephem/constraints.pyi
@@ -194,8 +194,10 @@ class EarthLimbConstraint(RustConstraintMixin):
 class BodyConstraint(RustConstraintMixin):
     type: Literal["body"] = "body"
     body: str
-    min_angle: float
+    min_angle: float | None = None
     max_angle: float | None = None
+    fov_polygon: list[tuple[float, float]] | None = None
+    roll_deg: float | None = None
 
 class MoonConstraint(RustConstraintMixin):
     type: Literal["moon"] = "moon"

--- a/src/constraints/body_proximity.rs
+++ b/src/constraints/body_proximity.rs
@@ -1,5 +1,6 @@
 /// Generic solar system body proximity constraint implementation
 use super::core::{track_violations, ConstraintConfig, ConstraintEvaluator, ConstraintResult};
+use crate::constraints::fov_polygon;
 use chrono::{DateTime, Utc};
 use ndarray::Array2;
 use serde::{Deserialize, Serialize};
@@ -9,19 +10,31 @@ use serde::{Deserialize, Serialize};
 pub struct BodyProximityConfig {
     /// Body identifier (NAIF ID or name, e.g., "Jupiter", "499")
     pub body: String,
-    /// Minimum allowed angular separation in degrees
-    pub min_angle: f64,
-    /// Maximum allowed angular separation in degrees (optional)
+    /// Minimum allowed angular separation in degrees (circle mode; mutually exclusive with fov_polygon)
+    #[serde(default)]
+    pub min_angle: Option<f64>,
+    /// Maximum allowed angular separation in degrees (circle mode only)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub max_angle: Option<f64>,
+    /// Polygon FoV vertices in instrument frame (u_deg, v_deg), mutually exclusive with min_angle.
+    /// At roll=0, +u points east and +v points north on the sky.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub fov_polygon: Option<Vec<[f64; 2]>>,
+    /// Roll angle in degrees (position angle of instrument +v from north, east of north).
+    /// None means sweep all rolls (polygon mode only).
+    #[serde(default)]
+    pub roll_deg: Option<f64>,
 }
 
 impl ConstraintConfig for BodyProximityConfig {
     fn to_evaluator(&self) -> Box<dyn ConstraintEvaluator> {
         Box::new(BodyProximityEvaluator {
             body: self.body.clone(),
-            min_angle_deg: self.min_angle,
+            // Kept for macro-generated evaluate_common (only used in circle mode)
+            min_angle_deg: self.min_angle.unwrap_or(0.0),
             max_angle_deg: self.max_angle,
+            fov_polygon: self.fov_polygon.clone(),
+            roll_rad: self.roll_deg.map(|r| r.to_radians()),
         })
     }
 }
@@ -29,8 +42,13 @@ impl ConstraintConfig for BodyProximityConfig {
 /// Evaluator for generic body proximity - requires body positions computed externally
 pub struct BodyProximityEvaluator {
     pub body: String,
+    /// Used by the macro-generated evaluate_common (circle mode only)
     pub min_angle_deg: f64,
     pub max_angle_deg: Option<f64>,
+    /// When set, the body must not fall inside this polygon FoV
+    pub fov_polygon: Option<Vec<[f64; 2]>>,
+    /// Fixed roll in radians; None means sweep all rolls (polygon mode only)
+    pub roll_rad: Option<f64>,
 }
 
 impl_proximity_evaluator!(BodyProximityEvaluator, "Body", "body", sun_positions);
@@ -54,6 +72,56 @@ impl BodyProximityEvaluator {
     fn intermediate_violation_description(&self) -> String {
         format!("Target violates {} proximity constraint", self.body)
     }
+
+    fn format_name(&self) -> String {
+        if let Some(ref vertices) = self.fov_polygon {
+            match self.roll_rad {
+                Some(r) => format!(
+                    "BodyProximity(body='{}', fov_polygon={} vertices, roll={:.1}°)",
+                    self.body,
+                    vertices.len(),
+                    r.to_degrees()
+                ),
+                None => format!(
+                    "BodyProximity(body='{}', fov_polygon={} vertices, any_roll)",
+                    self.body,
+                    vertices.len()
+                ),
+            }
+        } else {
+            match self.max_angle_deg {
+                Some(max) => format!(
+                    "BodyProximity(body='{}', min={:.1}°, max={:.1}°)",
+                    self.body, self.min_angle_deg, max
+                ),
+                None => format!(
+                    "BodyProximity(body='{}', min={:.1}°)",
+                    self.body, self.min_angle_deg
+                ),
+            }
+        }
+    }
+
+    /// Compute the body's RA/Dec (radians) from its GCRS position relative to the observer.
+    fn body_radec_at(
+        body_positions: &Array2<f64>,
+        observer_positions: &Array2<f64>,
+        i: usize,
+    ) -> Option<(f64, f64)> {
+        let body_rel = [
+            body_positions[[i, 0]] - observer_positions[[i, 0]],
+            body_positions[[i, 1]] - observer_positions[[i, 1]],
+            body_positions[[i, 2]] - observer_positions[[i, 2]],
+        ];
+        let dist =
+            (body_rel[0] * body_rel[0] + body_rel[1] * body_rel[1] + body_rel[2] * body_rel[2])
+                .sqrt();
+        if dist == 0.0 {
+            return None;
+        }
+        let unit = [body_rel[0] / dist, body_rel[1] / dist, body_rel[2] / dist];
+        Some(fov_polygon::unit_to_radec(&unit))
+    }
 }
 
 impl ConstraintEvaluator for BodyProximityEvaluator {
@@ -64,13 +132,50 @@ impl ConstraintEvaluator for BodyProximityEvaluator {
         target_dec: f64,
         time_indices: Option<&[usize]>,
     ) -> pyo3::PyResult<ConstraintResult> {
-        let (times_slice, sun_positions_slice, observer_positions_slice) =
+        let (times_slice, body_positions_slice, observer_positions_slice) =
             extract_standard_ephemeris_data!(ephemeris, time_indices);
 
+        if let Some(ref vertices) = self.fov_polygon {
+            let target_ra_rad = target_ra.to_radians();
+            let target_dec_rad = target_dec.to_radians();
+            let roll_rad = self.roll_rad;
+            let name = self.format_name();
+            let name_clone = name.clone();
+
+            let violations = track_violations(
+                &times_slice,
+                |i| {
+                    let violated =
+                        Self::body_radec_at(&body_positions_slice, &observer_positions_slice, i)
+                            .map(|(body_ra, body_dec)| {
+                                fov_polygon::point_violates_polygon(
+                                    target_ra_rad,
+                                    target_dec_rad,
+                                    body_ra,
+                                    body_dec,
+                                    vertices,
+                                    roll_rad,
+                                )
+                            })
+                            .unwrap_or(false);
+                    (violated, if violated { 1.0 } else { 0.0 })
+                },
+                |_, _| name_clone.clone(),
+            );
+            let all_satisfied = violations.is_empty();
+            return Ok(ConstraintResult::new(
+                violations,
+                all_satisfied,
+                name,
+                times_slice,
+            ));
+        }
+
+        // Circle mode
         let result = self.evaluate_common(
             &times_slice,
             (target_ra, target_dec),
-            &sun_positions_slice,
+            &body_positions_slice,
             &observer_positions_slice,
             || self.final_violation_description(),
             || self.intermediate_violation_description(),
@@ -88,21 +193,19 @@ impl ConstraintEvaluator for BodyProximityEvaluator {
         use crate::utils::vector_math::radec_to_unit_vectors_batch;
 
         let times = ephemeris.get_times()?;
-        let (sun_positions_slice, observer_positions_slice, n_times) =
+        let (body_positions_slice, observer_positions_slice, n_times) =
             if let Some(indices) = time_indices {
-                let sun_filtered = ephemeris
+                let body_filtered = ephemeris
                     .get_sun_positions()?
                     .select(ndarray::Axis(0), indices);
                 let obs_filtered = ephemeris
                     .get_gcrs_positions()?
                     .select(ndarray::Axis(0), indices);
-                (sun_filtered, obs_filtered, indices.len())
+                (body_filtered, obs_filtered, indices.len())
             } else {
-                let sun_positions = ephemeris.get_sun_positions()?;
+                let body_positions = ephemeris.get_sun_positions()?;
                 let observer_positions = ephemeris.get_gcrs_positions()?;
-                // sun_positions and observer_positions are already owned (from .to_owned() in getters)
-                // so no need to clone again
-                (sun_positions, observer_positions, times.len())
+                (body_positions, observer_positions, times.len())
             };
         if target_ras.len() != target_decs.len() {
             return Err(pyo3::exceptions::PyValueError::new_err(
@@ -111,36 +214,50 @@ impl ConstraintEvaluator for BodyProximityEvaluator {
         }
 
         let n_targets = target_ras.len();
-
-        // Convert all target RA/Dec to unit vectors at once
-        let target_vectors = radec_to_unit_vectors_batch(target_ras, target_decs);
-
-        // Initialize result array (false = not violated)
         let mut result = Array2::from_elem((n_targets, n_times), false);
 
-        // Pre-compute threshold (constant for all times)
-        let threshold = self.min_angle_deg.to_radians().cos();
+        if let Some(ref vertices) = self.fov_polygon {
+            let roll_rad = self.roll_rad;
+            for (i, (&ra, &dec)) in target_ras.iter().zip(target_decs.iter()).enumerate() {
+                let target_ra_rad = ra.to_radians();
+                let target_dec_rad = dec.to_radians();
+                for j in 0..n_times {
+                    if let Some((body_ra, body_dec)) =
+                        Self::body_radec_at(&body_positions_slice, &observer_positions_slice, j)
+                    {
+                        result[[i, j]] = fov_polygon::point_violates_polygon(
+                            target_ra_rad,
+                            target_dec_rad,
+                            body_ra,
+                            body_dec,
+                            vertices,
+                            roll_rad,
+                        );
+                    }
+                }
+            }
+            return Ok(result);
+        }
 
+        // Circle mode
+        let target_vectors = radec_to_unit_vectors_batch(target_ras, target_decs);
+        let threshold = self.min_angle_deg.to_radians().cos();
         let max_threshold = self.max_angle_deg.map(|max| max.to_radians().cos());
 
-        // For each target
         for (i, target_row) in target_vectors.axis_iter(ndarray::Axis(0)).enumerate() {
             let target_unit = [target_row[0], target_row[1], target_row[2]];
 
-            // Check all times for this target
             for j in 0..n_times {
                 let body_pos = [
-                    sun_positions_slice[[j, 0]],
-                    sun_positions_slice[[j, 1]],
-                    sun_positions_slice[[j, 2]],
+                    body_positions_slice[[j, 0]],
+                    body_positions_slice[[j, 1]],
+                    body_positions_slice[[j, 2]],
                 ];
                 let obs_pos = [
                     observer_positions_slice[[j, 0]],
                     observer_positions_slice[[j, 1]],
                     observer_positions_slice[[j, 2]],
                 ];
-
-                // Compute relative body position from observer
                 let body_rel = [
                     body_pos[0] - obs_pos[0],
                     body_pos[1] - obs_pos[1],
@@ -150,34 +267,26 @@ impl ConstraintEvaluator for BodyProximityEvaluator {
                     + body_rel[1] * body_rel[1]
                     + body_rel[2] * body_rel[2])
                     .sqrt();
-
                 if body_dist == 0.0 {
                     continue;
                 }
-
                 let body_unit = [
                     body_rel[0] / body_dist,
                     body_rel[1] / body_dist,
                     body_rel[2] / body_dist,
                 ];
-
-                // Dot product
                 let cos_angle = target_unit[0] * body_unit[0]
                     + target_unit[1] * body_unit[1]
                     + target_unit[2] * body_unit[2];
-
-                // Check constraints
                 let too_close = cos_angle > threshold;
                 let too_far = if let Some(max_thresh) = max_threshold {
                     cos_angle < max_thresh
                 } else {
                     false
                 };
-
                 result[[i, j]] = too_close || too_far;
             }
         }
-
         Ok(result)
     }
 
@@ -188,19 +297,19 @@ impl ConstraintEvaluator for BodyProximityEvaluator {
         time_indices: Option<&[usize]>,
     ) -> pyo3::PyResult<Option<Array2<bool>>> {
         let times = ephemeris.get_times()?;
-        let (sun_positions_slice, observer_positions_slice, n_times) =
+        let (body_positions_slice, observer_positions_slice, n_times) =
             if let Some(indices) = time_indices {
-                let sun_filtered = ephemeris
+                let body_filtered = ephemeris
                     .get_sun_positions()?
                     .select(ndarray::Axis(0), indices);
                 let obs_filtered = ephemeris
                     .get_gcrs_positions()?
                     .select(ndarray::Axis(0), indices);
-                (sun_filtered, obs_filtered, indices.len())
+                (body_filtered, obs_filtered, indices.len())
             } else {
-                let sun_positions = ephemeris.get_sun_positions()?;
+                let body_positions = ephemeris.get_sun_positions()?;
                 let observer_positions = ephemeris.get_gcrs_positions()?;
-                (sun_positions, observer_positions, times.len())
+                (body_positions, observer_positions, times.len())
             };
 
         if target_unit_vectors.ncols() != 3 {
@@ -212,6 +321,32 @@ impl ConstraintEvaluator for BodyProximityEvaluator {
         let n_targets = target_unit_vectors.nrows();
         let mut result = Array2::from_elem((n_targets, n_times), false);
 
+        if let Some(ref vertices) = self.fov_polygon {
+            let roll_rad = self.roll_rad;
+            for i in 0..n_targets {
+                let ux = target_unit_vectors[[i, 0]];
+                let uy = target_unit_vectors[[i, 1]];
+                let uz = target_unit_vectors[[i, 2]];
+                let (target_ra_rad, target_dec_rad) = fov_polygon::unit_to_radec(&[ux, uy, uz]);
+                for j in 0..n_times {
+                    if let Some((body_ra, body_dec)) =
+                        Self::body_radec_at(&body_positions_slice, &observer_positions_slice, j)
+                    {
+                        result[[i, j]] = fov_polygon::point_violates_polygon(
+                            target_ra_rad,
+                            target_dec_rad,
+                            body_ra,
+                            body_dec,
+                            vertices,
+                            roll_rad,
+                        );
+                    }
+                }
+            }
+            return Ok(Some(result));
+        }
+
+        // Circle mode
         let threshold = self.min_angle_deg.to_radians().cos();
         let max_threshold = self.max_angle_deg.map(|max| max.to_radians().cos());
 
@@ -221,19 +356,17 @@ impl ConstraintEvaluator for BodyProximityEvaluator {
                 target_unit_vectors[[i, 1]],
                 target_unit_vectors[[i, 2]],
             ];
-
             for j in 0..n_times {
                 let body_pos = [
-                    sun_positions_slice[[j, 0]],
-                    sun_positions_slice[[j, 1]],
-                    sun_positions_slice[[j, 2]],
+                    body_positions_slice[[j, 0]],
+                    body_positions_slice[[j, 1]],
+                    body_positions_slice[[j, 2]],
                 ];
                 let obs_pos = [
                     observer_positions_slice[[j, 0]],
                     observer_positions_slice[[j, 1]],
                     observer_positions_slice[[j, 2]],
                 ];
-
                 let body_rel = [
                     body_pos[0] - obs_pos[0],
                     body_pos[1] - obs_pos[1],
@@ -243,46 +376,31 @@ impl ConstraintEvaluator for BodyProximityEvaluator {
                     + body_rel[1] * body_rel[1]
                     + body_rel[2] * body_rel[2])
                     .sqrt();
-
                 if body_dist == 0.0 {
                     continue;
                 }
-
                 let body_unit = [
                     body_rel[0] / body_dist,
                     body_rel[1] / body_dist,
                     body_rel[2] / body_dist,
                 ];
-
                 let cos_angle = target_unit[0] * body_unit[0]
                     + target_unit[1] * body_unit[1]
                     + target_unit[2] * body_unit[2];
-
                 let too_close = cos_angle > threshold;
                 let too_far = if let Some(max_thresh) = max_threshold {
                     cos_angle < max_thresh
                 } else {
                     false
                 };
-
                 result[[i, j]] = too_close || too_far;
             }
         }
-
         Ok(Some(result))
     }
 
     fn name(&self) -> String {
-        match self.max_angle_deg {
-            Some(max) => format!(
-                "BodyProximity(body='{}', min={}°, max={}°)",
-                self.body, self.min_angle_deg, max
-            ),
-            None => format!(
-                "BodyProximity(body='{}', min={}°)",
-                self.body, self.min_angle_deg
-            ),
-        }
+        self.format_name()
     }
 
     fn as_any(&self) -> &dyn std::any::Any {

--- a/src/constraints/bright_star.rs
+++ b/src/constraints/bright_star.rs
@@ -1,0 +1,328 @@
+/// Bright star avoidance constraint
+///
+/// Violated when any catalog star falls within the telescope field of view.
+/// FoV is defined either as a circle (radius around boresight) or a polygon
+/// in instrument frame coordinates that rotates with spacecraft roll.
+use super::core::{ConstraintConfig, ConstraintEvaluator, ConstraintResult};
+use chrono::{DateTime, Utc};
+use ndarray::Array2;
+use pyo3::PyResult;
+use serde::{Deserialize, Serialize};
+use std::f64::consts::PI;
+
+/// Number of roll samples when sweeping all rolls (5° resolution)
+const N_ROLL_SAMPLES: usize = 72;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BrightStarConfig {
+    /// Stars to avoid: (ra_deg, dec_deg) pairs
+    pub stars: Vec<[f64; 2]>,
+    /// Circular FoV radius in degrees (mutually exclusive with fov_polygon)
+    pub fov_radius: Option<f64>,
+    /// Polygon FoV vertices in instrument frame (u_deg, v_deg), mutually exclusive with fov_radius.
+    /// At roll=0, +u points east and +v points north on the sky.
+    pub fov_polygon: Option<Vec<[f64; 2]>>,
+    /// Roll angle in degrees (position angle of instrument +v from north, east of north).
+    /// None means sweep all rolls: violated only if every roll has a star in the FoV.
+    pub roll_deg: Option<f64>,
+}
+
+impl ConstraintConfig for BrightStarConfig {
+    fn to_evaluator(&self) -> Box<dyn ConstraintEvaluator> {
+        let stars: Vec<StarData> = self
+            .stars
+            .iter()
+            .map(|&[ra, dec]| StarData::new(ra, dec))
+            .collect();
+
+        let fov = if let Some(radius) = self.fov_radius {
+            FovDefinition::Circle {
+                cos_radius: radius.to_radians().cos(),
+            }
+        } else if let Some(vertices) = &self.fov_polygon {
+            FovDefinition::Polygon {
+                vertices: vertices.clone(),
+                roll_rad: self.roll_deg.map(|r| r.to_radians()),
+            }
+        } else {
+            // Validated at the Python layer; this path should not be reachable
+            FovDefinition::Circle { cos_radius: 1.0 }
+        };
+
+        Box::new(BrightStarEvaluator { stars, fov })
+    }
+}
+
+struct StarData {
+    ra_rad: f64,
+    dec_rad: f64,
+    /// Precomputed ICRS unit vector for dot-product checks in circular FoV
+    unit: [f64; 3],
+}
+
+impl StarData {
+    fn new(ra_deg: f64, dec_deg: f64) -> Self {
+        let ra_rad = ra_deg.to_radians();
+        let dec_rad = dec_deg.to_radians();
+        let (sin_dec, cos_dec) = dec_rad.sin_cos();
+        let (sin_ra, cos_ra) = ra_rad.sin_cos();
+        Self {
+            ra_rad,
+            dec_rad,
+            unit: [cos_dec * cos_ra, cos_dec * sin_ra, sin_dec],
+        }
+    }
+}
+
+enum FovDefinition {
+    Circle {
+        /// cos(radius): star is inside if dot(target_unit, star_unit) > cos_radius
+        cos_radius: f64,
+    },
+    Polygon {
+        /// Vertices in instrument frame (u_deg, v_deg)
+        vertices: Vec<[f64; 2]>,
+        /// None = sweep all rolls; Some(r) = evaluate at this roll only
+        roll_rad: Option<f64>,
+    },
+}
+
+pub struct BrightStarEvaluator {
+    stars: Vec<StarData>,
+    fov: FovDefinition,
+}
+
+impl BrightStarEvaluator {
+    // ── Circle helpers ────────────────────────────────────────────────────────
+
+    fn any_star_in_circle(&self, target_unit: [f64; 3], cos_radius: f64) -> bool {
+        for star in &self.stars {
+            let cos_sep = target_unit[0] * star.unit[0]
+                + target_unit[1] * star.unit[1]
+                + target_unit[2] * star.unit[2];
+            if cos_sep > cos_radius {
+                return true;
+            }
+        }
+        false
+    }
+
+    // ── Polygon helpers ───────────────────────────────────────────────────────
+
+    /// Gnomonic (tangent-plane) projection of `star` relative to `target`.
+    /// Returns (east_rad, north_rad) or None if the star is on/behind the tangent plane.
+    fn gnomonic_project(
+        target_ra_rad: f64,
+        target_dec_rad: f64,
+        star: &StarData,
+    ) -> Option<(f64, f64)> {
+        let delta_ra = star.ra_rad - target_ra_rad;
+        let (sin_tdec, cos_tdec) = (target_dec_rad.sin(), target_dec_rad.cos());
+        let (sin_sdec, cos_sdec) = (star.dec_rad.sin(), star.dec_rad.cos());
+        let (sin_dra, cos_dra) = delta_ra.sin_cos();
+
+        let cos_c = sin_tdec * sin_sdec + cos_tdec * cos_sdec * cos_dra;
+        if cos_c <= 0.0 {
+            return None;
+        }
+
+        let east = cos_sdec * sin_dra / cos_c;
+        let north = (cos_tdec * sin_sdec - sin_tdec * cos_sdec * cos_dra) / cos_c;
+        Some((east, north))
+    }
+
+    /// Transform tangent-plane (east, north) offsets to instrument (u, v) at the given roll.
+    ///
+    /// Convention: at roll=0, u=east and v=north.  Roll is position angle of instrument
+    /// +v from north, measured east of north.
+    ///
+    ///   u = east * cos(roll) - north * sin(roll)
+    ///   v = east * sin(roll) + north * cos(roll)
+    #[inline]
+    fn to_instrument(east: f64, north: f64, sin_roll: f64, cos_roll: f64) -> (f64, f64) {
+        (
+            east * cos_roll - north * sin_roll,
+            east * sin_roll + north * cos_roll,
+        )
+    }
+
+    /// Ray-casting point-in-polygon test for (u, v) against `vertices` (both in degrees).
+    fn point_in_polygon(u: f64, v: f64, vertices: &[[f64; 2]]) -> bool {
+        let n = vertices.len();
+        if n < 3 {
+            return false;
+        }
+        let mut inside = false;
+        let mut j = n - 1;
+        for i in 0..n {
+            let ui = vertices[i][0];
+            let vi = vertices[i][1];
+            let uj = vertices[j][0];
+            let vj = vertices[j][1];
+            if ((vi > v) != (vj > v)) && (u < (uj - ui) * (v - vi) / (vj - vi) + ui) {
+                inside = !inside;
+            }
+            j = i;
+        }
+        inside
+    }
+
+    /// True if any star falls inside `vertices` when the instrument is at `roll_rad`.
+    fn any_star_in_polygon_at_roll(
+        &self,
+        target_ra_rad: f64,
+        target_dec_rad: f64,
+        vertices: &[[f64; 2]],
+        sin_roll: f64,
+        cos_roll: f64,
+    ) -> bool {
+        for star in &self.stars {
+            if let Some((east, north)) = Self::gnomonic_project(target_ra_rad, target_dec_rad, star)
+            {
+                let (u_rad, v_rad) = Self::to_instrument(east, north, sin_roll, cos_roll);
+                let u_deg = u_rad.to_degrees();
+                let v_deg = v_rad.to_degrees();
+                if Self::point_in_polygon(u_deg, v_deg, vertices) {
+                    return true;
+                }
+            }
+        }
+        false
+    }
+
+    // ── Top-level check ───────────────────────────────────────────────────────
+
+    /// Returns true when the constraint is violated for this target.
+    fn is_violated(&self, target_ra_deg: f64, target_dec_deg: f64) -> bool {
+        let target_ra_rad = target_ra_deg.to_radians();
+        let target_dec_rad = target_dec_deg.to_radians();
+
+        match &self.fov {
+            FovDefinition::Circle { cos_radius } => {
+                let (sin_dec, cos_dec) = target_dec_rad.sin_cos();
+                let (sin_ra, cos_ra) = target_ra_rad.sin_cos();
+                let target_unit = [cos_dec * cos_ra, cos_dec * sin_ra, sin_dec];
+                self.any_star_in_circle(target_unit, *cos_radius)
+            }
+
+            FovDefinition::Polygon { vertices, roll_rad } => {
+                if let Some(&roll) = roll_rad.as_ref() {
+                    let (sin_roll, cos_roll) = roll.sin_cos();
+                    self.any_star_in_polygon_at_roll(
+                        target_ra_rad,
+                        target_dec_rad,
+                        vertices,
+                        sin_roll,
+                        cos_roll,
+                    )
+                } else {
+                    // Sweep N_ROLL_SAMPLES roll angles evenly over [0°, 360°).
+                    // Violated only if every roll has at least one star in the FoV
+                    // (i.e., no clear roll exists).
+                    let roll_step = 2.0 * PI / N_ROLL_SAMPLES as f64;
+                    for step in 0..N_ROLL_SAMPLES {
+                        let roll = step as f64 * roll_step;
+                        let (sin_roll, cos_roll) = roll.sin_cos();
+                        if !self.any_star_in_polygon_at_roll(
+                            target_ra_rad,
+                            target_dec_rad,
+                            vertices,
+                            sin_roll,
+                            cos_roll,
+                        ) {
+                            return false; // found a clear roll
+                        }
+                    }
+                    true // every roll blocked
+                }
+            }
+        }
+    }
+
+    fn format_name(&self) -> String {
+        match &self.fov {
+            FovDefinition::Circle { cos_radius } => {
+                let r = cos_radius.acos().to_degrees();
+                format!("BrightStar(fov_radius={r:.3}°, {} stars)", self.stars.len())
+            }
+            FovDefinition::Polygon { vertices, roll_rad } => match roll_rad {
+                Some(r) => format!(
+                    "BrightStar(fov_polygon={} vertices, roll={:.1}°, {} stars)",
+                    vertices.len(),
+                    r.to_degrees(),
+                    self.stars.len()
+                ),
+                None => format!(
+                    "BrightStar(fov_polygon={} vertices, any_roll, {} stars)",
+                    vertices.len(),
+                    self.stars.len()
+                ),
+            },
+        }
+    }
+}
+
+impl ConstraintEvaluator for BrightStarEvaluator {
+    fn evaluate(
+        &self,
+        ephemeris: &dyn crate::ephemeris::ephemeris_common::EphemerisBase,
+        target_ra: f64,
+        target_dec: f64,
+        time_indices: Option<&[usize]>,
+    ) -> PyResult<ConstraintResult> {
+        let all_times = ephemeris.get_times()?;
+        let times: Vec<DateTime<Utc>> = match time_indices {
+            Some(idx) => idx.iter().map(|&i| all_times[i]).collect(),
+            None => all_times.to_vec(),
+        };
+
+        // The result is time-invariant: compute once.
+        let violated = self.is_violated(target_ra, target_dec);
+
+        let violations = super::core::track_violations(
+            &times,
+            |_i| (violated, if violated { 1.0 } else { 0.0 }),
+            |_i, _open| self.format_name(),
+        );
+        let all_satisfied = violations.is_empty();
+        Ok(ConstraintResult::new(
+            violations,
+            all_satisfied,
+            self.format_name(),
+            times,
+        ))
+    }
+
+    fn in_constraint_batch(
+        &self,
+        ephemeris: &dyn crate::ephemeris::ephemeris_common::EphemerisBase,
+        target_ras: &[f64],
+        target_decs: &[f64],
+        time_indices: Option<&[usize]>,
+    ) -> PyResult<Array2<bool>> {
+        let all_times = ephemeris.get_times()?;
+        let n_times = match time_indices {
+            Some(idx) => idx.len(),
+            None => all_times.len(),
+        };
+        let n_targets = target_ras.len();
+        let mut result = Array2::from_elem((n_targets, n_times), false);
+
+        for (i, (&ra, &dec)) in target_ras.iter().zip(target_decs.iter()).enumerate() {
+            if self.is_violated(ra, dec) {
+                for j in 0..n_times {
+                    result[[i, j]] = true;
+                }
+            }
+        }
+        Ok(result)
+    }
+
+    fn name(&self) -> String {
+        self.format_name()
+    }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+}

--- a/src/constraints/bright_star.rs
+++ b/src/constraints/bright_star.rs
@@ -155,18 +155,45 @@ impl BrightStarEvaluator {
         if n < 3 {
             return false;
         }
+        // Robust ray-casting. Guard against near-horizontal edges (vj == vi)
+        // to avoid division by zero and treat points on the polygon boundary as inside.
         let mut inside = false;
         let mut j = n - 1;
+        const EPS: f64 = 1.0e-12;
         for i in 0..n {
             let ui = vertices[i][0];
             let vi = vertices[i][1];
             let uj = vertices[j][0];
             let vj = vertices[j][1];
-            if ((vi > v) != (vj > v)) && (u < (uj - ui) * (v - vi) / (vj - vi) + ui) {
-                inside = !inside;
+
+            if (vi > v) != (vj > v) {
+                let denom = vj - vi;
+                if denom.abs() < EPS {
+                    // Nearly horizontal segment: skip the crossing test but
+                    // still check for boundary-on-segment cases below.
+                } else {
+                    let x_intersect = (uj - ui) * (v - vi) / denom + ui;
+                    // Point lies exactly on the edge -> consider inside
+                    if (u - x_intersect).abs() < EPS {
+                        return true;
+                    }
+                    if u < x_intersect {
+                        inside = !inside;
+                    }
+                }
+            } else if (v - vi).abs() < EPS {
+                // v equals a vertex v coordinate and the segment is (nearly)
+                // horizontal: check if u lies between the segment endpoints.
+                let min_u = ui.min(uj) - EPS;
+                let max_u = ui.max(uj) + EPS;
+                if u >= min_u && u <= max_u {
+                    return true;
+                }
             }
+
             j = i;
         }
+
         inside
     }
 

--- a/src/constraints/bright_star.rs
+++ b/src/constraints/bright_star.rs
@@ -75,7 +75,8 @@ impl ConstraintConfig for BrightStarConfig {
 
 struct StarData {
     ra_rad: f64,
-    dec_rad: f64,
+    sin_dec: f64,
+    cos_dec: f64,
     /// Precomputed ICRS unit vector for dot-product checks
     unit: [f64; 3],
 }
@@ -88,7 +89,8 @@ impl StarData {
         let (sin_ra, cos_ra) = ra_rad.sin_cos();
         Self {
             ra_rad,
-            dec_rad,
+            sin_dec,
+            cos_dec,
             unit: [cos_dec * cos_ra, cos_dec * sin_ra, sin_dec],
         }
     }
@@ -132,28 +134,6 @@ impl BrightStarEvaluator {
 
     // ── Polygon helpers ───────────────────────────────────────────────────────
 
-    /// Gnomonic (tangent-plane) projection of `star` relative to `target`.
-    /// Returns (east_rad, north_rad) or None if the star is on/behind the tangent plane.
-    fn gnomonic_project(
-        target_ra_rad: f64,
-        target_dec_rad: f64,
-        star: &StarData,
-    ) -> Option<(f64, f64)> {
-        let delta_ra = star.ra_rad - target_ra_rad;
-        let (sin_tdec, cos_tdec) = (target_dec_rad.sin(), target_dec_rad.cos());
-        let (sin_sdec, cos_sdec) = (star.dec_rad.sin(), star.dec_rad.cos());
-        let (sin_dra, cos_dra) = delta_ra.sin_cos();
-
-        let cos_c = sin_tdec * sin_sdec + cos_tdec * cos_sdec * cos_dra;
-        if cos_c <= 0.0 {
-            return None;
-        }
-
-        let east = cos_sdec * sin_dra / cos_c;
-        let north = (cos_tdec * sin_sdec - sin_tdec * cos_sdec * cos_dra) / cos_c;
-        Some((east, north))
-    }
-
     /// Transform tangent-plane (east, north) offsets to instrument (u, v) at the given roll.
     ///
     /// Convention: at roll=0, u=east and v=north.  Roll is position angle of instrument
@@ -190,21 +170,21 @@ impl BrightStarEvaluator {
         inside
     }
 
-    /// True if any star falls inside `vertices` when the instrument is at `roll_rad`.
+    /// Gnomonic (tangent-plane) project all stars that pass the bounding-circle filter
+    /// into (east, north) offsets relative to the target.
     ///
-    /// `target_unit` is the precomputed ICRS unit vector for the target — used for
-    /// the bounding-circle fast-rejection test before gnomonic projection.
-    fn any_star_in_polygon_at_roll(
+    /// Returns a small Vec of (east_rad, north_rad) pairs — typically 0-50 entries.
+    /// Projections are roll-independent; the result is reused across all roll samples.
+    fn nearby_tangent_offsets(
         &self,
         target_unit: [f64; 3],
         target_ra_rad: f64,
-        target_dec_rad: f64,
-        vertices: &[[f64; 2]],
-        sin_roll: f64,
-        cos_roll: f64,
-    ) -> bool {
+        sin_tdec: f64,
+        cos_tdec: f64,
+    ) -> Vec<(f64, f64)> {
+        let mut out = Vec::new();
         for star in &self.stars {
-            // Fast rejection: skip stars outside the polygon bounding circle
+            // Bounding-circle fast rejection
             if let Some(cos_thresh) = self.bounding_cos {
                 let dot = target_unit[0] * star.unit[0]
                     + target_unit[1] * star.unit[1]
@@ -213,17 +193,18 @@ impl BrightStarEvaluator {
                     continue;
                 }
             }
-            if let Some((east, north)) = Self::gnomonic_project(target_ra_rad, target_dec_rad, star)
-            {
-                let (u_rad, v_rad) = Self::to_instrument(east, north, sin_roll, cos_roll);
-                let u_deg = u_rad.to_degrees();
-                let v_deg = v_rad.to_degrees();
-                if Self::point_in_polygon(u_deg, v_deg, vertices) {
-                    return true;
-                }
+            // Gnomonic projection (roll-independent)
+            let delta_ra = star.ra_rad - target_ra_rad;
+            let (sin_dra, cos_dra) = delta_ra.sin_cos();
+            let cos_c = sin_tdec * star.sin_dec + cos_tdec * star.cos_dec * cos_dra;
+            if cos_c <= 0.0 {
+                continue;
             }
+            let east = star.cos_dec * sin_dra / cos_c;
+            let north = (cos_tdec * star.sin_dec - sin_tdec * star.cos_dec * cos_dra) / cos_c;
+            out.push((east, north));
         }
-        false
+        out
     }
 
     // ── Top-level check ───────────────────────────────────────────────────────
@@ -246,16 +227,17 @@ impl BrightStarEvaluator {
                 let (sin_tra, cos_tra) = target_ra_rad.sin_cos();
                 let target_unit = [cos_tdec * cos_tra, cos_tdec * sin_tra, sin_tdec];
 
+                // Gnomonic-project nearby stars once; then only the cheap rotation
+                // (to_instrument) is repeated per roll sample.
+                let nearby =
+                    self.nearby_tangent_offsets(target_unit, target_ra_rad, sin_tdec, cos_tdec);
+
                 if let Some(&roll) = roll_rad.as_ref() {
                     let (sin_roll, cos_roll) = roll.sin_cos();
-                    self.any_star_in_polygon_at_roll(
-                        target_unit,
-                        target_ra_rad,
-                        target_dec_rad,
-                        vertices,
-                        sin_roll,
-                        cos_roll,
-                    )
+                    nearby.iter().any(|&(east, north)| {
+                        let (u, v) = Self::to_instrument(east, north, sin_roll, cos_roll);
+                        Self::point_in_polygon(u.to_degrees(), v.to_degrees(), vertices)
+                    })
                 } else {
                     // Sweep N_ROLL_SAMPLES roll angles evenly over [0°, 360°).
                     // Violated only if every roll has at least one star in the FoV
@@ -264,15 +246,12 @@ impl BrightStarEvaluator {
                     for step in 0..N_ROLL_SAMPLES {
                         let roll = step as f64 * roll_step;
                         let (sin_roll, cos_roll) = roll.sin_cos();
-                        if !self.any_star_in_polygon_at_roll(
-                            target_unit,
-                            target_ra_rad,
-                            target_dec_rad,
-                            vertices,
-                            sin_roll,
-                            cos_roll,
-                        ) {
-                            return false; // found a clear roll
+                        let any_blocked = nearby.iter().any(|&(east, north)| {
+                            let (u, v) = Self::to_instrument(east, north, sin_roll, cos_roll);
+                            Self::point_in_polygon(u.to_degrees(), v.to_degrees(), vertices)
+                        });
+                        if !any_blocked {
+                            return false; // clear roll found
                         }
                     }
                     true // every roll blocked

--- a/src/constraints/bright_star.rs
+++ b/src/constraints/bright_star.rs
@@ -7,6 +7,7 @@ use super::core::{ConstraintConfig, ConstraintEvaluator, ConstraintResult};
 use chrono::{DateTime, Utc};
 use ndarray::Array2;
 use pyo3::PyResult;
+use rayon::prelude::*;
 use serde::{Deserialize, Serialize};
 use std::f64::consts::PI;
 
@@ -49,14 +50,33 @@ impl ConstraintConfig for BrightStarConfig {
             FovDefinition::Circle { cos_radius: 1.0 }
         };
 
-        Box::new(BrightStarEvaluator { stars, fov })
+        // For polygon FoV, precompute a bounding-circle threshold: the maximum angular
+        // separation at which a star could possibly fall inside the polygon at any roll.
+        // Stars outside this circle are skipped with a cheap dot-product test before
+        // the more expensive gnomonic projection.
+        let bounding_cos = if let FovDefinition::Polygon { ref vertices, .. } = fov {
+            let max_dist_deg = vertices
+                .iter()
+                .map(|&[u, v]| (u * u + v * v).sqrt())
+                .fold(0.0f64, f64::max);
+            // Add 1° margin to be safe around polygon edges
+            Some((max_dist_deg + 1.0).to_radians().cos())
+        } else {
+            None
+        };
+
+        Box::new(BrightStarEvaluator {
+            stars,
+            fov,
+            bounding_cos,
+        })
     }
 }
 
 struct StarData {
     ra_rad: f64,
     dec_rad: f64,
-    /// Precomputed ICRS unit vector for dot-product checks in circular FoV
+    /// Precomputed ICRS unit vector for dot-product checks
     unit: [f64; 3],
 }
 
@@ -90,6 +110,9 @@ enum FovDefinition {
 pub struct BrightStarEvaluator {
     stars: Vec<StarData>,
     fov: FovDefinition,
+    /// Precomputed cos(max_polygon_radius + 1°) for fast star rejection in polygon mode.
+    /// None for circular FoV (unused).
+    bounding_cos: Option<f64>,
 }
 
 impl BrightStarEvaluator {
@@ -168,8 +191,12 @@ impl BrightStarEvaluator {
     }
 
     /// True if any star falls inside `vertices` when the instrument is at `roll_rad`.
+    ///
+    /// `target_unit` is the precomputed ICRS unit vector for the target — used for
+    /// the bounding-circle fast-rejection test before gnomonic projection.
     fn any_star_in_polygon_at_roll(
         &self,
+        target_unit: [f64; 3],
         target_ra_rad: f64,
         target_dec_rad: f64,
         vertices: &[[f64; 2]],
@@ -177,6 +204,15 @@ impl BrightStarEvaluator {
         cos_roll: f64,
     ) -> bool {
         for star in &self.stars {
+            // Fast rejection: skip stars outside the polygon bounding circle
+            if let Some(cos_thresh) = self.bounding_cos {
+                let dot = target_unit[0] * star.unit[0]
+                    + target_unit[1] * star.unit[1]
+                    + target_unit[2] * star.unit[2];
+                if dot < cos_thresh {
+                    continue;
+                }
+            }
             if let Some((east, north)) = Self::gnomonic_project(target_ra_rad, target_dec_rad, star)
             {
                 let (u_rad, v_rad) = Self::to_instrument(east, north, sin_roll, cos_roll);
@@ -206,9 +242,14 @@ impl BrightStarEvaluator {
             }
 
             FovDefinition::Polygon { vertices, roll_rad } => {
+                let (sin_tdec, cos_tdec) = target_dec_rad.sin_cos();
+                let (sin_tra, cos_tra) = target_ra_rad.sin_cos();
+                let target_unit = [cos_tdec * cos_tra, cos_tdec * sin_tra, sin_tdec];
+
                 if let Some(&roll) = roll_rad.as_ref() {
                     let (sin_roll, cos_roll) = roll.sin_cos();
                     self.any_star_in_polygon_at_roll(
+                        target_unit,
                         target_ra_rad,
                         target_dec_rad,
                         vertices,
@@ -224,6 +265,7 @@ impl BrightStarEvaluator {
                         let roll = step as f64 * roll_step;
                         let (sin_roll, cos_roll) = roll.sin_cos();
                         if !self.any_star_in_polygon_at_roll(
+                            target_unit,
                             target_ra_rad,
                             target_dec_rad,
                             vertices,
@@ -306,10 +348,18 @@ impl ConstraintEvaluator for BrightStarEvaluator {
             None => all_times.len(),
         };
         let n_targets = target_ras.len();
-        let mut result = Array2::from_elem((n_targets, n_times), false);
 
-        for (i, (&ra, &dec)) in target_ras.iter().zip(target_decs.iter()).enumerate() {
-            if self.is_violated(ra, dec) {
+        // Bright-star violation is time-invariant: evaluate once per target.
+        // Parallelise across targets since each is fully independent.
+        let violated: Vec<bool> = target_ras
+            .par_iter()
+            .zip(target_decs.par_iter())
+            .map(|(&ra, &dec)| self.is_violated(ra, dec))
+            .collect();
+
+        let mut result = Array2::from_elem((n_targets, n_times), false);
+        for (i, &v) in violated.iter().enumerate() {
+            if v {
                 for j in 0..n_times {
                     result[[i, j]] = true;
                 }

--- a/src/constraints/constraint_wrapper/json_parser.rs
+++ b/src/constraints/constraint_wrapper/json_parser.rs
@@ -94,8 +94,14 @@ enum ConstraintSpec {
     #[serde(rename = "body")]
     Body {
         body: String,
-        min_angle: f64,
+        #[serde(default)]
+        min_angle: Option<f64>,
+        #[serde(default)]
         max_angle: Option<f64>,
+        #[serde(default)]
+        fov_polygon: Option<Vec<[f64; 2]>>,
+        #[serde(default)]
+        roll_deg: Option<f64>,
     },
     #[serde(rename = "daytime")]
     Daytime {
@@ -225,10 +231,14 @@ impl ConstraintSpec {
                 body,
                 min_angle,
                 max_angle,
+                fov_polygon,
+                roll_deg,
             } => Ok(BodyProximityConfig {
                 body,
                 min_angle,
                 max_angle,
+                fov_polygon,
+                roll_deg,
             }
             .to_evaluator()),
             ConstraintSpec::Daytime { twilight } => Ok(DaytimeConfig {

--- a/src/constraints/constraint_wrapper/json_parser.rs
+++ b/src/constraints/constraint_wrapper/json_parser.rs
@@ -1,6 +1,7 @@
 use crate::constraints::airmass::AirmassConfig;
 use crate::constraints::alt_az::AltAzConfig;
 use crate::constraints::body_proximity::BodyProximityConfig;
+use crate::constraints::bright_star::BrightStarConfig;
 use crate::constraints::core::{ConstraintConfig, ConstraintEvaluator};
 use crate::constraints::daytime::{DaytimeConfig, TwilightType};
 use crate::constraints::earth_limb::EarthLimbConfig;
@@ -166,6 +167,14 @@ enum ConstraintSpec {
     OrbitRam {
         min_angle: f64,
         max_angle: Option<f64>,
+    },
+    #[serde(rename = "bright_star")]
+    BrightStar {
+        stars: Vec<[f64; 2]>,
+        fov_radius: Option<f64>,
+        fov_polygon: Option<Vec<[f64; 2]>>,
+        #[serde(default)]
+        roll_deg: Option<f64>,
     },
 }
 
@@ -374,6 +383,18 @@ impl ConstraintSpec {
             } => Ok(OrbitRamConfig {
                 min_angle,
                 max_angle,
+            }
+            .to_evaluator()),
+            ConstraintSpec::BrightStar {
+                stars,
+                fov_radius,
+                fov_polygon,
+                roll_deg,
+            } => Ok(BrightStarConfig {
+                stars,
+                fov_radius,
+                fov_polygon,
+                roll_deg,
             }
             .to_evaluator()),
         }

--- a/src/constraints/constraint_wrapper/py_api.rs
+++ b/src/constraints/constraint_wrapper/py_api.rs
@@ -69,12 +69,12 @@ impl PyConstraint {
 
         let is_boresight_offset = constraint_type == "boresight_offset";
         let is_bright_star = constraint_type == "bright_star";
+        let is_body_polygon = constraint_type == "body" && config.get("fov_polygon").is_some();
 
-        // Bright star with a polygon FoV: inject target_roll as roll_deg so the
-        // evaluator rotates the polygon to the requested angle.  For a circular FoV
-        // roll is irrelevant, but we still bypass the BoresightOffset wrapper so the
-        // evaluator's own geometry is preserved.
-        if is_bright_star {
+        // Bright star or body proximity with a polygon FoV: inject target_roll as roll_deg
+        // so the evaluator rotates the polygon to the requested angle.  Both constraint types
+        // handle roll internally, so we bypass the BoresightOffset wrapper.
+        if is_bright_star || is_body_polygon {
             if config.get("fov_polygon").is_some() {
                 if let Some(obj) = config.as_object_mut() {
                     obj.insert("roll_deg".to_string(), serde_json::json!(target_roll_deg));
@@ -945,10 +945,19 @@ impl PyConstraint {
 
     /// Create a generic solar system body avoidance constraint
     ///
+    /// The exclusion zone can be defined as a circular angular separation (min_angle) or as
+    /// a polygon in the instrument frame (fov_polygon). These are mutually exclusive.
+    ///
     /// Args:
     ///     body (str): Body identifier - NAIF ID or name (e.g., "Jupiter", "499", "Mars")
-    ///     min_angle (float): Minimum allowed angular separation in degrees
-    ///     max_angle (float, optional): Maximum allowed angular separation in degrees
+    ///     min_angle (float, optional): Minimum allowed angular separation in degrees (circle mode)
+    ///     max_angle (float, optional): Maximum allowed angular separation in degrees (circle mode only)
+    ///     fov_polygon (list[tuple[float, float]], optional): Polygon FoV as (u_deg, v_deg) vertices
+    ///         in the instrument frame. At roll=0, +u points east and +v points north.
+    ///         Mutually exclusive with min_angle.
+    ///     roll_deg (float, optional): Position angle of instrument +v from north (degrees east of
+    ///         north). Only used with fov_polygon. None (default) sweeps all roll angles: violated
+    ///         only when every roll has the body inside the polygon.
     ///
     /// Returns:
     ///     Constraint: A new constraint object
@@ -956,40 +965,102 @@ impl PyConstraint {
     /// Note:
     ///     Supported bodies depend on the ephemeris type and loaded kernels.
     ///     Common bodies: Sun (10), Moon (301), planets (199, 299, 399, 499, 599, 699, 799, 899)
-    #[pyo3(signature=(body, min_angle, max_angle=None))]
+    #[pyo3(signature=(body, min_angle=None, max_angle=None, fov_polygon=None, roll_deg=None))]
     #[staticmethod]
-    fn body_proximity(body: String, min_angle: f64, max_angle: Option<f64>) -> PyResult<Self> {
-        if !(0.0..=180.0).contains(&min_angle) {
+    fn body_proximity(
+        body: String,
+        min_angle: Option<f64>,
+        max_angle: Option<f64>,
+        fov_polygon: Option<Vec<(f64, f64)>>,
+        roll_deg: Option<f64>,
+    ) -> PyResult<Self> {
+        let has_angle = min_angle.is_some();
+        let has_polygon = fov_polygon.is_some();
+
+        match (has_angle, has_polygon) {
+            (false, false) => {
+                return Err(pyo3::exceptions::PyValueError::new_err(
+                    "either min_angle or fov_polygon must be specified",
+                ))
+            }
+            (true, true) => {
+                return Err(pyo3::exceptions::PyValueError::new_err(
+                    "min_angle and fov_polygon are mutually exclusive",
+                ))
+            }
+            _ => {}
+        }
+
+        if let Some(min) = min_angle {
+            if !(0.0..=180.0).contains(&min) {
+                return Err(pyo3::exceptions::PyValueError::new_err(
+                    "min_angle must be between 0 and 180 degrees",
+                ));
+            }
+            if let Some(max) = max_angle {
+                if !(0.0..=180.0).contains(&max) {
+                    return Err(pyo3::exceptions::PyValueError::new_err(
+                        "max_angle must be between 0 and 180 degrees",
+                    ));
+                }
+                if max <= min {
+                    return Err(pyo3::exceptions::PyValueError::new_err(
+                        "max_angle must be greater than min_angle",
+                    ));
+                }
+            }
+        }
+
+        if has_angle && roll_deg.is_some() {
             return Err(pyo3::exceptions::PyValueError::new_err(
-                "min_angle must be between 0 and 180 degrees",
+                "roll_deg has no effect with min_angle",
             ));
         }
 
-        if let Some(max) = max_angle {
-            if !(0.0..=180.0).contains(&max) {
+        if has_angle && max_angle.is_none() {
+            // max_angle only meaningful in circle mode; check already done above
+        }
+
+        if let Some(ref poly) = fov_polygon {
+            if poly.len() < 3 {
                 return Err(pyo3::exceptions::PyValueError::new_err(
-                    "max_angle must be between 0 and 180 degrees",
-                ));
-            }
-            if max <= min_angle {
-                return Err(pyo3::exceptions::PyValueError::new_err(
-                    "max_angle must be greater than min_angle",
+                    "fov_polygon must have at least 3 vertices",
                 ));
             }
         }
+
+        if let Some(r) = roll_deg {
+            if !r.is_finite() {
+                return Err(pyo3::exceptions::PyValueError::new_err(
+                    "roll_deg must be a finite number when provided",
+                ));
+            }
+        }
+
+        let poly_array: Option<Vec<[f64; 2]>> = fov_polygon
+            .as_ref()
+            .map(|v| v.iter().map(|&(u, v)| [u, v]).collect());
 
         let config = BodyProximityConfig {
             body: body.clone(),
             min_angle,
             max_angle,
+            fov_polygon: poly_array.clone(),
+            roll_deg,
         };
-        let mut json_obj = serde_json::json!({
-            "type": "body",
-            "body": body,
-            "min_angle": min_angle
-        });
+
+        let mut json_obj = serde_json::json!({ "type": "body", "body": body });
+        if let Some(min) = min_angle {
+            json_obj["min_angle"] = serde_json::json!(min);
+        }
         if let Some(max) = max_angle {
             json_obj["max_angle"] = serde_json::json!(max);
+        }
+        if let Some(ref poly) = poly_array {
+            json_obj["fov_polygon"] = serde_json::json!(poly);
+        }
+        if let Some(r) = roll_deg {
+            json_obj["roll_deg"] = serde_json::json!(r);
         }
         let config_json = json_obj.to_string();
 

--- a/src/constraints/constraint_wrapper/py_api.rs
+++ b/src/constraints/constraint_wrapper/py_api.rs
@@ -5,6 +5,7 @@
 use crate::constraints::airmass::AirmassConfig;
 use crate::constraints::alt_az::AltAzConfig;
 use crate::constraints::body_proximity::BodyProximityConfig;
+use crate::constraints::bright_star::BrightStarConfig;
 use crate::constraints::core::*;
 use crate::constraints::daytime::{DaytimeConfig, TwilightType};
 use crate::constraints::earth_limb::EarthLimbConfig;
@@ -60,11 +61,28 @@ impl PyConstraint {
         let mut config: serde_json::Value = serde_json::from_str(&self.config_json)
             .map_err(|e| pyo3::exceptions::PyValueError::new_err(e.to_string()))?;
 
-        let is_boresight_offset = config
+        let constraint_type = config
             .get("type")
             .and_then(|v| v.as_str())
-            .map(|t| t == "boresight_offset")
-            .unwrap_or(false);
+            .unwrap_or("")
+            .to_owned();
+
+        let is_boresight_offset = constraint_type == "boresight_offset";
+        let is_bright_star = constraint_type == "bright_star";
+
+        // Bright star with a polygon FoV: inject target_roll as roll_deg so the
+        // evaluator rotates the polygon to the requested angle.  For a circular FoV
+        // roll is irrelevant, but we still bypass the BoresightOffset wrapper so the
+        // evaluator's own geometry is preserved.
+        if is_bright_star {
+            if config.get("fov_polygon").is_some() {
+                if let Some(obj) = config.as_object_mut() {
+                    obj.insert("roll_deg".to_string(), serde_json::json!(target_roll_deg));
+                }
+            }
+            let evaluator = parse_constraint_json(&config)?;
+            return f(&*evaluator);
+        }
 
         if is_boresight_offset {
             let base_roll_deg = config
@@ -972,6 +990,108 @@ impl PyConstraint {
         });
         if let Some(max) = max_angle {
             json_obj["max_angle"] = serde_json::json!(max);
+        }
+        let config_json = json_obj.to_string();
+
+        Ok(PyConstraint {
+            evaluator: config.to_evaluator(),
+            config_json,
+        })
+    }
+
+    /// Create a bright star avoidance constraint
+    ///
+    /// Violated when any catalog star falls within the telescope field of view.
+    ///
+    /// Args:
+    ///     stars (list[tuple[float, float]]): Stars to avoid as (ra_deg, dec_deg) pairs.
+    ///     fov_radius (float, optional): Circular FoV radius in degrees. Mutually exclusive
+    ///         with fov_polygon.
+    ///     fov_polygon (list[tuple[float, float]], optional): Polygon FoV as a list of
+    ///         (u_deg, v_deg) vertices in the instrument frame. At roll=0, +u points east
+    ///         and +v points north. Mutually exclusive with fov_radius.
+    ///     roll_deg (float, optional): Position angle of the instrument +v axis from north
+    ///         (degrees east of north). Only valid with fov_polygon. When None (default),
+    ///         all roll angles are swept: the constraint is violated only if every roll has
+    ///         a star inside the FoV.
+    ///
+    /// Returns:
+    ///     Constraint: A new constraint object
+    #[pyo3(signature = (stars, fov_radius=None, fov_polygon=None, roll_deg=None))]
+    #[staticmethod]
+    fn bright_star(
+        stars: Vec<(f64, f64)>,
+        fov_radius: Option<f64>,
+        fov_polygon: Option<Vec<(f64, f64)>>,
+        roll_deg: Option<f64>,
+    ) -> PyResult<Self> {
+        if stars.is_empty() {
+            return Err(pyo3::exceptions::PyValueError::new_err(
+                "stars list cannot be empty",
+            ));
+        }
+        match (&fov_radius, &fov_polygon) {
+            (None, None) => {
+                return Err(pyo3::exceptions::PyValueError::new_err(
+                    "either fov_radius or fov_polygon must be specified",
+                ))
+            }
+            (Some(_), Some(_)) => {
+                return Err(pyo3::exceptions::PyValueError::new_err(
+                    "fov_radius and fov_polygon are mutually exclusive",
+                ))
+            }
+            _ => {}
+        }
+        if let Some(r) = fov_radius {
+            if !(0.0..=180.0).contains(&r) {
+                return Err(pyo3::exceptions::PyValueError::new_err(
+                    "fov_radius must be between 0 and 180 degrees",
+                ));
+            }
+        }
+        if let Some(ref poly) = fov_polygon {
+            if poly.len() < 3 {
+                return Err(pyo3::exceptions::PyValueError::new_err(
+                    "fov_polygon must have at least 3 vertices",
+                ));
+            }
+        }
+        if let Some(r) = roll_deg {
+            if !r.is_finite() {
+                return Err(pyo3::exceptions::PyValueError::new_err(
+                    "roll_deg must be a finite number when provided",
+                ));
+            }
+        }
+        if fov_radius.is_some() && roll_deg.is_some() {
+            return Err(pyo3::exceptions::PyValueError::new_err(
+                "roll_deg has no effect with fov_radius",
+            ));
+        }
+
+        let stars_arr: Vec<[f64; 2]> = stars.iter().map(|&(ra, dec)| [ra, dec]).collect();
+        let poly_arr: Option<Vec<[f64; 2]>> = fov_polygon
+            .as_ref()
+            .map(|verts| verts.iter().map(|&(u, v)| [u, v]).collect());
+
+        let config = BrightStarConfig {
+            stars: stars_arr.clone(),
+            fov_radius,
+            fov_polygon: poly_arr.clone(),
+            roll_deg,
+        };
+
+        let mut json_obj = serde_json::json!({
+            "type": "bright_star",
+            "stars": stars_arr,
+        });
+        if let Some(r) = fov_radius {
+            json_obj["fov_radius"] = serde_json::json!(r);
+        }
+        if let Some(ref p) = poly_arr {
+            json_obj["fov_polygon"] = serde_json::json!(p);
+            json_obj["roll_deg"] = serde_json::json!(roll_deg);
         }
         let config_json = json_obj.to_string();
 

--- a/src/constraints/fov_polygon.rs
+++ b/src/constraints/fov_polygon.rs
@@ -1,0 +1,142 @@
+/// Shared tangent-plane polygon geometry for instrument FoV checks.
+///
+/// Used by both the bright star avoidance and body proximity polygon modes.
+use std::f64::consts::PI;
+
+/// Number of roll samples when sweeping all roll angles (5° resolution).
+pub const N_ROLL_SAMPLES: usize = 72;
+
+/// Gnomonic (tangent-plane) projection of a sky point relative to a boresight.
+///
+/// Returns `(east_rad, north_rad)` in tangent-plane coordinates, or `None` if
+/// the point is on or behind the tangent plane (cos_c ≤ 0).
+pub fn gnomonic_project(
+    target_ra_rad: f64,
+    target_dec_rad: f64,
+    point_ra_rad: f64,
+    point_dec_rad: f64,
+) -> Option<(f64, f64)> {
+    let delta_ra = point_ra_rad - target_ra_rad;
+    let (sin_tdec, cos_tdec) = target_dec_rad.sin_cos();
+    let (sin_sdec, cos_sdec) = point_dec_rad.sin_cos();
+    let (sin_dra, cos_dra) = delta_ra.sin_cos();
+
+    let cos_c = sin_tdec * sin_sdec + cos_tdec * cos_sdec * cos_dra;
+    if cos_c <= 0.0 {
+        return None;
+    }
+
+    let east = cos_sdec * sin_dra / cos_c;
+    let north = (cos_tdec * sin_sdec - sin_tdec * cos_sdec * cos_dra) / cos_c;
+    Some((east, north))
+}
+
+/// Transform tangent-plane (east, north) offsets to instrument (u, v) at a given roll.
+///
+/// Convention: at roll = 0°, u = east and v = north.  Roll is the position angle
+/// of instrument +v from north, measured east of north.
+#[inline]
+pub fn to_instrument(east: f64, north: f64, sin_roll: f64, cos_roll: f64) -> (f64, f64) {
+    (
+        east * cos_roll - north * sin_roll,
+        east * sin_roll + north * cos_roll,
+    )
+}
+
+/// Ray-casting point-in-polygon test for `(u_deg, v_deg)` against `vertices` (degrees).
+pub fn point_in_polygon(u: f64, v: f64, vertices: &[[f64; 2]]) -> bool {
+    let n = vertices.len();
+    if n < 3 {
+        return false;
+    }
+    let mut inside = false;
+    let mut j = n - 1;
+    for i in 0..n {
+        let ui = vertices[i][0];
+        let vi = vertices[i][1];
+        let uj = vertices[j][0];
+        let vj = vertices[j][1];
+        if ((vi > v) != (vj > v)) && (u < (uj - ui) * (v - vi) / (vj - vi) + ui) {
+            inside = !inside;
+        }
+        j = i;
+    }
+    inside
+}
+
+/// True if the sky point `(point_ra_rad, point_dec_rad)` falls inside `vertices`
+/// when the instrument is at the given roll.
+pub fn point_in_polygon_at_roll(
+    target_ra_rad: f64,
+    target_dec_rad: f64,
+    point_ra_rad: f64,
+    point_dec_rad: f64,
+    vertices: &[[f64; 2]],
+    sin_roll: f64,
+    cos_roll: f64,
+) -> bool {
+    if let Some((east, north)) =
+        gnomonic_project(target_ra_rad, target_dec_rad, point_ra_rad, point_dec_rad)
+    {
+        let (u_rad, v_rad) = to_instrument(east, north, sin_roll, cos_roll);
+        point_in_polygon(u_rad.to_degrees(), v_rad.to_degrees(), vertices)
+    } else {
+        false
+    }
+}
+
+/// True if the sky point falls inside the polygon for the given roll configuration.
+///
+/// When `roll_rad` is `None` the function sweeps `N_ROLL_SAMPLES` evenly-spaced
+/// roll angles and returns `true` only when **every** roll has the point inside the
+/// polygon (i.e., no clear roll exists).
+pub fn point_violates_polygon(
+    target_ra_rad: f64,
+    target_dec_rad: f64,
+    point_ra_rad: f64,
+    point_dec_rad: f64,
+    vertices: &[[f64; 2]],
+    roll_rad: Option<f64>,
+) -> bool {
+    if let Some(roll) = roll_rad {
+        let (sin_roll, cos_roll) = roll.sin_cos();
+        point_in_polygon_at_roll(
+            target_ra_rad,
+            target_dec_rad,
+            point_ra_rad,
+            point_dec_rad,
+            vertices,
+            sin_roll,
+            cos_roll,
+        )
+    } else {
+        let roll_step = 2.0 * PI / N_ROLL_SAMPLES as f64;
+        for step in 0..N_ROLL_SAMPLES {
+            let roll = step as f64 * roll_step;
+            let (sin_roll, cos_roll) = roll.sin_cos();
+            if !point_in_polygon_at_roll(
+                target_ra_rad,
+                target_dec_rad,
+                point_ra_rad,
+                point_dec_rad,
+                vertices,
+                sin_roll,
+                cos_roll,
+            ) {
+                return false; // found a clear roll
+            }
+        }
+        true // all rolls blocked
+    }
+}
+
+/// Convert a unit vector `[x, y, z]` to `(ra_rad, dec_rad)`.
+///
+/// The vector is assumed to be in the same equatorial frame as the target RA/Dec
+/// (e.g., GCRS / ICRS for observer-relative directions).
+#[inline]
+pub fn unit_to_radec(unit: &[f64; 3]) -> (f64, f64) {
+    let dec_rad = unit[2].clamp(-1.0, 1.0).asin();
+    let ra_rad = unit[1].atan2(unit[0]);
+    (ra_rad, dec_rad)
+}

--- a/src/constraints/mod.rs
+++ b/src/constraints/mod.rs
@@ -11,6 +11,7 @@ pub mod core;
 pub mod airmass;
 pub mod alt_az;
 pub mod body_proximity;
+pub mod bright_star;
 pub mod daytime;
 pub mod earth_limb;
 pub mod eclipse;

--- a/src/constraints/mod.rs
+++ b/src/constraints/mod.rs
@@ -7,6 +7,9 @@
 #[macro_use]
 pub mod core;
 
+// Shared FoV geometry
+pub mod fov_polygon;
+
 // Constraint implementations
 pub mod airmass;
 pub mod alt_az;

--- a/tests/constraints/bright_star_constraint/test_bright_star_constraint.py
+++ b/tests/constraints/bright_star_constraint/test_bright_star_constraint.py
@@ -1,0 +1,285 @@
+"""Geometry and evaluation tests for the bright star avoidance constraint."""
+
+import math
+from datetime import datetime, timezone
+from typing import Generator
+
+import pytest
+
+import rust_ephem
+
+# Swift TLE (28485) used throughout the constraint test suite
+_TLE1 = "1 28485U 04047A   25317.24527149  .00068512  00000+0  12522-2 0  9999"
+_TLE2 = "2 28485  20.5556  25.5469 0004740 206.7882 153.2316 15.47667717153136"
+_BEGIN = datetime(2025, 9, 23, 0, 0, 0, tzinfo=timezone.utc)
+_END = datetime(2025, 9, 24, 0, 0, 0, tzinfo=timezone.utc)
+_STEP = 60
+
+# Small rectangular polygon: ±0.25° u, ±0.15° v  (~0.5° × 0.3° FoV)
+_POLYGON = [(-0.25, -0.15), (0.25, -0.15), (0.25, 0.15), (-0.25, 0.15)]
+
+
+@pytest.fixture(scope="module")
+def tle_ephem() -> Generator[rust_ephem.TLEEphemeris, None, None]:
+    yield rust_ephem.TLEEphemeris(_TLE1, _TLE2, _BEGIN, _END, _STEP)
+
+
+# ── Helpers ────────────────────────────────────────────────────────────────────
+
+
+def _is_violated(
+    constraint: rust_ephem.Constraint,
+    ephem: rust_ephem.TLEEphemeris,
+    ra: float,
+    dec: float,
+) -> bool:
+    """Return True when the constraint is violated at the given (ra, dec)."""
+    result = constraint.evaluate(ephemeris=ephem, target_ra=ra, target_dec=dec)
+    return any(result.constraint_array)
+
+
+def _offset_ra(ra: float, dec: float, delta_deg: float) -> float:
+    """Shift ra by delta_deg / cos(dec) so the on-sky separation is delta_deg."""
+    cos_dec = math.cos(math.radians(dec))
+    if abs(cos_dec) < 1e-9:
+        return ra
+    return (ra + delta_deg / cos_dec) % 360.0
+
+
+# ── Circular FoV ───────────────────────────────────────────────────────────────
+
+
+class TestCircularFov:
+    """Star at boresight, offset outside radius, and boundary cases."""
+
+    def test_star_at_boresight_is_violated(
+        self, tle_ephem: rust_ephem.TLEEphemeris
+    ) -> None:
+        # target == star → always inside the circle
+        star_ra, star_dec = 45.0, 10.0
+        c = rust_ephem.Constraint.bright_star(
+            stars=[(star_ra, star_dec)], fov_radius=1.0
+        )
+        assert _is_violated(c, tle_ephem, star_ra, star_dec)
+
+    def test_star_outside_radius_not_violated(
+        self, tle_ephem: rust_ephem.TLEEphemeris
+    ) -> None:
+        star_ra, star_dec = 45.0, 10.0
+        c = rust_ephem.Constraint.bright_star(
+            stars=[(star_ra, star_dec)], fov_radius=1.0
+        )
+        # 5° offset — well outside the 1° radius
+        offset_ra = _offset_ra(star_ra, star_dec, 5.0)
+        assert not _is_violated(c, tle_ephem, offset_ra, star_dec)
+
+    @pytest.mark.parametrize("offset_deg", [0.5, 0.9, 0.99])
+    def test_star_inside_radius_violated(
+        self, tle_ephem: rust_ephem.TLEEphemeris, offset_deg: float
+    ) -> None:
+        star_ra, star_dec = 45.0, 10.0
+        c = rust_ephem.Constraint.bright_star(
+            stars=[(star_ra, star_dec)], fov_radius=1.0
+        )
+        offset_ra = _offset_ra(star_ra, star_dec, offset_deg)
+        assert _is_violated(c, tle_ephem, offset_ra, star_dec)
+
+    @pytest.mark.parametrize("offset_deg", [1.1, 2.0, 5.0])
+    def test_star_outside_radius_not_violated_parametrized(
+        self, tle_ephem: rust_ephem.TLEEphemeris, offset_deg: float
+    ) -> None:
+        star_ra, star_dec = 45.0, 10.0
+        c = rust_ephem.Constraint.bright_star(
+            stars=[(star_ra, star_dec)], fov_radius=1.0
+        )
+        offset_ra = _offset_ra(star_ra, star_dec, offset_deg)
+        assert not _is_violated(c, tle_ephem, offset_ra, star_dec)
+
+    def test_multiple_stars_any_triggers_violation(
+        self, tle_ephem: rust_ephem.TLEEphemeris
+    ) -> None:
+        # Place two stars: one inside, one outside
+        target_ra, target_dec = 100.0, 5.0
+        star_inside = (target_ra, target_dec)  # coincident → inside
+        star_outside = (_offset_ra(target_ra, target_dec, 5.0), target_dec)
+        c = rust_ephem.Constraint.bright_star(
+            stars=[star_inside, star_outside], fov_radius=1.0
+        )
+        assert _is_violated(c, tle_ephem, target_ra, target_dec)
+
+    def test_no_stars_inside_not_violated(
+        self, tle_ephem: rust_ephem.TLEEphemeris
+    ) -> None:
+        target_ra, target_dec = 100.0, 5.0
+        stars = [
+            (_offset_ra(target_ra, target_dec, d), target_dec) for d in [3.0, 5.0, 10.0]
+        ]
+        c = rust_ephem.Constraint.bright_star(stars=stars, fov_radius=1.0)
+        assert not _is_violated(c, tle_ephem, target_ra, target_dec)
+
+
+# ── Polygon FoV at fixed roll ──────────────────────────────────────────────────
+
+
+class TestPolygonFovFixedRoll:
+    """Star inside/outside an axis-aligned rectangular FoV at roll=0."""
+
+    def test_star_at_boresight_polygon_violated(
+        self, tle_ephem: rust_ephem.TLEEphemeris
+    ) -> None:
+        star_ra, star_dec = 60.0, 5.0
+        c = rust_ephem.Constraint.bright_star(
+            stars=[(star_ra, star_dec)],
+            fov_polygon=_POLYGON,
+            roll_deg=0.0,
+        )
+        assert _is_violated(c, tle_ephem, star_ra, star_dec)
+
+    def test_star_well_outside_polygon_not_violated(
+        self, tle_ephem: rust_ephem.TLEEphemeris
+    ) -> None:
+        star_ra, star_dec = 60.0, 5.0
+        c = rust_ephem.Constraint.bright_star(
+            stars=[(star_ra, star_dec)],
+            fov_polygon=_POLYGON,
+            roll_deg=0.0,
+        )
+        # Target 2° away — star will be 2° from boresight, outside 0.5°×0.3° box
+        offset_ra = _offset_ra(star_ra, star_dec, 2.0)
+        assert not _is_violated(c, tle_ephem, offset_ra, star_dec)
+
+    def test_star_inside_polygon_at_roll_90(
+        self, tle_ephem: rust_ephem.TLEEphemeris
+    ) -> None:
+        # At roll=90°: u = north, v = -east (per convention).
+        # A star 0.10° east of target maps to u≈0.10° at roll=0 but u≈0° at roll=90°.
+        # At roll=90°, a star 0.10° north maps to u=0° (v), v=0.10° — inside the polygon.
+        # We construct a star slightly north of the target so it's in the box at roll=90.
+        star_dec = 6.0
+        target_dec = 5.9  # star is 0.1° north of target → v≈0.1° < 0.15° → inside
+        star_ra = 60.0
+        target_ra = star_ra  # same RA → delta_ra = 0
+        c = rust_ephem.Constraint.bright_star(
+            stars=[(star_ra, star_dec)],
+            fov_polygon=_POLYGON,
+            roll_deg=90.0,
+        )
+        assert _is_violated(c, tle_ephem, target_ra, target_dec)
+
+    def test_pydantic_polygon_fixed_roll_evaluates(
+        self, tle_ephem: rust_ephem.TLEEphemeris
+    ) -> None:
+        from rust_ephem.constraints import BrightStarConstraint
+
+        pyd = BrightStarConstraint(
+            stars=[(60.0, 5.0)],
+            fov_polygon=_POLYGON,
+            roll_deg=0.0,
+        )
+        c = rust_ephem.Constraint.from_json(pyd.model_dump_json())
+        assert _is_violated(c, tle_ephem, 60.0, 5.0)
+
+
+# ── Roll-sweep semantics ───────────────────────────────────────────────────────
+
+
+class TestRollSweep:
+    """When roll_deg is None the constraint sweeps all roll angles.
+
+    Violated only if every sampled roll has a star in the FoV.
+    """
+
+    def test_star_at_boresight_all_rolls_blocked(
+        self, tle_ephem: rust_ephem.TLEEphemeris
+    ) -> None:
+        # Star == target: it's at the origin of the instrument frame for any roll.
+        star_ra, star_dec = 70.0, -5.0
+        c = rust_ephem.Constraint.bright_star(
+            stars=[(star_ra, star_dec)],
+            fov_polygon=_POLYGON,
+            roll_deg=None,
+        )
+        assert _is_violated(c, tle_ephem, star_ra, star_dec)
+
+    def test_target_far_from_stars_not_violated(
+        self, tle_ephem: rust_ephem.TLEEphemeris
+    ) -> None:
+        # Stars are all 10° away — no roll can put them in a sub-degree box.
+        target_ra, target_dec = 70.0, -5.0
+        stars = [
+            (_offset_ra(target_ra, target_dec, d), target_dec)
+            for d in [10.0, 15.0, 20.0]
+        ]
+        c = rust_ephem.Constraint.bright_star(
+            stars=stars,
+            fov_polygon=_POLYGON,
+            roll_deg=None,
+        )
+        assert not _is_violated(c, tle_ephem, target_ra, target_dec)
+
+    def test_star_in_only_some_rolls_not_violated(
+        self, tle_ephem: rust_ephem.TLEEphemeris
+    ) -> None:
+        # Place a star 0.20° east (just outside u-limit of ±0.25°, inside at roll=0 east).
+        # Actually put it *inside* at roll=0 but outside at roll=90. The sweep should
+        # find a clear roll → not violated.
+        # Star 0.15° north and 0.30° east of target:
+        #   roll=0: u=0.30°, v=0.15° — u > 0.25° → outside
+        #   roll=90: u=-0.15°, v=0.30° — v > 0.15° → outside
+        # Since neither at roll=0 nor roll=90 is it inside, definitely not violated.
+        target_ra, target_dec = 80.0, 10.0
+        star_ra = _offset_ra(target_ra, target_dec, 0.30)
+        star_dec = target_dec + 0.15
+        c = rust_ephem.Constraint.bright_star(
+            stars=[(star_ra, star_dec)],
+            fov_polygon=_POLYGON,
+            roll_deg=None,
+        )
+        assert not _is_violated(c, tle_ephem, target_ra, target_dec)
+
+
+# ── JSON round-trip ────────────────────────────────────────────────────────────
+
+
+class TestJsonRoundTrip:
+    def test_circle_roundtrip(self, tle_ephem: rust_ephem.TLEEphemeris) -> None:
+        from rust_ephem.constraints import (
+            BrightStarConstraint,
+            CombinedConstraintConfig,
+        )
+
+        star_ra, star_dec = 90.0, 15.0
+        pyd = BrightStarConstraint(stars=[(star_ra, star_dec)], fov_radius=2.0)
+        json_str = pyd.model_dump_json()
+
+        # Validate through CombinedConstraintConfig (TypeAdapter)
+        restored = CombinedConstraintConfig.validate_json(json_str)
+        c = rust_ephem.Constraint.from_json(restored.model_dump_json())
+        assert _is_violated(c, tle_ephem, star_ra, star_dec)
+
+    def test_polygon_roundtrip(self, tle_ephem: rust_ephem.TLEEphemeris) -> None:
+        from rust_ephem.constraints import BrightStarConstraint
+
+        star_ra, star_dec = 90.0, 15.0
+        pyd = BrightStarConstraint(
+            stars=[(star_ra, star_dec)],
+            fov_polygon=_POLYGON,
+            roll_deg=0.0,
+        )
+        c = rust_ephem.Constraint.from_json(pyd.model_dump_json())
+        assert _is_violated(c, tle_ephem, star_ra, star_dec)
+
+    def test_polygon_roll_sweep_roundtrip(
+        self, tle_ephem: rust_ephem.TLEEphemeris
+    ) -> None:
+        from rust_ephem.constraints import BrightStarConstraint
+
+        star_ra, star_dec = 90.0, 15.0
+        pyd = BrightStarConstraint(
+            stars=[(star_ra, star_dec)],
+            fov_polygon=_POLYGON,
+            roll_deg=None,
+        )
+        c = rust_ephem.Constraint.from_json(pyd.model_dump_json())
+        # Star at boresight → all rolls blocked
+        assert _is_violated(c, tle_ephem, star_ra, star_dec)

--- a/tests/constraints/bright_star_constraint/test_bright_star_validators.py
+++ b/tests/constraints/bright_star_constraint/test_bright_star_validators.py
@@ -1,0 +1,93 @@
+"""Pydantic validation tests for BrightStarConstraint."""
+
+import pytest
+
+import rust_ephem
+from rust_ephem.constraints import BrightStarConstraint
+
+_STARS = [(10.0, 20.0), (30.0, 40.0)]
+_POLYGON = [(-0.25, -0.15), (0.25, -0.15), (0.25, 0.15), (-0.25, 0.15)]
+
+
+class TestBrightStarPydanticValidators:
+    def test_valid_circle_fov(self) -> None:
+        c = BrightStarConstraint(stars=_STARS, fov_radius=0.5)
+        assert c.fov_radius == 0.5
+        assert c.fov_polygon is None
+
+    def test_valid_polygon_fov(self) -> None:
+        c = BrightStarConstraint(stars=_STARS, fov_polygon=_POLYGON)
+        assert c.fov_polygon is not None
+        assert c.fov_radius is None
+
+    def test_valid_polygon_with_roll(self) -> None:
+        c = BrightStarConstraint(stars=_STARS, fov_polygon=_POLYGON, roll_deg=45.0)
+        assert c.roll_deg == 45.0
+
+    def test_neither_fov_raises(self) -> None:
+        with pytest.raises(ValueError, match="fov_radius or fov_polygon"):
+            BrightStarConstraint(stars=_STARS)
+
+    def test_both_fov_raises(self) -> None:
+        with pytest.raises(ValueError, match="mutually exclusive"):
+            BrightStarConstraint(stars=_STARS, fov_radius=0.5, fov_polygon=_POLYGON)
+
+    def test_polygon_too_few_vertices_raises(self) -> None:
+        with pytest.raises(ValueError, match="at least 3"):
+            BrightStarConstraint(stars=_STARS, fov_polygon=[(0.0, 0.0), (1.0, 0.0)])
+
+    def test_roll_with_circle_fov_raises(self) -> None:
+        with pytest.raises(ValueError, match="roll_deg"):
+            BrightStarConstraint(stars=_STARS, fov_radius=0.5, roll_deg=45.0)
+
+    def test_roll_none_with_polygon_is_valid(self) -> None:
+        c = BrightStarConstraint(stars=_STARS, fov_polygon=_POLYGON, roll_deg=None)
+        assert c.roll_deg is None
+
+
+class TestBrightStarRustValidators:
+    """Tests for validation in the Rust-side Constraint.bright_star() factory."""
+
+    def test_valid_circle(self) -> None:
+        c = rust_ephem.Constraint.bright_star(stars=_STARS, fov_radius=0.5)
+        assert c is not None
+
+    def test_valid_polygon(self) -> None:
+        c = rust_ephem.Constraint.bright_star(stars=_STARS, fov_polygon=_POLYGON)
+        assert c is not None
+
+    def test_empty_stars_raises(self) -> None:
+        with pytest.raises(ValueError, match="empty"):
+            rust_ephem.Constraint.bright_star(stars=[], fov_radius=0.5)
+
+    def test_neither_fov_raises(self) -> None:
+        with pytest.raises(ValueError, match="fov_radius or fov_polygon"):
+            rust_ephem.Constraint.bright_star(stars=_STARS)
+
+    def test_both_fov_raises(self) -> None:
+        with pytest.raises(ValueError, match="mutually exclusive"):
+            rust_ephem.Constraint.bright_star(
+                stars=_STARS, fov_radius=0.5, fov_polygon=_POLYGON
+            )
+
+    def test_polygon_too_few_vertices_raises(self) -> None:
+        with pytest.raises(ValueError, match="at least 3"):
+            rust_ephem.Constraint.bright_star(
+                stars=_STARS, fov_polygon=[(0.0, 0.0), (1.0, 0.0)]
+            )
+
+    def test_roll_with_circle_raises(self) -> None:
+        with pytest.raises(ValueError, match="roll_deg"):
+            rust_ephem.Constraint.bright_star(
+                stars=_STARS, fov_radius=0.5, roll_deg=45.0
+            )
+
+    def test_fov_radius_out_of_range_raises(self) -> None:
+        with pytest.raises(ValueError):
+            rust_ephem.Constraint.bright_star(stars=_STARS, fov_radius=200.0)
+
+    def test_roll_with_polygon(self) -> None:
+        c = rust_ephem.Constraint.bright_star(
+            stars=_STARS, fov_polygon=_POLYGON, roll_deg=0.0
+        )
+        assert c is not None

--- a/tests/constraints/bright_star_constraint/test_get_bright_stars.py
+++ b/tests/constraints/bright_star_constraint/test_get_bright_stars.py
@@ -1,0 +1,186 @@
+"""Tests for the get_bright_stars catalog utility (VizieR mocked)."""
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+import pytest
+
+import rust_ephem
+from rust_ephem import get_bright_stars
+
+
+def _make_table(ras: list[float], decs: list[float], vmags: list[float]) -> MagicMock:
+    """Build a fake astropy Table-like object whose items are proper numpy arrays."""
+    data = {
+        "_RA.icrs": np.array(ras, dtype=float),
+        "_DE.icrs": np.array(decs, dtype=float),
+        "Vmag": np.array(vmags, dtype=float),
+    }
+    table = MagicMock()
+    table.__getitem__ = MagicMock(side_effect=lambda key: data[key])
+    return table
+
+
+def _make_vizier_result(table: MagicMock) -> MagicMock:
+    result = MagicMock()
+    result.__len__ = MagicMock(return_value=1)
+    result.__bool__ = MagicMock(return_value=True)
+    result.__getitem__ = MagicMock(return_value=table)
+    return result
+
+
+# ── Cache behaviour ────────────────────────────────────────────────────────────
+
+
+class TestGetBrightStarsCaching:
+    """VizieR is mocked; tests verify cache read/write semantics."""
+
+    def test_first_call_downloads_and_caches(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr("rust_ephem.bright_stars._cache_dir", lambda: tmp_path)
+
+        table = _make_table([10.0, 20.0], [5.0, -5.0], [4.0, 5.0])
+        vizier_result = _make_vizier_result(table)
+
+        with patch("rust_ephem.bright_stars.Vizier") as MockVizier:
+            instance = MockVizier.return_value
+            instance.query_constraints.return_value = vizier_result
+
+            stars = get_bright_stars(mag_limit=6.0, refresh=True)
+
+        assert len(stars) == 2
+        assert all(len(s) == 2 for s in stars)
+        # Cache file should exist
+        cache_files = list(tmp_path.glob("hipparcos_vmag_*.npy"))
+        assert len(cache_files) == 1
+
+    def test_second_call_uses_cache_no_download(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr("rust_ephem.bright_stars._cache_dir", lambda: tmp_path)
+
+        # Pre-populate cache
+        data = np.array([[10.0, 5.0, 4.0], [20.0, -5.0, 5.5]])
+        np.save(tmp_path / "hipparcos_vmag_6.00.npy", data)
+
+        with patch("rust_ephem.bright_stars.Vizier") as MockVizier:
+            stars = get_bright_stars(mag_limit=6.0)
+            MockVizier.assert_not_called()
+
+        assert len(stars) == 2
+
+    def test_magnitude_filter_applied(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr("rust_ephem.bright_stars._cache_dir", lambda: tmp_path)
+
+        # Cache has 3 stars: two bright (4, 5) and one dim (7)
+        data = np.array([[10.0, 5.0, 4.0], [20.0, -5.0, 5.0], [30.0, 0.0, 7.0]])
+        np.save(tmp_path / "hipparcos_vmag_8.00.npy", data)
+
+        stars = get_bright_stars(mag_limit=6.0)
+        assert len(stars) == 2  # only the two with vmag <= 6.0
+
+    def test_broader_cache_serves_tighter_request(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr("rust_ephem.bright_stars._cache_dir", lambda: tmp_path)
+
+        # A broad cache (mag_limit=8.0) exists; request mag_limit=5.0
+        data = np.array([[10.0, 5.0, 4.0], [20.0, -5.0, 7.5]])
+        np.save(tmp_path / "hipparcos_vmag_8.00.npy", data)
+
+        with patch("rust_ephem.bright_stars.Vizier") as MockVizier:
+            stars = get_bright_stars(mag_limit=5.0)
+            MockVizier.assert_not_called()
+
+        assert len(stars) == 1  # only star with vmag=4.0 passes the 5.0 limit
+
+    def test_refresh_ignores_cache(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr("rust_ephem.bright_stars._cache_dir", lambda: tmp_path)
+
+        # Put a cache file with different content
+        old_data = np.array([[99.0, 99.0, 3.0]])
+        np.save(tmp_path / "hipparcos_vmag_6.00.npy", old_data)
+
+        fresh_table = _make_table([1.0, 2.0], [0.0, 0.0], [4.0, 5.0])
+        vizier_result = _make_vizier_result(fresh_table)
+
+        with patch("rust_ephem.bright_stars.Vizier") as MockVizier:
+            instance = MockVizier.return_value
+            instance.query_constraints.return_value = vizier_result
+
+            stars = get_bright_stars(mag_limit=6.0, refresh=True)
+
+        # Should get the fresh data (2 stars), not the cached (1 star)
+        assert len(stars) == 2
+
+    def test_cache_mag_limit_larger_than_mag_limit(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr("rust_ephem.bright_stars._cache_dir", lambda: tmp_path)
+
+        table = _make_table([10.0, 20.0, 30.0], [0.0, 0.0, 0.0], [4.0, 6.0, 7.5])
+        vizier_result = _make_vizier_result(table)
+
+        with patch("rust_ephem.bright_stars.Vizier") as MockVizier:
+            instance = MockVizier.return_value
+            instance.query_constraints.return_value = vizier_result
+
+            # Download up to 8.0, return only up to 5.0
+            stars = get_bright_stars(mag_limit=5.0, cache_mag_limit=8.0, refresh=True)
+
+        assert len(stars) == 1  # only vmag=4.0
+        # Cache written at the broader limit
+        assert (tmp_path / "hipparcos_vmag_8.00.npy").exists()
+
+    def test_cache_mag_limit_less_than_mag_limit_raises(self) -> None:
+        with pytest.raises(ValueError, match="cache_mag_limit"):
+            get_bright_stars(mag_limit=7.0, cache_mag_limit=5.0)
+
+
+# ── Return format ──────────────────────────────────────────────────────────────
+
+
+class TestGetBrightStarsReturnFormat:
+    def test_returns_list_of_tuples(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr("rust_ephem.bright_stars._cache_dir", lambda: tmp_path)
+
+        data = np.array([[15.5, -3.2, 4.1], [270.0, 45.0, 5.8]])
+        np.save(tmp_path / "hipparcos_vmag_7.00.npy", data)
+
+        stars = get_bright_stars(mag_limit=7.0)
+        assert isinstance(stars, list)
+        assert all(isinstance(s, tuple) and len(s) == 2 for s in stars)
+
+    def test_ra_dec_values_correct(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr("rust_ephem.bright_stars._cache_dir", lambda: tmp_path)
+
+        data = np.array([[15.5, -3.2, 4.1]])
+        np.save(tmp_path / "hipparcos_vmag_7.00.npy", data)
+
+        stars = get_bright_stars(mag_limit=7.0)
+        ra, dec = stars[0]
+        assert ra == pytest.approx(15.5)
+        assert dec == pytest.approx(-3.2)
+
+    def test_stars_suitable_for_constraint(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Stars returned by get_bright_stars can be passed directly to Constraint.bright_star."""
+        monkeypatch.setattr("rust_ephem.bright_stars._cache_dir", lambda: tmp_path)
+
+        data = np.array([[10.0, 5.0, 4.5], [20.0, -5.0, 6.0]])
+        np.save(tmp_path / "hipparcos_vmag_7.00.npy", data)
+
+        stars = get_bright_stars(mag_limit=7.0)
+        c = rust_ephem.Constraint.bright_star(stars=stars, fov_radius=1.0)
+        assert c is not None


### PR DESCRIPTION
This pull request introduces a new "Bright Star Avoidance" constraint to the `rust_ephem` library, allowing users to prevent bright catalog stars from entering a telescope's field of view. It adds both the constraint implementation and a utility for fetching and caching bright stars from the Hipparcos catalog, along with comprehensive documentation and Python interface updates. The changes also add `astroquery` as a required dependency for catalog access.

**Bright Star Avoidance Constraint:**

- Added `BrightStarConstraint` class to `rust_ephem.constraints`, enabling users to define a constraint that is violated when any specified catalog star falls within a circular or polygonal field of view, with support for roll angle sweeps and both circular and polygon FoV definitions. This includes Pydantic validation and detailed attribute documentation. [[1]](diffhunk://#diff-3dba367a5f087cea43ad0c5fbf3566683f951c8c54401173472d5b6bf22c07b3R1604-R1654) [[2]](diffhunk://#diff-3dba367a5f087cea43ad0c5fbf3566683f951c8c54401173472d5b6bf22c07b3R1669) [[3]](diffhunk://#diff-5a41ff46843312c1bbeebbea63a22a87f5b99c7a96f464279697e3a2f5a2c888R280-R286)

- Added the static method `Constraint.bright_star` to the Rust/Python interface, allowing direct creation of bright star constraints from star lists and FoV parameters.

**Bright Star Catalog Utility:**

- Introduced the `get_bright_stars` function in a new module `rust_ephem.bright_stars`, which fetches and caches Hipparcos stars using `astroquery`, supports efficient on-disk caching keyed by magnitude limit, and provides a simple interface for retrieving star positions for constraint use.

**Documentation:**

- Added detailed documentation for the new constraint and catalog utility, including usage examples, parameter explanations, and caching behavior in both the constraints API reference and planning constraints guide. [[1]](diffhunk://#diff-a7488628cf251be8ef7295e1006d7543b58fa88ed5f95460609fe41895b87ef1R1204-R1348) [[2]](diffhunk://#diff-a58ce1c51d4d4bff8b44ea426bf528c9074831356d61b96c3bf9dfadc32289c4R125-R182) [[3]](diffhunk://#diff-a58ce1c51d4d4bff8b44ea426bf528c9074831356d61b96c3bf9dfadc32289c4L209-R267)

**Python API and Typings:**

- Updated `__init__.py` and `__init__.pyi` to expose `BrightStarConstraint` and `get_bright_stars` at the top-level API, ensuring discoverability and type hinting support. [[1]](diffhunk://#diff-1c620d65e824d1b356a2ba35492ab5783b7697b72d6bbc8021cce190fd151284R24-R32) [[2]](diffhunk://#diff-1c620d65e824d1b356a2ba35492ab5783b7697b72d6bbc8021cce190fd151284R103-R104) [[3]](diffhunk://#diff-1ca0f2ecfa3a291421954ea9140b1a28dd75f5ff2297d0cec51d1b4253000dbaR67-R69) [[4]](diffhunk://#diff-1ca0f2ecfa3a291421954ea9140b1a28dd75f5ff2297d0cec51d1b4253000dbaR88-R90) [[5]](diffhunk://#diff-1ca0f2ecfa3a291421954ea9140b1a28dd75f5ff2297d0cec51d1b4253000dbaR194-R195)

**Dependencies:**

- Added `astroquery` as a required dependency in `pyproject.toml` to support catalog fetching.