### PR TITLE
fix(constraints): roll_range support for at least and xor constraints

### DIFF
--- a/src/constraints/constraint_wrapper/roll_range.rs
+++ b/src/constraints/constraint_wrapper/roll_range.rs
@@ -318,6 +318,87 @@ pub(super) fn roll_sweep_vec(
             Ok(result.into_iter().map(|v| !v).collect())
         }
 
+        // AT_LEAST: violated if at least `min_violated` children are violated.
+        Some("at_least") => {
+            let children = config
+                .get("constraints")
+                .and_then(|v| v.as_array())
+                .ok_or_else(|| {
+                    pyo3::exceptions::PyValueError::new_err(
+                        "at_least node is missing 'constraints'",
+                    )
+                })?;
+            if children.is_empty() {
+                return Ok(vec![false; n]);
+            }
+            let min_violated = config
+                .get("min_violated")
+                .and_then(|v| v.as_u64())
+                .unwrap_or(1) as usize;
+
+            // collect child results
+            let mut child_results: Vec<Vec<bool>> = Vec::with_capacity(children.len());
+            for child in children {
+                child_results.push(roll_sweep_vec(
+                    child,
+                    target_ras,
+                    target_decs,
+                    rolls,
+                    ephem,
+                    time_idx,
+                    sun_unit,
+                )?);
+            }
+
+            let mut result = vec![false; n];
+            for i in 0..n {
+                let mut count = 0usize;
+                for cr in &child_results {
+                    if cr[i] {
+                        count += 1;
+                        if count >= min_violated {
+                            break;
+                        }
+                    }
+                }
+                result[i] = count >= min_violated;
+            }
+            Ok(result)
+        }
+
+        // XOR: violated if exactly one child is violated.
+        Some("xor") => {
+            let children = config
+                .get("constraints")
+                .and_then(|v| v.as_array())
+                .ok_or_else(|| {
+                    pyo3::exceptions::PyValueError::new_err("xor node is missing 'constraints'")
+                })?;
+            if children.is_empty() {
+                return Ok(vec![false; n]);
+            }
+
+            let mut child_results: Vec<Vec<bool>> = Vec::with_capacity(children.len());
+            for child in children {
+                child_results.push(roll_sweep_vec(
+                    child,
+                    target_ras,
+                    target_decs,
+                    rolls,
+                    ephem,
+                    time_idx,
+                    sun_unit,
+                )?);
+            }
+
+            let mut result = vec![false; n];
+            for i in 0..n {
+                let count = child_results.iter().filter(|cr| cr[i]).count();
+                result[i] = count == 1;
+            }
+            Ok(result)
+        }
+
         _ => {
             // Leaf constraint (sun, moon, eclipse, …) or unsupported compound (xor,
             // at_least).  Build ONE evaluator, call in_constraint_batch once with all N


### PR DESCRIPTION
This pull request adds support for two new compound constraint types, "at_least" and "xor", to the `roll_sweep_vec` function in `roll_range.rs`. These enhancements allow more flexible and expressive constraint definitions by enabling users to specify constraints that are violated if at least a certain number of child constraints are violated, or if exactly one child constraint is violated.

New compound constraint support:

* Added handling for the "at_least" constraint, which is violated if at least a specified minimum number (`min_violated`) of its child constraints are violated. This allows for threshold-based constraint logic.
* Added handling for the "xor" constraint, which is violated if exactly one of its child constraints is violated, enabling exclusive-or logic in constraint definitions.