### PR TITLE
feat: add new constraint that restricts roll to set range based on solar panel illumination

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -499,7 +499,7 @@ Classes
       - ``index`` — Optional ephemeris index to evaluate
       - ``n_points`` — Number of sky samples (Fibonacci sphere integration, default :data:`DEFAULT_N_POINTS`)
       - ``target_roll`` — Spacecraft roll angle (degrees) to evaluate at. When ``None`` (default), sweeps all roll angles for boresight-offset FoR.
-      - ``n_roll_samples`` — Spacecraft roll angles to sweep when ``target_roll`` is ``None`` and pitch/yaw offsets are present (default :data:`DEFAULT_N_ROLL_SAMPLES` = 72, i.e. 5° resolution). Ignored otherwise.
+      - ``n_roll_samples`` — Spacecraft roll angles to sweep when ``target_roll`` is ``None`` and pitch/yaw offsets are present (default :data:`DEFAULT_N_ROLL_SAMPLES` = 360, i.e. 1° resolution). Can be reduced (e.g., 72 for 5° resolution) for faster evaluation. Ignored otherwise.
       - Returns: ``float`` steradians in ``[0, 4π]``
       - Requirement: exactly one of ``time`` or ``index`` must be provided
       - Semantics: constraints are violated when ``True``; this method integrates visible sky where constraint is ``False``

--- a/docs/constraints_api.rst
+++ b/docs/constraints_api.rst
@@ -1529,7 +1529,7 @@ All Pydantic constraint models inherit these methods:
    :type target_roll: float or None
    :param int n_roll_samples: Number of roll angles to sweep when ``target_roll`` is ``None``
       and the constraint is roll-dependent.  Default
-      :data:`~rust_ephem.constraints.DEFAULT_N_ROLL_SAMPLES` (72 ≈ 5° resolution).
+      :data:`~rust_ephem.constraints.DEFAULT_N_ROLL_SAMPLES` (360 ≈ 1° resolution).
       Ignored when ``target_roll`` is given or no pitch/yaw offset is present.
    :returns: ConstraintResult containing violation windows
    :rtype: ConstraintResult
@@ -1553,7 +1553,7 @@ All Pydantic constraint models inherit these methods:
    :type target_rolls: list[float | None] or None
    :param int n_roll_samples: Number of roll angles to sweep when a target has ``target_roll=None``
       and the constraint is roll-dependent. Default
-      :data:`~rust_ephem.constraints.DEFAULT_N_ROLL_SAMPLES` (72 ≈ 5° resolution).
+      :data:`~rust_ephem.constraints.DEFAULT_N_ROLL_SAMPLES` (360 ≈ 1° resolution).
    :returns: List of ``ConstraintResult`` objects, one per input target
    :rtype: list[ConstraintResult]
 
@@ -1659,7 +1659,8 @@ All Pydantic constraint models inherit these methods:
    :param int n_roll_samples: Number of spacecraft roll angles to sweep when ``target_roll``
       is not specified (uniformly spaced over [0°, 360°)). Ignored when ``target_roll`` is
       given or no pitch/yaw offset is present. Default
-      :data:`~rust_ephem.constraints.DEFAULT_N_ROLL_SAMPLES` (72 ≈ 5° resolution).
+      :data:`~rust_ephem.constraints.DEFAULT_N_ROLL_SAMPLES` (360 ≈ 1° resolution).
+      Can be reduced (e.g., 72 for 5° resolution) for faster evaluation.
    :param float target_roll: Spacecraft roll angle about +X (degrees).  When ``None``
       (default), sweeps all roll angles for boresight-offset FoR.
    :returns: Visible solid angle in steradians, range ``[0, 4π]``

--- a/docs/planning_constraints.rst
+++ b/docs/planning_constraints.rst
@@ -342,7 +342,7 @@ boresight offset with non-zero pitch/yaw, all three evaluation methods
 roll angles and report a target as blocked only when **every** possible roll is
 blocked — i.e., no valid spacecraft orientation exists.  The sweep resolution is
 controlled by the ``n_roll_samples`` parameter (default
-:data:`~rust_ephem.constraints.DEFAULT_N_ROLL_SAMPLES` = 72 ≈ 5° resolution).
+:data:`~rust_ephem.constraints.DEFAULT_N_ROLL_SAMPLES` = 360 ≈ 1° resolution).
 This is the conservative "is there any viable roll?" check.  Pass an explicit
 ``target_roll`` value to evaluate against a single commanded roll.
 
@@ -386,11 +386,11 @@ Notes:
 - Exactly one of ``time`` or ``index`` must be provided.
 - ``n_points`` controls integration accuracy vs speed (higher = more accurate, slower).
 - ``n_roll_samples`` controls how finely spacecraft roll is swept when ``target_roll`` is
-  not specified (default ``DEFAULT_N_ROLL_SAMPLES`` = 72 ≈ 5° resolution). Reduce to speed
+  not specified (default ``DEFAULT_N_ROLL_SAMPLES`` = 360 ≈ 1° resolution). Reduce to speed
   up at the cost of accuracy; ignored when ``target_roll`` is given or when no pitch/yaw
   offset is present.
 - Constraints are ``True`` when blocked/not visible, so field of regard integrates where constraint is ``False``.
-- For boresight-offset constraints with non-zero pitch/yaw, the sky is sampled at 72
+- For boresight-offset constraints with non-zero pitch/yaw, the sky is sampled at ``n_roll_samples``
   evenly-spaced spacecraft roll angles when ``target_roll`` is not specified.  A direction
   is counted accessible if *any* roll angle satisfies the inner constraint, modelling a
   spacecraft that can rotate about its pointing axis.  The evaluation scales with

--- a/rust_ephem/__init__.py
+++ b/rust_ephem/__init__.py
@@ -45,6 +45,7 @@ from .constraints import (
     OrbitRamConstraint,
     OrConstraint,
     SAAConstraint,
+    SolarRollConstraint,
     SunConstraint,
     XorConstraint,
 )
@@ -65,6 +66,7 @@ __all__ = [
     "MovingVisibilityResult",
     "SAAConstraint",
     "AltAzConstraint",
+    "SolarRollConstraint",
     "OrbitRamConstraint",
     "OrbitPoleConstraint",
     "CombinedConstraintConfig",

--- a/rust_ephem/__init__.pyi
+++ b/rust_ephem/__init__.pyi
@@ -131,6 +131,9 @@ from rust_ephem.constraints import (
     SAAConstraint as SAAConstraint,
 )
 from rust_ephem.constraints import (
+    SolarRollConstraint as SolarRollConstraint,
+)
+from rust_ephem.constraints import (
     SunConstraint as SunConstraint,
 )
 from rust_ephem.constraints import (
@@ -156,6 +159,7 @@ __all__ = [
     "AtLeastConstraint",
     "MoonPhaseConstraint",
     "SAAConstraint",
+    "SolarRollConstraint",
     "AltAzConstraint",
     "OrbitRamConstraint",
     "OrbitPoleConstraint",

--- a/rust_ephem/_rust_ephem.pyi
+++ b/rust_ephem/_rust_ephem.pyi
@@ -642,6 +642,7 @@ class Constraint:
         times: datetime | list[datetime] | None = None,
         indices: int | list[int] | None = None,
         target_rolls: list[float] | None = None,
+        n_roll_samples: int = 72,
     ) -> npt.NDArray[np.bool_]:
         """
         Check if targets are in-constraint for multiple RA/Dec positions (vectorized).

--- a/rust_ephem/constraints.py
+++ b/rust_ephem/constraints.py
@@ -457,6 +457,14 @@ class RustConstraintMixin(BaseModel):
                     apply_eval_roll(inner)
                 return
 
+            if node_type == "solar_roll":
+                # Inject the spacecraft roll directly so the evaluator can compare
+                # it to the solar-optimal roll.  Only inject when a roll is known
+                # (not during a sweep_roll pass, which doesn't apply here).
+                if target_roll is not None and not sweep_roll:
+                    node["roll_deg"] = float(target_roll)
+                return
+
             if node_type in {"and", "or", "xor", "at_least"}:
                 for child in node.get("constraints", []):
                     apply_eval_roll(child)
@@ -1577,6 +1585,46 @@ class AltAzConstraint(RustConstraintMixin):
     )
 
 
+class SolarRollConstraint(RustConstraintMixin):
+    """Solar roll constraint.
+
+    Violated when the spacecraft's roll deviates from the solar-optimal roll
+    (the roll that maximises solar illumination of the +Y body panel) by more
+    than ``tolerance_deg`` degrees.
+
+    The optimal roll is computed from the sun direction in the north-referenced
+    spacecraft body frame.  No panel geometry parameters are needed — the
+    constraint is generic and works for any spacecraft where the primary panel
+    normal is approximately +Y body.
+
+    When ``target_roll`` is not provided (the default), the constraint always
+    reports "not violated" — it is only active when a specific roll angle is
+    evaluated.  Use :meth:`~RustConstraintMixin.roll_range` to obtain the valid
+    roll windows for a given pointing.
+
+    Attributes:
+        type: Always "solar_roll"
+        tolerance_deg: Half-width of the allowed roll window around the solar-optimal
+            roll (degrees).  A target roll within ``[opt - tolerance_deg, opt + tolerance_deg]``
+            is considered valid.
+        roll_deg: Spacecraft roll angle (degrees) at evaluation time.  Injected
+            automatically when evaluating with a fixed roll; leave as ``None``
+            in configuration.
+    """
+
+    type: Literal["solar_roll"] = "solar_roll"
+    tolerance_deg: float = Field(
+        ...,
+        ge=0.0,
+        le=180.0,
+        description="Half-width of valid roll window around solar-optimal (degrees)",
+    )
+    roll_deg: float | None = Field(
+        default=None,
+        description="Evaluation-time spacecraft roll (degrees). Injected automatically; leave None in config.",
+    )
+
+
 class OrbitRamConstraint(RustConstraintMixin):
     """Orbit RAM direction constraint
 
@@ -1698,6 +1746,7 @@ ConstraintConfig = Union[
     DaytimeConstraint,
     AirmassConstraint,
     MoonPhaseConstraint,
+    SolarRollConstraint,
     OrbitRamConstraint,
     OrbitPoleConstraint,
     SAAConstraint,

--- a/rust_ephem/constraints.py
+++ b/rust_ephem/constraints.py
@@ -1589,13 +1589,11 @@ class SolarRollConstraint(RustConstraintMixin):
     """Solar roll constraint.
 
     Violated when the spacecraft's roll deviates from the solar-optimal roll
-    (the roll that maximises solar illumination of the +Y body panel) by more
+    (the roll that maximises solar illumination of the specified panel) by more
     than ``tolerance_deg`` degrees.
 
     The optimal roll is computed from the sun direction in the north-referenced
-    spacecraft body frame.  No panel geometry parameters are needed — the
-    constraint is generic and works for any spacecraft where the primary panel
-    normal is approximately +Y body.
+    spacecraft body frame.
 
     When ``target_roll`` is not provided (the default), the constraint always
     reports "not violated" — it is only active when a specific roll angle is
@@ -1607,6 +1605,11 @@ class SolarRollConstraint(RustConstraintMixin):
         tolerance_deg: Half-width of the allowed roll window around the solar-optimal
             roll (degrees).  A target roll within ``[opt - tolerance_deg, opt + tolerance_deg]``
             is considered valid.
+        panel_normal: Body-frame unit vector normal to the solar panel surface
+            (x = boresight, y = cross-track, z = north-aligned).  Default
+            ``(0, 1, 0)`` is the standard orientation for a nadir-pointing
+            spacecraft with panels on the ±Y faces.  Adjust for panels mounted
+            at a different angle.
         roll_deg: Spacecraft roll angle (degrees) at evaluation time.  Injected
             automatically when evaluating with a fixed roll; leave as ``None``
             in configuration.
@@ -1618,6 +1621,14 @@ class SolarRollConstraint(RustConstraintMixin):
         ge=0.0,
         le=180.0,
         description="Half-width of valid roll window around solar-optimal (degrees)",
+    )
+    panel_normal: tuple[float, float, float] = Field(
+        default=(0.0, 1.0, 0.0),
+        description=(
+            "Body-frame normal vector of the solar panel "
+            "(x=boresight, y=cross-track, z=north). "
+            "Defaults to (0, 1, 0) (+Y body axis)."
+        ),
     )
     roll_deg: float | None = Field(
         default=None,

--- a/rust_ephem/constraints.py
+++ b/rust_ephem/constraints.py
@@ -1639,6 +1639,19 @@ class SolarRollConstraint(RustConstraintMixin):
         description="Evaluation-time spacecraft roll (degrees). Injected automatically; leave None in config.",
     )
 
+    @model_validator(mode="after")
+    def validate_panel_normal(self) -> SolarRollConstraint:
+        vec = np.asarray(self.panel_normal, dtype=float)
+        if not np.all(np.isfinite(vec)):
+            raise ValueError("panel_normal must contain only finite values")
+        if np.linalg.norm(vec) == 0.0:
+            raise ValueError("panel_normal must be a non-zero vector")
+        if vec[1] == 0.0 and vec[2] == 0.0:
+            raise ValueError(
+                "panel_normal must have a non-zero Y or Z component for the solar roll constraint to be meaningful"
+            )
+        return self
+
 
 class OrbitRamConstraint(RustConstraintMixin):
     """Orbit RAM direction constraint

--- a/rust_ephem/constraints.py
+++ b/rust_ephem/constraints.py
@@ -871,7 +871,8 @@ class RustConstraintMixin(BaseModel):
                 ``target_roll`` is not specified and boresight pitch/yaw offsets
                 are present (uniformly spaced over [0°, 360°)).  Ignored when
                 ``target_roll`` is given or no pitch/yaw offset is defined.
-                Default :data:`DEFAULT_N_ROLL_SAMPLES` (5° resolution).
+                Default :data:`DEFAULT_N_ROLL_SAMPLES` (360 ≈ 1° resolution).
+                Can be reduced (e.g., 72 for 5° resolution) for faster evaluation.
             target_roll: Spacecraft roll angle (degrees) about the boresight +X axis.
                 When ``None`` (default), FoR sweeps all possible roll angles for
                 boresight-offset constraints with non-zero pitch/yaw.

--- a/rust_ephem/constraints.py
+++ b/rust_ephem/constraints.py
@@ -369,6 +369,7 @@ class RustConstraintMixin(BaseModel):
                 target_decs,
                 times,
                 indices,
+                n_roll_samples=n_roll_samples,
             ),
         )
 

--- a/rust_ephem/constraints.py
+++ b/rust_ephem/constraints.py
@@ -484,6 +484,8 @@ class RustConstraintMixin(BaseModel):
             if not isinstance(node, dict):
                 return False
             node_type = node.get("type")
+            if node_type == "solar_roll":
+                return True
             if node_type == "boresight_offset":
                 pitch = float(node.get("pitch_deg", 0.0) or 0.0)
                 yaw = float(node.get("yaw_deg", 0.0) or 0.0)

--- a/rust_ephem/constraints.pyi
+++ b/rust_ephem/constraints.pyi
@@ -241,6 +241,7 @@ class AltAzConstraint(RustConstraintMixin):
 class SolarRollConstraint(RustConstraintMixin):
     type: Literal["solar_roll"] = "solar_roll"
     tolerance_deg: float
+    panel_normal: tuple[float, float, float] = (0.0, 1.0, 0.0)
     roll_deg: float | None = None
 
 class OrbitRamConstraint(RustConstraintMixin):

--- a/rust_ephem/constraints.pyi
+++ b/rust_ephem/constraints.pyi
@@ -238,6 +238,11 @@ class AltAzConstraint(RustConstraintMixin):
     max_azimuth: float | None = None
     polygon: list[tuple[float, float]] | None = None
 
+class SolarRollConstraint(RustConstraintMixin):
+    type: Literal["solar_roll"] = "solar_roll"
+    tolerance_deg: float
+    roll_deg: float | None = None
+
 class OrbitRamConstraint(RustConstraintMixin):
     type: Literal["orbit_ram"] = "orbit_ram"
     min_angle: float
@@ -295,6 +300,7 @@ ConstraintConfig = (
     | DaytimeConstraint
     | AirmassConstraint
     | MoonPhaseConstraint
+    | SolarRollConstraint
     | SAAConstraint
     | AltAzConstraint
     | OrbitRamConstraint

--- a/src/constraints/body_proximity.rs
+++ b/src/constraints/body_proximity.rs
@@ -54,6 +54,25 @@ pub struct BodyProximityEvaluator {
 impl_proximity_evaluator!(BodyProximityEvaluator, "Body", "body", sun_positions);
 
 impl BodyProximityEvaluator {
+    /// Return body positions in GCRS (km) for the correct body.
+    ///
+    /// Earth centre is the GCRS origin so its position is all zeros.
+    fn body_positions(
+        &self,
+        ephemeris: &dyn crate::ephemeris::ephemeris_common::EphemerisBase,
+    ) -> pyo3::PyResult<Array2<f64>> {
+        match self.body.to_lowercase().as_str() {
+            "sun" => ephemeris.get_sun_positions(),
+            "moon" => ephemeris.get_moon_positions(),
+            "earth" => {
+                // Earth centre = GCRS origin: return zero array with the same shape as observer.
+                let obs = ephemeris.get_gcrs_positions()?;
+                Ok(Array2::zeros(obs.raw_dim()))
+            }
+            _ => ephemeris.get_any_body_gcrs_positions(&self.body),
+        }
+    }
+
     #[allow(dead_code)]
     fn final_violation_description(&self) -> String {
         match self.max_angle_deg {
@@ -132,8 +151,19 @@ impl ConstraintEvaluator for BodyProximityEvaluator {
         target_dec: f64,
         time_indices: Option<&[usize]>,
     ) -> pyo3::PyResult<ConstraintResult> {
+        let all_times = ephemeris.get_times()?;
+        let body_all = self.body_positions(ephemeris)?;
+        let obs_all = ephemeris.get_gcrs_positions()?;
         let (times_slice, body_positions_slice, observer_positions_slice) =
-            extract_standard_ephemeris_data!(ephemeris, time_indices);
+            if let Some(indices) = time_indices {
+                (
+                    indices.iter().map(|&i| all_times[i]).collect::<Vec<_>>(),
+                    body_all.select(ndarray::Axis(0), indices),
+                    obs_all.select(ndarray::Axis(0), indices),
+                )
+            } else {
+                (all_times.to_vec(), body_all, obs_all)
+            };
 
         if let Some(ref vertices) = self.fov_polygon {
             let target_ra_rad = target_ra.to_radians();
@@ -195,15 +225,15 @@ impl ConstraintEvaluator for BodyProximityEvaluator {
         let times = ephemeris.get_times()?;
         let (body_positions_slice, observer_positions_slice, n_times) =
             if let Some(indices) = time_indices {
-                let body_filtered = ephemeris
-                    .get_sun_positions()?
+                let body_filtered = self
+                    .body_positions(ephemeris)?
                     .select(ndarray::Axis(0), indices);
                 let obs_filtered = ephemeris
                     .get_gcrs_positions()?
                     .select(ndarray::Axis(0), indices);
                 (body_filtered, obs_filtered, indices.len())
             } else {
-                let body_positions = ephemeris.get_sun_positions()?;
+                let body_positions = self.body_positions(ephemeris)?;
                 let observer_positions = ephemeris.get_gcrs_positions()?;
                 (body_positions, observer_positions, times.len())
             };
@@ -299,15 +329,15 @@ impl ConstraintEvaluator for BodyProximityEvaluator {
         let times = ephemeris.get_times()?;
         let (body_positions_slice, observer_positions_slice, n_times) =
             if let Some(indices) = time_indices {
-                let body_filtered = ephemeris
-                    .get_sun_positions()?
+                let body_filtered = self
+                    .body_positions(ephemeris)?
                     .select(ndarray::Axis(0), indices);
                 let obs_filtered = ephemeris
                     .get_gcrs_positions()?
                     .select(ndarray::Axis(0), indices);
                 (body_filtered, obs_filtered, indices.len())
             } else {
-                let body_positions = ephemeris.get_sun_positions()?;
+                let body_positions = self.body_positions(ephemeris)?;
                 let observer_positions = ephemeris.get_gcrs_positions()?;
                 (body_positions, observer_positions, times.len())
             };
@@ -397,6 +427,70 @@ impl ConstraintEvaluator for BodyProximityEvaluator {
             }
         }
         Ok(Some(result))
+    }
+
+    /// When this evaluator uses a free-roll polygon (no fixed roll), the polygon
+    /// orientation changes with roll, so the outer field-of-regard sweep must pass
+    /// the same roll to every constraint at each step.  Returning `true` here opts
+    /// this evaluator into that sweep.
+    fn is_roll_dependent(&self) -> bool {
+        self.fov_polygon.is_some() && self.roll_rad.is_none()
+    }
+
+    /// For the free-roll polygon case: check whether the body falls inside the polygon
+    /// at the specific `roll_deg` coming from the outer sweep.  This ensures the body
+    /// and solar-roll constraints are evaluated at the same roll angle simultaneously.
+    fn field_of_regard_violated_at_roll(
+        &self,
+        ephemeris: &dyn crate::ephemeris::ephemeris_common::EphemerisBase,
+        target_unit_vectors: &Array2<f64>,
+        time_index: usize,
+        roll_deg: f64,
+    ) -> pyo3::PyResult<Vec<bool>> {
+        let n_targets = target_unit_vectors.nrows();
+
+        // Not free-roll polygon mode — fall back to the default (uses in_constraint_batch_unit_vectors).
+        let vertices = match &self.fov_polygon {
+            Some(v) if self.roll_rad.is_none() => v,
+            _ => {
+                if let Some(result) = self.in_constraint_batch_unit_vectors(
+                    ephemeris,
+                    target_unit_vectors,
+                    Some(&[time_index]),
+                )? {
+                    return Ok((0..n_targets).map(|i| result[[i, 0]]).collect());
+                }
+                return Ok(vec![false; n_targets]);
+            }
+        };
+
+        let body_positions = self.body_positions(ephemeris)?;
+        let obs_positions = ephemeris.get_gcrs_positions()?;
+
+        let body_radec = Self::body_radec_at(&body_positions, &obs_positions, time_index);
+
+        let (sin_roll, cos_roll) = roll_deg.to_radians().sin_cos();
+        let mut result = Vec::with_capacity(n_targets);
+        for i in 0..n_targets {
+            let ux = target_unit_vectors[[i, 0]];
+            let uy = target_unit_vectors[[i, 1]];
+            let uz = target_unit_vectors[[i, 2]];
+            let (target_ra_rad, target_dec_rad) = fov_polygon::unit_to_radec(&[ux, uy, uz]);
+            let violated = match body_radec {
+                Some((body_ra, body_dec)) => fov_polygon::point_in_polygon_at_roll(
+                    target_ra_rad,
+                    target_dec_rad,
+                    body_ra,
+                    body_dec,
+                    vertices,
+                    sin_roll,
+                    cos_roll,
+                ),
+                None => false,
+            };
+            result.push(violated);
+        }
+        Ok(result)
     }
 
     fn name(&self) -> String {

--- a/src/constraints/body_proximity.rs
+++ b/src/constraints/body_proximity.rs
@@ -429,6 +429,66 @@ impl ConstraintEvaluator for BodyProximityEvaluator {
         Ok(Some(result))
     }
 
+    /// Hot path for coordinated roll sweep: evaluate polygon at `roll_deg` without
+    /// JSON round-trips.  Circle mode and fixed-roll polygon delegate unchanged.
+    fn in_constraint_batch_at_roll(
+        &self,
+        ephemeris: &dyn crate::ephemeris::ephemeris_common::EphemerisBase,
+        target_ras: &[f64],
+        target_decs: &[f64],
+        time_indices: Option<&[usize]>,
+        roll_deg: f64,
+    ) -> pyo3::PyResult<Array2<bool>> {
+        let vertices = match &self.fov_polygon {
+            Some(v) if self.roll_rad.is_none() => v,
+            _ => return self.in_constraint_batch(ephemeris, target_ras, target_decs, time_indices),
+        };
+
+        let times = ephemeris.get_times()?;
+        let (body_positions_slice, observer_positions_slice, n_times) =
+            if let Some(indices) = time_indices {
+                let body_filtered = self
+                    .body_positions(ephemeris)?
+                    .select(ndarray::Axis(0), indices);
+                let obs_filtered = ephemeris
+                    .get_gcrs_positions()?
+                    .select(ndarray::Axis(0), indices);
+                (body_filtered, obs_filtered, indices.len())
+            } else {
+                (
+                    self.body_positions(ephemeris)?,
+                    ephemeris.get_gcrs_positions()?,
+                    times.len(),
+                )
+            };
+
+        let n_targets = target_ras.len();
+        let mut result = Array2::from_elem((n_targets, n_times), false);
+        let (sin_roll, cos_roll) = roll_deg.to_radians().sin_cos();
+
+        for (i, (&ra, &dec)) in target_ras.iter().zip(target_decs.iter()).enumerate() {
+            let target_ra_rad = ra.to_radians();
+            let target_dec_rad = dec.to_radians();
+            for j in 0..n_times {
+                if let Some((body_ra, body_dec)) =
+                    Self::body_radec_at(&body_positions_slice, &observer_positions_slice, j)
+                {
+                    result[[i, j]] = fov_polygon::point_in_polygon_at_roll(
+                        target_ra_rad,
+                        target_dec_rad,
+                        body_ra,
+                        body_dec,
+                        vertices,
+                        sin_roll,
+                        cos_roll,
+                    );
+                }
+            }
+        }
+
+        Ok(result)
+    }
+
     /// When this evaluator uses a free-roll polygon (no fixed roll), the polygon
     /// orientation changes with roll, so the outer field-of-regard sweep must pass
     /// the same roll to every constraint at each step.  Returning `true` here opts

--- a/src/constraints/body_proximity.rs
+++ b/src/constraints/body_proximity.rs
@@ -6,6 +6,21 @@ use ndarray::Array2;
 use serde::{Deserialize, Serialize};
 use std::sync::Mutex;
 
+/// Content-derived fingerprint identifying an ephemeris's time grid and observer
+/// trajectory.  Avoids relying on pointer addresses, which Rust may reuse after a
+/// value is dropped — that would make a pointer-keyed cache return stale data
+/// when a different ephemeris happens to land at a previously freed address.
+///
+/// f64s are compared by bit pattern so the struct can derive `Eq`.
+#[derive(Clone, PartialEq, Eq)]
+struct EphemerisFingerprint {
+    n_times: usize,
+    first_time: DateTime<Utc>,
+    last_time: DateTime<Utc>,
+    first_obs_bits: [u64; 3],
+    last_obs_bits: [u64; 3],
+}
+
 /// Configuration for generic solar system body proximity constraint
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct BodyProximityConfig {
@@ -42,7 +57,7 @@ impl ConstraintConfig for BodyProximityConfig {
 }
 
 struct RollSweepCacheEntry {
-    ephemeris_key: usize,
+    fingerprint: EphemerisFingerprint,
     time_indices: Option<Vec<usize>>,
     body_positions: Array2<f64>,
     observer_positions: Array2<f64>,
@@ -66,11 +81,47 @@ pub struct BodyProximityEvaluator {
 impl_proximity_evaluator!(BodyProximityEvaluator, "Body", "body", sun_positions);
 
 impl BodyProximityEvaluator {
-    fn ephemeris_cache_key(
+    /// Build a content-derived fingerprint for an ephemeris.  Reads endpoints
+    /// directly out of `data()` without cloning the underlying arrays.
+    fn ephemeris_fingerprint(
         ephemeris: &dyn crate::ephemeris::ephemeris_common::EphemerisBase,
-    ) -> usize {
-        (ephemeris as *const dyn crate::ephemeris::ephemeris_common::EphemerisBase) as *const ()
-            as usize
+    ) -> pyo3::PyResult<EphemerisFingerprint> {
+        let data = ephemeris.data();
+        let times = data
+            .times
+            .as_ref()
+            .ok_or_else(|| pyo3::exceptions::PyValueError::new_err("No times available"))?;
+        let n_times = times.len();
+        if n_times == 0 {
+            return Err(pyo3::exceptions::PyValueError::new_err(
+                "Ephemeris has no times",
+            ));
+        }
+        let gcrs = data.gcrs.as_ref().ok_or_else(|| {
+            pyo3::exceptions::PyValueError::new_err("No GCRS positions available")
+        })?;
+        if gcrs.nrows() != n_times || gcrs.ncols() < 3 {
+            return Err(pyo3::exceptions::PyValueError::new_err(
+                "GCRS positions shape does not match times",
+            ));
+        }
+        let first_obs_bits = [
+            gcrs[[0, 0]].to_bits(),
+            gcrs[[0, 1]].to_bits(),
+            gcrs[[0, 2]].to_bits(),
+        ];
+        let last_obs_bits = [
+            gcrs[[n_times - 1, 0]].to_bits(),
+            gcrs[[n_times - 1, 1]].to_bits(),
+            gcrs[[n_times - 1, 2]].to_bits(),
+        ];
+        Ok(EphemerisFingerprint {
+            n_times,
+            first_time: times[0],
+            last_time: times[n_times - 1],
+            first_obs_bits,
+            last_obs_bits,
+        })
     }
 
     fn ensure_roll_sweep_cache(
@@ -78,7 +129,7 @@ impl BodyProximityEvaluator {
         ephemeris: &dyn crate::ephemeris::ephemeris_common::EphemerisBase,
         time_indices: Option<&[usize]>,
     ) -> pyo3::PyResult<()> {
-        let ephemeris_key = Self::ephemeris_cache_key(ephemeris);
+        let fingerprint = Self::ephemeris_fingerprint(ephemeris)?;
         let indices_key = time_indices.map(|idx| idx.to_vec());
 
         let needs_refresh = {
@@ -87,7 +138,7 @@ impl BodyProximityEvaluator {
             })?;
             match cache.as_ref() {
                 Some(entry) => {
-                    entry.ephemeris_key != ephemeris_key || entry.time_indices != indices_key
+                    entry.fingerprint != fingerprint || entry.time_indices != indices_key
                 }
                 None => true,
             }
@@ -115,7 +166,7 @@ impl BodyProximityEvaluator {
                 pyo3::exceptions::PyRuntimeError::new_err("roll_sweep_cache mutex was poisoned")
             })?;
             *cache = Some(RollSweepCacheEntry {
-                ephemeris_key,
+                fingerprint,
                 time_indices: indices_key,
                 body_positions,
                 observer_positions,

--- a/src/constraints/body_proximity.rs
+++ b/src/constraints/body_proximity.rs
@@ -589,7 +589,7 @@ impl ConstraintEvaluator for BodyProximityEvaluator {
             }
         };
 
-        self.ensure_roll_sweep_cache(ephemeris, None)?;
+        self.ensure_roll_sweep_cache(ephemeris, Some(&[time_index]))?;
         let cached = self.roll_sweep_cache.lock().map_err(|_| {
             pyo3::exceptions::PyRuntimeError::new_err("roll_sweep_cache mutex was poisoned")
         })?;

--- a/src/constraints/body_proximity.rs
+++ b/src/constraints/body_proximity.rs
@@ -7,11 +7,7 @@ use serde::{Deserialize, Serialize};
 use std::sync::Mutex;
 
 /// Content-derived fingerprint identifying an ephemeris's time grid and observer
-/// trajectory.  Avoids relying on pointer addresses, which Rust may reuse after a
-/// value is dropped — that would make a pointer-keyed cache return stale data
-/// when a different ephemeris happens to land at a previously freed address.
-///
-/// f64s are compared by bit pattern so the struct can derive `Eq`.
+/// trajectory.
 #[derive(Clone, PartialEq, Eq)]
 struct EphemerisFingerprint {
     n_times: usize,

--- a/src/constraints/body_proximity.rs
+++ b/src/constraints/body_proximity.rs
@@ -4,6 +4,7 @@ use crate::constraints::fov_polygon;
 use chrono::{DateTime, Utc};
 use ndarray::Array2;
 use serde::{Deserialize, Serialize};
+use std::sync::Mutex;
 
 /// Configuration for generic solar system body proximity constraint
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -35,8 +36,17 @@ impl ConstraintConfig for BodyProximityConfig {
             max_angle_deg: self.max_angle,
             fov_polygon: self.fov_polygon.clone(),
             roll_rad: self.roll_deg.map(|r| r.to_radians()),
+            roll_sweep_cache: Mutex::new(None),
         })
     }
+}
+
+struct RollSweepCacheEntry {
+    ephemeris_key: usize,
+    time_indices: Option<Vec<usize>>,
+    body_positions: Array2<f64>,
+    observer_positions: Array2<f64>,
+    n_times: usize,
 }
 
 /// Evaluator for generic body proximity - requires body positions computed externally
@@ -49,11 +59,73 @@ pub struct BodyProximityEvaluator {
     pub fov_polygon: Option<Vec<[f64; 2]>>,
     /// Fixed roll in radians; None means sweep all rolls (polygon mode only)
     pub roll_rad: Option<f64>,
+    /// Cached body/observer slices for repeated roll-step evaluation.
+    roll_sweep_cache: Mutex<Option<RollSweepCacheEntry>>,
 }
 
 impl_proximity_evaluator!(BodyProximityEvaluator, "Body", "body", sun_positions);
 
 impl BodyProximityEvaluator {
+    fn ephemeris_cache_key(
+        ephemeris: &dyn crate::ephemeris::ephemeris_common::EphemerisBase,
+    ) -> usize {
+        (ephemeris as *const dyn crate::ephemeris::ephemeris_common::EphemerisBase) as *const ()
+            as usize
+    }
+
+    fn ensure_roll_sweep_cache(
+        &self,
+        ephemeris: &dyn crate::ephemeris::ephemeris_common::EphemerisBase,
+        time_indices: Option<&[usize]>,
+    ) -> pyo3::PyResult<()> {
+        let ephemeris_key = Self::ephemeris_cache_key(ephemeris);
+        let indices_key = time_indices.map(|idx| idx.to_vec());
+
+        let needs_refresh = {
+            let cache = self.roll_sweep_cache.lock().map_err(|_| {
+                pyo3::exceptions::PyRuntimeError::new_err("roll_sweep_cache mutex was poisoned")
+            })?;
+            match cache.as_ref() {
+                Some(entry) => {
+                    entry.ephemeris_key != ephemeris_key || entry.time_indices != indices_key
+                }
+                None => true,
+            }
+        };
+
+        if needs_refresh {
+            let (body_positions, observer_positions, n_times) = if let Some(indices) = time_indices
+            {
+                (
+                    self.body_positions(ephemeris)?
+                        .select(ndarray::Axis(0), indices),
+                    ephemeris
+                        .get_gcrs_positions()?
+                        .select(ndarray::Axis(0), indices),
+                    indices.len(),
+                )
+            } else {
+                let body_positions = self.body_positions(ephemeris)?;
+                let observer_positions = ephemeris.get_gcrs_positions()?;
+                let n_times = body_positions.nrows();
+                (body_positions, observer_positions, n_times)
+            };
+
+            let mut cache = self.roll_sweep_cache.lock().map_err(|_| {
+                pyo3::exceptions::PyRuntimeError::new_err("roll_sweep_cache mutex was poisoned")
+            })?;
+            *cache = Some(RollSweepCacheEntry {
+                ephemeris_key,
+                time_indices: indices_key,
+                body_positions,
+                observer_positions,
+                n_times,
+            });
+        }
+
+        Ok(())
+    }
+
     /// Return body positions in GCRS (km) for the correct body.
     ///
     /// Earth centre is the GCRS origin so its position is all zeros.
@@ -444,23 +516,16 @@ impl ConstraintEvaluator for BodyProximityEvaluator {
             _ => return self.in_constraint_batch(ephemeris, target_ras, target_decs, time_indices),
         };
 
-        let times = ephemeris.get_times()?;
-        let (body_positions_slice, observer_positions_slice, n_times) =
-            if let Some(indices) = time_indices {
-                let body_filtered = self
-                    .body_positions(ephemeris)?
-                    .select(ndarray::Axis(0), indices);
-                let obs_filtered = ephemeris
-                    .get_gcrs_positions()?
-                    .select(ndarray::Axis(0), indices);
-                (body_filtered, obs_filtered, indices.len())
-            } else {
-                (
-                    self.body_positions(ephemeris)?,
-                    ephemeris.get_gcrs_positions()?,
-                    times.len(),
-                )
-            };
+        self.ensure_roll_sweep_cache(ephemeris, time_indices)?;
+        let cached = self.roll_sweep_cache.lock().map_err(|_| {
+            pyo3::exceptions::PyRuntimeError::new_err("roll_sweep_cache mutex was poisoned")
+        })?;
+        let entry = cached
+            .as_ref()
+            .expect("roll_sweep_cache must be initialized");
+        let body_positions_slice = &entry.body_positions;
+        let observer_positions_slice = &entry.observer_positions;
+        let n_times = entry.n_times;
 
         let n_targets = target_ras.len();
         let mut result = Array2::from_elem((n_targets, n_times), false);
@@ -471,7 +536,7 @@ impl ConstraintEvaluator for BodyProximityEvaluator {
             let target_dec_rad = dec.to_radians();
             for j in 0..n_times {
                 if let Some((body_ra, body_dec)) =
-                    Self::body_radec_at(&body_positions_slice, &observer_positions_slice, j)
+                    Self::body_radec_at(body_positions_slice, observer_positions_slice, j)
                 {
                     result[[i, j]] = fov_polygon::point_in_polygon_at_roll(
                         target_ra_rad,
@@ -524,10 +589,16 @@ impl ConstraintEvaluator for BodyProximityEvaluator {
             }
         };
 
-        let body_positions = self.body_positions(ephemeris)?;
-        let obs_positions = ephemeris.get_gcrs_positions()?;
+        self.ensure_roll_sweep_cache(ephemeris, None)?;
+        let cached = self.roll_sweep_cache.lock().map_err(|_| {
+            pyo3::exceptions::PyRuntimeError::new_err("roll_sweep_cache mutex was poisoned")
+        })?;
+        let entry = cached
+            .as_ref()
+            .expect("roll_sweep_cache must be initialized");
 
-        let body_radec = Self::body_radec_at(&body_positions, &obs_positions, time_index);
+        let body_radec =
+            Self::body_radec_at(&entry.body_positions, &entry.observer_positions, time_index);
 
         let (sin_roll, cos_roll) = roll_deg.to_radians().sin_cos();
         let mut result = Vec::with_capacity(n_targets);

--- a/src/constraints/bright_star.rs
+++ b/src/constraints/bright_star.rs
@@ -374,6 +374,63 @@ impl ConstraintEvaluator for BrightStarEvaluator {
         Ok(result)
     }
 
+    /// Hot path for coordinated roll sweep: evaluate polygon at `roll_deg` without
+    /// JSON round-trips.  Circle mode and fixed-roll polygon delegate unchanged.
+    fn in_constraint_batch_at_roll(
+        &self,
+        ephemeris: &dyn crate::ephemeris::ephemeris_common::EphemerisBase,
+        target_ras: &[f64],
+        target_decs: &[f64],
+        time_indices: Option<&[usize]>,
+        roll_deg: f64,
+    ) -> PyResult<Array2<bool>> {
+        let vertices = match &self.fov {
+            FovDefinition::Polygon {
+                vertices,
+                roll_rad: None,
+            } => vertices,
+            _ => return self.in_constraint_batch(ephemeris, target_ras, target_decs, time_indices),
+        };
+
+        let all_times = ephemeris.get_times()?;
+        let n_times = match time_indices {
+            Some(idx) => idx.len(),
+            None => all_times.len(),
+        };
+        let n_targets = target_ras.len();
+        let (sin_roll, cos_roll) = roll_deg.to_radians().sin_cos();
+
+        // Bright-star violation is time-invariant; evaluate once per target, parallelise.
+        let violated: Vec<bool> = target_ras
+            .par_iter()
+            .zip(target_decs.par_iter())
+            .map(|(&ra_deg, &dec_deg)| {
+                let target_ra_rad = ra_deg.to_radians();
+                let target_dec_rad = dec_deg.to_radians();
+                let sin_tdec = target_dec_rad.sin();
+                let cos_tdec = target_dec_rad.cos();
+                let (sin_tra, cos_tra) = target_ra_rad.sin_cos();
+                let target_unit = [cos_tdec * cos_tra, cos_tdec * sin_tra, sin_tdec];
+                let nearby =
+                    self.nearby_tangent_offsets(target_unit, target_ra_rad, sin_tdec, cos_tdec);
+                nearby.iter().any(|&(east, north)| {
+                    let (u, v) = Self::to_instrument(east, north, sin_roll, cos_roll);
+                    Self::point_in_polygon(u.to_degrees(), v.to_degrees(), vertices)
+                })
+            })
+            .collect();
+
+        let mut result = Array2::from_elem((n_targets, n_times), false);
+        for (i, &v) in violated.iter().enumerate() {
+            if v {
+                for j in 0..n_times {
+                    result[[i, j]] = true;
+                }
+            }
+        }
+        Ok(result)
+    }
+
     /// Free-roll polygon mode: the polygon rotates with roll, so the outer
     /// field-of-regard sweep must test every constraint at the same roll step.
     fn is_roll_dependent(&self) -> bool {

--- a/src/constraints/bright_star.rs
+++ b/src/constraints/bright_star.rs
@@ -374,6 +374,63 @@ impl ConstraintEvaluator for BrightStarEvaluator {
         Ok(result)
     }
 
+    /// Free-roll polygon mode: the polygon rotates with roll, so the outer
+    /// field-of-regard sweep must test every constraint at the same roll step.
+    fn is_roll_dependent(&self) -> bool {
+        matches!(&self.fov, FovDefinition::Polygon { roll_rad: None, .. })
+    }
+
+    /// Evaluate at a specific roll angle supplied by the outer sweep, rather than
+    /// running an independent internal roll sweep.
+    fn field_of_regard_violated_at_roll(
+        &self,
+        _ephemeris: &dyn crate::ephemeris::ephemeris_common::EphemerisBase,
+        target_unit_vectors: &Array2<f64>,
+        _time_index: usize,
+        roll_deg: f64,
+    ) -> PyResult<Vec<bool>> {
+        let n_targets = target_unit_vectors.nrows();
+
+        let (vertices, stored_roll_rad) = match &self.fov {
+            FovDefinition::Polygon { vertices, roll_rad } => (vertices, roll_rad),
+            FovDefinition::Circle { cos_radius } => {
+                // Circle mode is not roll-dependent; evaluate normally.
+                return Ok((0..n_targets)
+                    .map(|i| {
+                        let target_unit = [
+                            target_unit_vectors[[i, 0]],
+                            target_unit_vectors[[i, 1]],
+                            target_unit_vectors[[i, 2]],
+                        ];
+                        self.any_star_in_circle(target_unit, *cos_radius)
+                    })
+                    .collect());
+            }
+        };
+
+        // Use stored fixed roll if set, otherwise use the roll from the outer sweep.
+        let effective_roll_rad = stored_roll_rad.unwrap_or_else(|| roll_deg.to_radians());
+        let (sin_roll, cos_roll) = effective_roll_rad.sin_cos();
+
+        Ok((0..n_targets)
+            .map(|i| {
+                let ux = target_unit_vectors[[i, 0]];
+                let uy = target_unit_vectors[[i, 1]];
+                let uz = target_unit_vectors[[i, 2]];
+                let target_ra_rad = uy.atan2(ux);
+                let target_dec_rad = uz.clamp(-1.0, 1.0).asin();
+                let sin_tdec = target_dec_rad.sin();
+                let cos_tdec = target_dec_rad.cos();
+                let nearby =
+                    self.nearby_tangent_offsets([ux, uy, uz], target_ra_rad, sin_tdec, cos_tdec);
+                nearby.iter().any(|&(east, north)| {
+                    let (u, v) = Self::to_instrument(east, north, sin_roll, cos_roll);
+                    Self::point_in_polygon(u.to_degrees(), v.to_degrees(), vertices)
+                })
+            })
+            .collect())
+    }
+
     fn name(&self) -> String {
         self.format_name()
     }

--- a/src/constraints/constraint_wrapper/combinators.rs
+++ b/src/constraints/constraint_wrapper/combinators.rs
@@ -277,6 +277,50 @@ impl ConstraintEvaluator for AndEvaluator {
         Ok(result)
     }
 
+    fn in_constraint_batch_at_roll(
+        &self,
+        ephemeris: &dyn crate::ephemeris::ephemeris_common::EphemerisBase,
+        target_ras: &[f64],
+        target_decs: &[f64],
+        time_indices: Option<&[usize]>,
+        roll_deg: f64,
+    ) -> pyo3::PyResult<Array2<bool>> {
+        if target_ras.len() != target_decs.len() {
+            return Err(pyo3::exceptions::PyValueError::new_err(
+                "target_ras and target_decs must have the same length",
+            ));
+        }
+        let times = ephemeris.get_times()?;
+        let n_times = time_indices.map(|idx| idx.len()).unwrap_or(times.len());
+        let results: Result<Vec<_>, _> = self
+            .constraints
+            .iter()
+            .map(|c| {
+                c.in_constraint_batch_at_roll(
+                    ephemeris,
+                    target_ras,
+                    target_decs,
+                    time_indices,
+                    roll_deg,
+                )
+            })
+            .collect();
+        let results = results?;
+        let n_targets = target_ras.len();
+        if results.is_empty() {
+            return Ok(Array2::from_elem((n_targets, n_times), true));
+        }
+        let mut result = results[0].clone();
+        for sub_result in &results[1..] {
+            for i in 0..n_targets {
+                for j in 0..n_times {
+                    result[[i, j]] = result[[i, j]] && sub_result[[i, j]];
+                }
+            }
+        }
+        Ok(result)
+    }
+
     fn is_roll_dependent(&self) -> bool {
         self.constraints.iter().any(|c| c.is_roll_dependent())
     }
@@ -530,6 +574,50 @@ impl ConstraintEvaluator for OrEvaluator {
         Ok(result)
     }
 
+    fn in_constraint_batch_at_roll(
+        &self,
+        ephemeris: &dyn crate::ephemeris::ephemeris_common::EphemerisBase,
+        target_ras: &[f64],
+        target_decs: &[f64],
+        time_indices: Option<&[usize]>,
+        roll_deg: f64,
+    ) -> pyo3::PyResult<Array2<bool>> {
+        if target_ras.len() != target_decs.len() {
+            return Err(pyo3::exceptions::PyValueError::new_err(
+                "target_ras and target_decs must have the same length",
+            ));
+        }
+        let times = ephemeris.get_times()?;
+        let n_times = time_indices.map(|idx| idx.len()).unwrap_or(times.len());
+        let results: Result<Vec<_>, _> = self
+            .constraints
+            .iter()
+            .map(|c| {
+                c.in_constraint_batch_at_roll(
+                    ephemeris,
+                    target_ras,
+                    target_decs,
+                    time_indices,
+                    roll_deg,
+                )
+            })
+            .collect();
+        let results = results?;
+        let n_targets = target_ras.len();
+        if results.is_empty() {
+            return Ok(Array2::from_elem((n_targets, n_times), false));
+        }
+        let mut result = results[0].clone();
+        for sub_result in &results[1..] {
+            for i in 0..n_targets {
+                for j in 0..n_times {
+                    result[[i, j]] = result[[i, j]] || sub_result[[i, j]];
+                }
+            }
+        }
+        Ok(result)
+    }
+
     fn is_roll_dependent(&self) -> bool {
         self.constraints.iter().any(|c| c.is_roll_dependent())
     }
@@ -737,6 +825,33 @@ impl ConstraintEvaluator for NotEvaluator {
 
         // NOT logic: invert all values
         Ok(sub_result.into_iter().map(|v| !v).collect())
+    }
+
+    fn in_constraint_batch_at_roll(
+        &self,
+        ephemeris: &dyn crate::ephemeris::ephemeris_common::EphemerisBase,
+        target_ras: &[f64],
+        target_decs: &[f64],
+        time_indices: Option<&[usize]>,
+        roll_deg: f64,
+    ) -> pyo3::PyResult<Array2<bool>> {
+        let times = ephemeris.get_times()?;
+        let sub_result = self.constraint.in_constraint_batch_at_roll(
+            ephemeris,
+            target_ras,
+            target_decs,
+            time_indices,
+            roll_deg,
+        )?;
+        let n_targets = target_ras.len();
+        let n_times = time_indices.map(|idx| idx.len()).unwrap_or(times.len());
+        let mut result = Array2::from_elem((n_targets, n_times), false);
+        for i in 0..n_targets {
+            for j in 0..n_times {
+                result[[i, j]] = !sub_result[[i, j]];
+            }
+        }
+        Ok(result)
     }
 
     fn is_roll_dependent(&self) -> bool {
@@ -962,6 +1077,46 @@ impl ConstraintEvaluator for XorEvaluator {
             result.push(violation_count == 1);
         }
 
+        Ok(result)
+    }
+
+    fn in_constraint_batch_at_roll(
+        &self,
+        ephemeris: &dyn crate::ephemeris::ephemeris_common::EphemerisBase,
+        target_ras: &[f64],
+        target_decs: &[f64],
+        time_indices: Option<&[usize]>,
+        roll_deg: f64,
+    ) -> pyo3::PyResult<Array2<bool>> {
+        if target_ras.len() != target_decs.len() {
+            return Err(pyo3::exceptions::PyValueError::new_err(
+                "target_ras and target_decs must have the same length",
+            ));
+        }
+        let times = ephemeris.get_times()?;
+        let n_times = time_indices.map(|idx| idx.len()).unwrap_or(times.len());
+        let results: Result<Vec<_>, _> = self
+            .constraints
+            .iter()
+            .map(|c| {
+                c.in_constraint_batch_at_roll(
+                    ephemeris,
+                    target_ras,
+                    target_decs,
+                    time_indices,
+                    roll_deg,
+                )
+            })
+            .collect();
+        let results = results?;
+        let n_targets = target_ras.len();
+        let mut result = Array2::from_elem((n_targets, n_times), false);
+        for i in 0..n_targets {
+            for j in 0..n_times {
+                let count = results.iter().filter(|r| r[[i, j]]).count();
+                result[[i, j]] = count == 1;
+            }
+        }
         Ok(result)
     }
 
@@ -1203,6 +1358,54 @@ impl ConstraintEvaluator for AtLeastEvaluator {
             result.push(violation_count >= self.min_violated);
         }
 
+        Ok(result)
+    }
+
+    fn in_constraint_batch_at_roll(
+        &self,
+        ephemeris: &dyn crate::ephemeris::ephemeris_common::EphemerisBase,
+        target_ras: &[f64],
+        target_decs: &[f64],
+        time_indices: Option<&[usize]>,
+        roll_deg: f64,
+    ) -> pyo3::PyResult<Array2<bool>> {
+        if target_ras.len() != target_decs.len() {
+            return Err(pyo3::exceptions::PyValueError::new_err(
+                "target_ras and target_decs must have the same length",
+            ));
+        }
+        let times = ephemeris.get_times()?;
+        let n_times = time_indices.map(|idx| idx.len()).unwrap_or(times.len());
+        let results: Result<Vec<_>, _> = self
+            .constraints
+            .iter()
+            .map(|c| {
+                c.in_constraint_batch_at_roll(
+                    ephemeris,
+                    target_ras,
+                    target_decs,
+                    time_indices,
+                    roll_deg,
+                )
+            })
+            .collect();
+        let results = results?;
+        let n_targets = target_ras.len();
+        let mut result = Array2::from_elem((n_targets, n_times), false);
+        for i in 0..n_targets {
+            for j in 0..n_times {
+                let mut count = 0usize;
+                for sub_result in &results {
+                    if sub_result[[i, j]] {
+                        count += 1;
+                        if count >= self.min_violated {
+                            break;
+                        }
+                    }
+                }
+                result[[i, j]] = count >= self.min_violated;
+            }
+        }
         Ok(result)
     }
 

--- a/src/constraints/constraint_wrapper/field_of_regard.rs
+++ b/src/constraints/constraint_wrapper/field_of_regard.rs
@@ -10,9 +10,10 @@ use pyo3::prelude::*;
 use std::f64::consts::PI;
 use std::sync::{Arc, OnceLock, RwLock};
 
-/// Default number of roll-angle samples for free-roll field-of-regard sweeps.
-/// 72 samples gives 5° resolution, sufficient for Fibonacci-sphere accuracy.
-pub(super) const DEFAULT_N_ROLL_SAMPLES: usize = 72;
+/// Default number of roll-angle samples for constraint evaluation roll sweeps.
+/// 360 samples gives 1° resolution, matching the Python DEFAULT_N_ROLL_SAMPLES constant.
+/// For field-of-regard calculations, users can override to 72 (5° resolution) for faster evaluation.
+pub(super) const DEFAULT_N_ROLL_SAMPLES: usize = 360;
 
 /// Default number of Fibonacci-sphere sky samples for field-of-regard integration.
 pub(super) const DEFAULT_N_POINTS: usize = 20_000;

--- a/src/constraints/constraint_wrapper/json_parser.rs
+++ b/src/constraints/constraint_wrapper/json_parser.rs
@@ -11,7 +11,7 @@ use crate::constraints::moon_proximity::MoonProximityConfig;
 use crate::constraints::orbit_pole::OrbitPoleConfig;
 use crate::constraints::orbit_ram::OrbitRamConfig;
 use crate::constraints::saa::SAAConfig;
-use crate::constraints::solar_roll::SolarRollConfig;
+use crate::constraints::solar_roll::{default_panel_normal, SolarRollConfig};
 use crate::constraints::sun_proximity::SunProximityConfig;
 use pyo3::PyResult;
 use serde::Deserialize;
@@ -188,6 +188,8 @@ enum ConstraintSpec {
         tolerance_deg: f64,
         #[serde(default)]
         roll_deg: Option<f64>,
+        #[serde(default = "default_panel_normal")]
+        panel_normal: [f64; 3],
     },
 }
 
@@ -417,9 +419,11 @@ impl ConstraintSpec {
             ConstraintSpec::SolarRoll {
                 tolerance_deg,
                 roll_deg,
+                panel_normal,
             } => Ok(SolarRollConfig {
                 tolerance_deg,
                 roll_deg,
+                panel_normal,
             }
             .to_evaluator()),
         }

--- a/src/constraints/constraint_wrapper/json_parser.rs
+++ b/src/constraints/constraint_wrapper/json_parser.rs
@@ -11,6 +11,7 @@ use crate::constraints::moon_proximity::MoonProximityConfig;
 use crate::constraints::orbit_pole::OrbitPoleConfig;
 use crate::constraints::orbit_ram::OrbitRamConfig;
 use crate::constraints::saa::SAAConfig;
+use crate::constraints::solar_roll::SolarRollConfig;
 use crate::constraints::sun_proximity::SunProximityConfig;
 use pyo3::PyResult;
 use serde::Deserialize;
@@ -179,6 +180,12 @@ enum ConstraintSpec {
         stars: Vec<[f64; 2]>,
         fov_radius: Option<f64>,
         fov_polygon: Option<Vec<[f64; 2]>>,
+        #[serde(default)]
+        roll_deg: Option<f64>,
+    },
+    #[serde(rename = "solar_roll")]
+    SolarRoll {
+        tolerance_deg: f64,
         #[serde(default)]
         roll_deg: Option<f64>,
     },
@@ -404,6 +411,14 @@ impl ConstraintSpec {
                 stars,
                 fov_radius,
                 fov_polygon,
+                roll_deg,
+            }
+            .to_evaluator()),
+            ConstraintSpec::SolarRoll {
+                tolerance_deg,
+                roll_deg,
+            } => Ok(SolarRollConfig {
+                tolerance_deg,
                 roll_deg,
             }
             .to_evaluator()),

--- a/src/constraints/constraint_wrapper/py_api.rs
+++ b/src/constraints/constraint_wrapper/py_api.rs
@@ -70,6 +70,7 @@ impl PyConstraint {
         let is_boresight_offset = constraint_type == "boresight_offset";
         let is_bright_star = constraint_type == "bright_star";
         let is_body_polygon = constraint_type == "body" && config.get("fov_polygon").is_some();
+        let is_solar_roll = constraint_type == "solar_roll";
 
         // Bright star or body proximity with a polygon FoV: inject target_roll as roll_deg
         // so the evaluator rotates the polygon to the requested angle.  Both constraint types
@@ -79,6 +80,16 @@ impl PyConstraint {
                 if let Some(obj) = config.as_object_mut() {
                     obj.insert("roll_deg".to_string(), serde_json::json!(target_roll_deg));
                 }
+            }
+            let evaluator = parse_constraint_json(&config)?;
+            return f(&*evaluator);
+        }
+
+        // SolarRoll: inject the spacecraft roll so the evaluator can compare to the
+        // solar-optimal roll.  Handled internally — bypass the BoresightOffset wrapper.
+        if is_solar_roll {
+            if let Some(obj) = config.as_object_mut() {
+                obj.insert("roll_deg".to_string(), serde_json::json!(target_roll_deg));
             }
             let evaluator = parse_constraint_json(&config)?;
             return f(&*evaluator);

--- a/src/constraints/constraint_wrapper/py_api.rs
+++ b/src/constraints/constraint_wrapper/py_api.rs
@@ -34,6 +34,75 @@ use super::json_parser::parse_constraint_json;
 use super::json_to_py::json_to_pyobject;
 use super::roll_range::run_roll_sweep;
 
+/// Recursively inject `roll_deg` into every roll-sensitive leaf node in a
+/// constraint JSON tree so the entire combined constraint is evaluated at the
+/// same spacecraft roll angle in a single pass.
+///
+/// Nodes updated:
+///   - `solar_roll`                         → sets `roll_deg`
+///   - `body` with `fov_polygon`            → sets `roll_deg`
+///   - `bright_star` with `fov_polygon`     → sets `roll_deg`
+///   - `boresight_offset`                   → adds sweep roll to existing `roll_deg`
+///   - compound nodes (or/and/not/xor/…)    → recurse into children
+///   - everything else                      → unchanged (roll-independent)
+fn inject_roll_into_json(config: &mut serde_json::Value, roll_deg: f64) {
+    let ctype = config
+        .get("type")
+        .and_then(|v| v.as_str())
+        .map(str::to_owned);
+    match ctype.as_deref() {
+        Some("solar_roll") => {
+            if let Some(obj) = config.as_object_mut() {
+                obj.insert("roll_deg".to_string(), serde_json::json!(roll_deg));
+            }
+        }
+        Some("body") if config.get("fov_polygon").is_some() => {
+            if let Some(obj) = config.as_object_mut() {
+                obj.insert("roll_deg".to_string(), serde_json::json!(roll_deg));
+            }
+        }
+        Some("bright_star") if config.get("fov_polygon").is_some() => {
+            if let Some(obj) = config.as_object_mut() {
+                obj.insert("roll_deg".to_string(), serde_json::json!(roll_deg));
+            }
+        }
+        Some("boresight_offset") => {
+            let base = config
+                .get("roll_deg")
+                .and_then(|v| v.as_f64())
+                .unwrap_or(0.0);
+            let clockwise = config
+                .get("roll_clockwise")
+                .and_then(|v| v.as_bool())
+                .unwrap_or(false);
+            let combined = if clockwise {
+                base - roll_deg
+            } else {
+                base + roll_deg
+            };
+            if let Some(obj) = config.as_object_mut() {
+                obj.insert("roll_deg".to_string(), serde_json::json!(combined));
+            }
+            if let Some(inner) = config.get_mut("constraint") {
+                inject_roll_into_json(inner, roll_deg);
+            }
+        }
+        Some("or") | Some("and") | Some("xor") | Some("at_least") => {
+            if let Some(arr) = config.get_mut("constraints").and_then(|v| v.as_array_mut()) {
+                for child in arr.iter_mut() {
+                    inject_roll_into_json(child, roll_deg);
+                }
+            }
+        }
+        Some("not") => {
+            if let Some(inner) = config.get_mut("constraint") {
+                inject_roll_into_json(inner, roll_deg);
+            }
+        }
+        _ => {}
+    }
+}
+
 /// Python-facing constraint evaluator
 ///
 /// This wraps the Rust constraint system and provides a convenient Python API.
@@ -1909,8 +1978,79 @@ impl PyConstraint {
             None
         };
 
-        // If no per-target rolls, use uniform None roll for all targets
+        // target_rolls=None means "evaluate at all rolls and report targets constrained at every
+        // roll" (i.e., no valid roll exists).  For roll-dependent constraints the sweep must be
+        // coordinated: the same roll angle is injected into every sub-constraint simultaneously
+        // so that, e.g., SolarRollConstraint and BodyConstraint share the same roll value.
         if target_rolls.is_none() {
+            if self.evaluator.is_roll_dependent() {
+                // Sweep roll angles.  A target is constrained (true) only when EVERY roll
+                // violates at least one sub-constraint, meaning no valid roll exists.
+                let roll_step = 360.0 / DEFAULT_N_ROLL_SAMPLES as f64;
+                let mut acc: Option<ndarray::Array2<bool>> = None;
+
+                for step in 0..DEFAULT_N_ROLL_SAMPLES {
+                    let roll_deg = step as f64 * roll_step;
+
+                    let mut config: serde_json::Value = serde_json::from_str(&self.config_json)
+                        .map_err(|e| pyo3::exceptions::PyValueError::new_err(e.to_string()))?;
+                    inject_roll_into_json(&mut config, roll_deg);
+                    let evaluator = parse_constraint_json(&config)?;
+
+                    let step_result = if let Ok(ephem) = bound.extract::<PyRef<TLEEphemeris>>() {
+                        evaluator.in_constraint_batch(
+                            &*ephem as &dyn EphemerisBase,
+                            &target_ras,
+                            &target_decs,
+                            time_indices.as_deref(),
+                        )?
+                    } else if let Ok(ephem) = bound.extract::<PyRef<SPICEEphemeris>>() {
+                        evaluator.in_constraint_batch(
+                            &*ephem as &dyn EphemerisBase,
+                            &target_ras,
+                            &target_decs,
+                            time_indices.as_deref(),
+                        )?
+                    } else if let Ok(ephem) = bound.extract::<PyRef<GroundEphemeris>>() {
+                        evaluator.in_constraint_batch(
+                            &*ephem as &dyn EphemerisBase,
+                            &target_ras,
+                            &target_decs,
+                            time_indices.as_deref(),
+                        )?
+                    } else if let Ok(ephem) = bound.extract::<PyRef<OEMEphemeris>>() {
+                        evaluator.in_constraint_batch(
+                            &*ephem as &dyn EphemerisBase,
+                            &target_ras,
+                            &target_decs,
+                            time_indices.as_deref(),
+                        )?
+                    } else if let Ok(ephem) = bound.extract::<PyRef<FileEphemeris>>() {
+                        evaluator.in_constraint_batch(
+                            &*ephem as &dyn EphemerisBase,
+                            &target_ras,
+                            &target_decs,
+                            time_indices.as_deref(),
+                        )?
+                    } else {
+                        return Err(pyo3::exceptions::PyTypeError::new_err(
+                            "Unsupported ephemeris type",
+                        ));
+                    };
+
+                    match acc {
+                        None => acc = Some(step_result),
+                        Some(ref mut a) => a.zip_mut_with(&step_result, |x, &y| *x &= y),
+                    }
+                }
+
+                let result_array =
+                    acc.unwrap_or_else(|| ndarray::Array2::from_elem((target_ras.len(), 0), false));
+                use numpy::IntoPyArray;
+                return Ok(result_array.into_pyarray(py).into());
+            }
+
+            // Roll-independent: original behaviour — evaluate with the stored evaluator.
             let result_array = self.with_effective_evaluator(None, |evaluator| {
                 if let Ok(ephem) = bound.extract::<PyRef<TLEEphemeris>>() {
                     return evaluator.in_constraint_batch(
@@ -1952,13 +2092,11 @@ impl PyConstraint {
                         time_indices.as_deref(),
                     );
                 }
-
                 Err(pyo3::exceptions::PyTypeError::new_err(
                     "Unsupported ephemeris type. Expected TLEEphemeris, SPICEEphemeris, GroundEphemeris, or OEMEphemeris",
                 ))
             })?;
 
-            // Convert to numpy array
             use numpy::IntoPyArray;
             return Ok(result_array.into_pyarray(py).into());
         }

--- a/src/constraints/constraint_wrapper/py_api.rs
+++ b/src/constraints/constraint_wrapper/py_api.rs
@@ -34,75 +34,6 @@ use super::json_parser::parse_constraint_json;
 use super::json_to_py::json_to_pyobject;
 use super::roll_range::run_roll_sweep;
 
-/// Recursively inject `roll_deg` into every roll-sensitive leaf node in a
-/// constraint JSON tree so the entire combined constraint is evaluated at the
-/// same spacecraft roll angle in a single pass.
-///
-/// Nodes updated:
-///   - `solar_roll`                         → sets `roll_deg`
-///   - `body` with `fov_polygon`            → sets `roll_deg`
-///   - `bright_star` with `fov_polygon`     → sets `roll_deg`
-///   - `boresight_offset`                   → adds sweep roll to existing `roll_deg`
-///   - compound nodes (or/and/not/xor/…)    → recurse into children
-///   - everything else                      → unchanged (roll-independent)
-fn inject_roll_into_json(config: &mut serde_json::Value, roll_deg: f64) {
-    let ctype = config
-        .get("type")
-        .and_then(|v| v.as_str())
-        .map(str::to_owned);
-    match ctype.as_deref() {
-        Some("solar_roll") => {
-            if let Some(obj) = config.as_object_mut() {
-                obj.insert("roll_deg".to_string(), serde_json::json!(roll_deg));
-            }
-        }
-        Some("body") if config.get("fov_polygon").is_some() => {
-            if let Some(obj) = config.as_object_mut() {
-                obj.insert("roll_deg".to_string(), serde_json::json!(roll_deg));
-            }
-        }
-        Some("bright_star") if config.get("fov_polygon").is_some() => {
-            if let Some(obj) = config.as_object_mut() {
-                obj.insert("roll_deg".to_string(), serde_json::json!(roll_deg));
-            }
-        }
-        Some("boresight_offset") => {
-            let base = config
-                .get("roll_deg")
-                .and_then(|v| v.as_f64())
-                .unwrap_or(0.0);
-            let clockwise = config
-                .get("roll_clockwise")
-                .and_then(|v| v.as_bool())
-                .unwrap_or(false);
-            let combined = if clockwise {
-                base - roll_deg
-            } else {
-                base + roll_deg
-            };
-            if let Some(obj) = config.as_object_mut() {
-                obj.insert("roll_deg".to_string(), serde_json::json!(combined));
-            }
-            if let Some(inner) = config.get_mut("constraint") {
-                inject_roll_into_json(inner, roll_deg);
-            }
-        }
-        Some("or") | Some("and") | Some("xor") | Some("at_least") => {
-            if let Some(arr) = config.get_mut("constraints").and_then(|v| v.as_array_mut()) {
-                for child in arr.iter_mut() {
-                    inject_roll_into_json(child, roll_deg);
-                }
-            }
-        }
-        Some("not") => {
-            if let Some(inner) = config.get_mut("constraint") {
-                inject_roll_into_json(inner, roll_deg);
-            }
-        }
-        _ => {}
-    }
-}
-
 /// Python-facing constraint evaluator
 ///
 /// This wraps the Rust constraint system and provides a convenient Python API.
@@ -1986,62 +1917,51 @@ impl PyConstraint {
             if self.evaluator.is_roll_dependent() {
                 // Sweep roll angles.  A target is constrained (true) only when EVERY roll
                 // violates at least one sub-constraint, meaning no valid roll exists.
+                // Extract the ephemeris once and call in_constraint_batch_at_roll in the
+                // loop — no JSON round-trips, no evaluator reconstruction per step.
                 let roll_step = 360.0 / DEFAULT_N_ROLL_SAMPLES as f64;
                 let mut acc: Option<ndarray::Array2<bool>> = None;
 
-                for step in 0..DEFAULT_N_ROLL_SAMPLES {
-                    let roll_deg = step as f64 * roll_step;
+                macro_rules! do_roll_sweep {
+                    ($ephem:expr) => {{
+                        let ephem_ref = &*$ephem as &dyn EphemerisBase;
+                        for step in 0..DEFAULT_N_ROLL_SAMPLES {
+                            // Early break: once all targets are accessible no roll can block them.
+                            if let Some(ref a) = acc {
+                                if a.iter().all(|&b| !b) {
+                                    break;
+                                }
+                            }
+                            let roll_deg = step as f64 * roll_step;
+                            let step_result = self.evaluator.in_constraint_batch_at_roll(
+                                ephem_ref,
+                                &target_ras,
+                                &target_decs,
+                                time_indices.as_deref(),
+                                roll_deg,
+                            )?;
+                            match acc {
+                                None => acc = Some(step_result),
+                                Some(ref mut a) => a.zip_mut_with(&step_result, |x, &y| *x &= y),
+                            }
+                        }
+                    }};
+                }
 
-                    let mut config: serde_json::Value = serde_json::from_str(&self.config_json)
-                        .map_err(|e| pyo3::exceptions::PyValueError::new_err(e.to_string()))?;
-                    inject_roll_into_json(&mut config, roll_deg);
-                    let evaluator = parse_constraint_json(&config)?;
-
-                    let step_result = if let Ok(ephem) = bound.extract::<PyRef<TLEEphemeris>>() {
-                        evaluator.in_constraint_batch(
-                            &*ephem as &dyn EphemerisBase,
-                            &target_ras,
-                            &target_decs,
-                            time_indices.as_deref(),
-                        )?
-                    } else if let Ok(ephem) = bound.extract::<PyRef<SPICEEphemeris>>() {
-                        evaluator.in_constraint_batch(
-                            &*ephem as &dyn EphemerisBase,
-                            &target_ras,
-                            &target_decs,
-                            time_indices.as_deref(),
-                        )?
-                    } else if let Ok(ephem) = bound.extract::<PyRef<GroundEphemeris>>() {
-                        evaluator.in_constraint_batch(
-                            &*ephem as &dyn EphemerisBase,
-                            &target_ras,
-                            &target_decs,
-                            time_indices.as_deref(),
-                        )?
-                    } else if let Ok(ephem) = bound.extract::<PyRef<OEMEphemeris>>() {
-                        evaluator.in_constraint_batch(
-                            &*ephem as &dyn EphemerisBase,
-                            &target_ras,
-                            &target_decs,
-                            time_indices.as_deref(),
-                        )?
-                    } else if let Ok(ephem) = bound.extract::<PyRef<FileEphemeris>>() {
-                        evaluator.in_constraint_batch(
-                            &*ephem as &dyn EphemerisBase,
-                            &target_ras,
-                            &target_decs,
-                            time_indices.as_deref(),
-                        )?
-                    } else {
-                        return Err(pyo3::exceptions::PyTypeError::new_err(
-                            "Unsupported ephemeris type",
-                        ));
-                    };
-
-                    match acc {
-                        None => acc = Some(step_result),
-                        Some(ref mut a) => a.zip_mut_with(&step_result, |x, &y| *x &= y),
-                    }
+                if let Ok(ephem) = bound.extract::<PyRef<TLEEphemeris>>() {
+                    do_roll_sweep!(ephem);
+                } else if let Ok(ephem) = bound.extract::<PyRef<SPICEEphemeris>>() {
+                    do_roll_sweep!(ephem);
+                } else if let Ok(ephem) = bound.extract::<PyRef<GroundEphemeris>>() {
+                    do_roll_sweep!(ephem);
+                } else if let Ok(ephem) = bound.extract::<PyRef<OEMEphemeris>>() {
+                    do_roll_sweep!(ephem);
+                } else if let Ok(ephem) = bound.extract::<PyRef<FileEphemeris>>() {
+                    do_roll_sweep!(ephem);
+                } else {
+                    return Err(pyo3::exceptions::PyTypeError::new_err(
+                        "Unsupported ephemeris type",
+                    ));
                 }
 
                 let result_array =

--- a/src/constraints/constraint_wrapper/py_api.rs
+++ b/src/constraints/constraint_wrapper/py_api.rs
@@ -1600,26 +1600,10 @@ impl PyConstraint {
             all_groups.push((group_indices, group_array));
         }
 
-        // Reconstruct results in original order
-        let mut final_results: Vec<Vec<bool>> = vec![vec![false; n_times]; target_ras.len()];
-
-        for (group_indices, group_array) in all_groups {
-            for (row_in_group, &orig_idx) in group_indices.iter().enumerate() {
-                for col in 0..n_times {
-                    final_results[orig_idx][col] = group_array[[row_in_group, col]];
-                }
-            }
-        }
+        let arr = Self::reassemble_grouped_batch_results(target_ras.len(), n_times, all_groups)?;
 
         // Convert to numpy array
         use numpy::IntoPyArray;
-        let arr: numpy::ndarray::Array2<bool> = numpy::ndarray::Array2::from_shape_vec(
-            (target_ras.len(), n_times),
-            final_results.into_iter().flatten().collect(),
-        )
-        .map_err(|e| {
-            pyo3::exceptions::PyValueError::new_err(format!("Failed to create array: {}", e))
-        })?;
         Ok(arr.into_pyarray(py).into())
     }
 

--- a/src/constraints/constraint_wrapper/py_api.rs
+++ b/src/constraints/constraint_wrapper/py_api.rs
@@ -71,15 +71,16 @@ impl PyConstraint {
         target_ras: &[f64],
         target_decs: &[f64],
         time_indices: Option<&[usize]>,
+        n_roll_samples: usize,
     ) -> PyResult<ndarray::Array2<bool>> {
         if !evaluator.is_roll_dependent() {
             return evaluator.in_constraint_batch(ephemeris, target_ras, target_decs, time_indices);
         }
 
         // Sweep roll angles and require violation at every roll to mark a cell violated.
-        let roll_step = 360.0 / DEFAULT_N_ROLL_SAMPLES as f64;
+        let roll_step = 360.0 / n_roll_samples as f64;
         let mut acc: Option<ndarray::Array2<bool>> = None;
-        for step in 0..DEFAULT_N_ROLL_SAMPLES {
+        for step in 0..n_roll_samples {
             if let Some(ref a) = acc {
                 if a.iter().all(|&b| !b) {
                     break;
@@ -213,6 +214,7 @@ impl PyConstraint {
             &[target_ra],
             &[target_dec],
             time_indices.as_deref(),
+            DEFAULT_N_ROLL_SAMPLES,
         )?;
 
         // Get the times we evaluated
@@ -259,6 +261,7 @@ impl PyConstraint {
             target_ras,
             target_decs,
             time_indices.as_deref(),
+            DEFAULT_N_ROLL_SAMPLES,
         )?;
 
         let all_times = ephemeris.get_times()?;
@@ -1927,7 +1930,7 @@ impl PyConstraint {
     ///     >>> violations.shape  # (3, n_times)
     ///     >>> violations[0, :]  # Violations for first target across all times
     #[allow(clippy::too_many_arguments)]
-    #[pyo3(signature = (ephemeris, target_ras, target_decs, times=None, indices=None, target_rolls=None))]
+    #[pyo3(signature = (ephemeris, target_ras, target_decs, times=None, indices=None, target_rolls=None, n_roll_samples=DEFAULT_N_ROLL_SAMPLES))]
     fn in_constraint_batch(
         &self,
         py: Python,
@@ -1937,7 +1940,13 @@ impl PyConstraint {
         times: Option<&Bound<PyAny>>,
         indices: Option<&Bound<PyAny>>,
         target_rolls: Option<Vec<f64>>,
+        n_roll_samples: usize,
     ) -> PyResult<Py<PyAny>> {
+        if n_roll_samples == 0 {
+            return Err(pyo3::exceptions::PyValueError::new_err(
+                "n_roll_samples must be greater than 0",
+            ));
+        }
         if target_ras.len() != target_decs.len() {
             return Err(pyo3::exceptions::PyValueError::new_err(
                 "target_ras and target_decs must have the same length",
@@ -1978,13 +1987,13 @@ impl PyConstraint {
                 // violates at least one sub-constraint, meaning no valid roll exists.
                 // Extract the ephemeris once and call in_constraint_batch_at_roll in the
                 // loop — no JSON round-trips, no evaluator reconstruction per step.
-                let roll_step = 360.0 / DEFAULT_N_ROLL_SAMPLES as f64;
+                let roll_step = 360.0 / n_roll_samples as f64;
                 let mut acc: Option<ndarray::Array2<bool>> = None;
 
                 macro_rules! do_roll_sweep {
                     ($ephem:expr) => {{
                         let ephem_ref = &*$ephem as &dyn EphemerisBase;
-                        for step in 0..DEFAULT_N_ROLL_SAMPLES {
+                        for step in 0..n_roll_samples {
                             // Early break: once all targets are accessible no roll can block them.
                             if let Some(ref a) = acc {
                                 if a.iter().all(|&b| !b) {
@@ -2424,6 +2433,7 @@ impl PyConstraint {
             Some(bound_time),
             None,
             target_rolls,
+            DEFAULT_N_ROLL_SAMPLES,
         )?;
 
         // Extract the results for the single target (first row)

--- a/src/constraints/constraint_wrapper/py_api.rs
+++ b/src/constraints/constraint_wrapper/py_api.rs
@@ -33,6 +33,8 @@ use super::field_of_regard::DEFAULT_N_ROLL_SAMPLES;
 use super::json_parser::parse_constraint_json;
 use super::json_to_py::json_to_pyobject;
 use super::roll_range::run_roll_sweep;
+#[path = "py_api_helpers.rs"]
+mod py_api_helpers;
 
 /// Python-facing constraint evaluator
 ///
@@ -41,316 +43,6 @@ use super::roll_range::run_roll_sweep;
 pub struct PyConstraint {
     evaluator: Box<dyn ConstraintEvaluator>,
     config_json: String,
-}
-
-impl PyConstraint {
-    fn inject_solar_roll(config: &mut serde_json::Value, roll_deg: f64) {
-        let Some(obj) = config.as_object_mut() else {
-            return;
-        };
-
-        if obj.get("type").and_then(|v| v.as_str()) == Some("solar_roll") {
-            obj.insert("roll_deg".to_string(), serde_json::json!(roll_deg));
-        }
-
-        if let Some(inner) = obj.get_mut("constraint") {
-            Self::inject_solar_roll(inner, roll_deg);
-        }
-
-        if let Some(children) = obj.get_mut("constraints").and_then(|v| v.as_array_mut()) {
-            for child in children {
-                Self::inject_solar_roll(child, roll_deg);
-            }
-        }
-    }
-
-    fn in_constraint_batch_with_roll_sweep(
-        &self,
-        evaluator: &dyn ConstraintEvaluator,
-        ephemeris: &dyn EphemerisBase,
-        target_ras: &[f64],
-        target_decs: &[f64],
-        time_indices: Option<&[usize]>,
-        n_roll_samples: usize,
-    ) -> PyResult<ndarray::Array2<bool>> {
-        if !evaluator.is_roll_dependent() {
-            return evaluator.in_constraint_batch(ephemeris, target_ras, target_decs, time_indices);
-        }
-
-        // Sweep roll angles and require violation at every roll to mark a cell violated.
-        let roll_step = 360.0 / n_roll_samples as f64;
-        let mut acc: Option<ndarray::Array2<bool>> = None;
-        for step in 0..n_roll_samples {
-            if let Some(ref a) = acc {
-                if a.iter().all(|&b| !b) {
-                    break;
-                }
-            }
-            let roll_deg = step as f64 * roll_step;
-            let step_result = evaluator.in_constraint_batch_at_roll(
-                ephemeris,
-                target_ras,
-                target_decs,
-                time_indices,
-                roll_deg,
-            )?;
-            match acc {
-                None => acc = Some(step_result),
-                Some(ref mut a) => a.zip_mut_with(&step_result, |x, &y| *x &= y),
-            }
-        }
-
-        Ok(acc.unwrap_or_else(|| ndarray::Array2::from_elem((target_ras.len(), 0), false)))
-    }
-
-    fn with_effective_evaluator<T, F>(&self, target_roll: Option<f64>, f: F) -> PyResult<T>
-    where
-        F: FnOnce(&dyn ConstraintEvaluator) -> PyResult<T>,
-    {
-        let Some(target_roll_deg) = target_roll else {
-            return f(&*self.evaluator);
-        };
-
-        if !target_roll_deg.is_finite() {
-            return Err(pyo3::exceptions::PyValueError::new_err(
-                "target_roll must be a finite number",
-            ));
-        }
-
-        let mut config: serde_json::Value = serde_json::from_str(&self.config_json)
-            .map_err(|e| pyo3::exceptions::PyValueError::new_err(e.to_string()))?;
-
-        Self::inject_solar_roll(&mut config, target_roll_deg);
-
-        let constraint_type = config
-            .get("type")
-            .and_then(|v| v.as_str())
-            .unwrap_or("")
-            .to_owned();
-
-        let is_boresight_offset = constraint_type == "boresight_offset";
-        let is_bright_star = constraint_type == "bright_star";
-        let is_body_polygon = constraint_type == "body" && config.get("fov_polygon").is_some();
-        let is_solar_roll = constraint_type == "solar_roll";
-
-        // Bright star or body proximity with a polygon FoV: inject target_roll as roll_deg
-        // so the evaluator rotates the polygon to the requested angle.  Both constraint types
-        // handle roll internally, so we bypass the BoresightOffset wrapper.
-        if is_bright_star || is_body_polygon {
-            if config.get("fov_polygon").is_some() {
-                if let Some(obj) = config.as_object_mut() {
-                    obj.insert("roll_deg".to_string(), serde_json::json!(target_roll_deg));
-                }
-            }
-            let evaluator = parse_constraint_json(&config)?;
-            return f(&*evaluator);
-        }
-
-        // SolarRoll: inject the spacecraft roll so the evaluator can compare to the
-        // solar-optimal roll.  Handled internally — bypass the BoresightOffset wrapper.
-        if is_solar_roll {
-            let evaluator = parse_constraint_json(&config)?;
-            return f(&*evaluator);
-        }
-
-        if is_boresight_offset {
-            let base_roll_deg = config
-                .get("roll_deg")
-                .and_then(|v| v.as_f64())
-                .unwrap_or(0.0);
-            let base_clockwise = config
-                .get("roll_clockwise")
-                .and_then(|v| v.as_bool())
-                .unwrap_or(false);
-
-            // Match RustConstraintMixin semantics: add evaluation-time roll in the
-            // configured command convention.
-            let signed_target_roll = if base_clockwise {
-                -target_roll_deg
-            } else {
-                target_roll_deg
-            };
-
-            if let Some(obj) = config.as_object_mut() {
-                obj.insert(
-                    "roll_deg".to_string(),
-                    serde_json::json!(base_roll_deg + signed_target_roll),
-                );
-            }
-        } else {
-            config = serde_json::json!({
-                "type": "boresight_offset",
-                "constraint": config,
-                "roll_deg": target_roll_deg,
-                "roll_clockwise": false,
-                "roll_reference": "north",
-                "pitch_deg": 0.0,
-                "yaw_deg": 0.0
-            });
-        }
-
-        let evaluator = parse_constraint_json(&config)?;
-        f(&*evaluator)
-    }
-
-    /// Internal helper to evaluate against any Ephemeris implementing EphemerisBase
-    #[allow(deprecated)]
-    fn eval_with_ephemeris<E: EphemerisBase>(
-        &self,
-        evaluator: &dyn ConstraintEvaluator,
-        ephemeris: &E,
-        target_ra: f64,
-        target_dec: f64,
-        time_indices: Option<Vec<usize>>,
-    ) -> PyResult<ConstraintResult> {
-        // PERFORMANCE OPTIMIZATION: Use fast batch path internally
-        // Instead of the slow evaluate() that tracks violations step-by-step,
-        // use in_constraint_batch() which is 1700x faster, then construct violations from the result
-
-        // Call the fast batch evaluation for single target
-        let violation_array = self.in_constraint_batch_with_roll_sweep(
-            evaluator,
-            ephemeris,
-            &[target_ra],
-            &[target_dec],
-            time_indices.as_deref(),
-            DEFAULT_N_ROLL_SAMPLES,
-        )?;
-
-        // Get the times we evaluated
-        let all_times = ephemeris.get_times()?;
-        let times: Vec<_> = if let Some(ref indices) = time_indices {
-            indices.iter().map(|&i| all_times[i]).collect()
-        } else {
-            all_times.to_vec()
-        };
-
-        // Extract the boolean array for our single target (first row)
-        // Note: in_constraint_batch now consistently returns true when VIOLATED (matches track_violations)
-        let violated: Vec<bool> = (0..violation_array.ncols())
-            .map(|i| violation_array[[0, i]])
-            .collect();
-
-        // Track violations using the same helper function
-        let violations = crate::constraints::core::track_violations(
-            &times,
-            |i| (violated[i], if violated[i] { 1.0 } else { 0.0 }),
-            |_i, _is_open| evaluator.name(),
-        );
-
-        let all_satisfied = violations.is_empty();
-        Ok(ConstraintResult::new(
-            violations,
-            all_satisfied,
-            evaluator.name(),
-            times,
-        ))
-    }
-
-    fn eval_batch_with_ephemeris<E: EphemerisBase>(
-        &self,
-        evaluator: &dyn ConstraintEvaluator,
-        ephemeris: &E,
-        target_ras: &[f64],
-        target_decs: &[f64],
-        time_indices: Option<Vec<usize>>,
-    ) -> PyResult<Vec<ConstraintResult>> {
-        let violation_array = self.in_constraint_batch_with_roll_sweep(
-            evaluator,
-            ephemeris,
-            target_ras,
-            target_decs,
-            time_indices.as_deref(),
-            DEFAULT_N_ROLL_SAMPLES,
-        )?;
-
-        let all_times = ephemeris.get_times()?;
-        let times: Vec<_> = if let Some(ref indices) = time_indices {
-            indices.iter().map(|&i| all_times[i]).collect()
-        } else {
-            all_times.to_vec()
-        };
-
-        let mut results = Vec::with_capacity(target_ras.len());
-        for target_index in 0..target_ras.len() {
-            let violated: Vec<bool> = (0..violation_array.ncols())
-                .map(|i| violation_array[[target_index, i]])
-                .collect();
-
-            let violations = crate::constraints::core::track_violations(
-                &times,
-                |i| (violated[i], if violated[i] { 1.0 } else { 0.0 }),
-                |_i, _is_open| evaluator.name(),
-            );
-
-            let all_satisfied = violations.is_empty();
-            results.push(ConstraintResult::new(
-                violations,
-                all_satisfied,
-                evaluator.name(),
-                times.clone(),
-            ));
-        }
-
-        Ok(results)
-    }
-
-    /// Vectorized evaluation for moving bodies - evaluates all targets at their corresponding times
-    ///
-    /// For N targets at N times, this calls in_constraint_batch once with all N targets
-    /// Uses the efficient diagonal batch evaluation for moving bodies.
-    /// Each target_i is evaluated only at time_i, which is O(N) instead of O(N²).
-    fn eval_moving_body_batch_diagonal(
-        &self,
-        py: Python,
-        ephemeris: &Py<PyAny>,
-        target_ras: &[f64],
-        target_decs: &[f64],
-    ) -> PyResult<Vec<bool>> {
-        let n = target_ras.len();
-        if n == 0 {
-            return Ok(Vec::new());
-        }
-
-        let bound = ephemeris.bind(py);
-
-        // Use the efficient diagonal batch evaluation
-        if let Ok(ephem) = bound.extract::<PyRef<TLEEphemeris>>() {
-            self.evaluator.in_constraint_batch_diagonal(
-                &*ephem as &dyn EphemerisBase,
-                target_ras,
-                target_decs,
-            )
-        } else if let Ok(ephem) = bound.extract::<PyRef<SPICEEphemeris>>() {
-            self.evaluator.in_constraint_batch_diagonal(
-                &*ephem as &dyn EphemerisBase,
-                target_ras,
-                target_decs,
-            )
-        } else if let Ok(ephem) = bound.extract::<PyRef<GroundEphemeris>>() {
-            self.evaluator.in_constraint_batch_diagonal(
-                &*ephem as &dyn EphemerisBase,
-                target_ras,
-                target_decs,
-            )
-        } else if let Ok(ephem) = bound.extract::<PyRef<OEMEphemeris>>() {
-            self.evaluator.in_constraint_batch_diagonal(
-                &*ephem as &dyn EphemerisBase,
-                target_ras,
-                target_decs,
-            )
-        } else if let Ok(ephem) = bound.extract::<PyRef<FileEphemeris>>() {
-            self.evaluator.in_constraint_batch_diagonal(
-                &*ephem as &dyn EphemerisBase,
-                target_ras,
-                target_decs,
-            )
-        } else {
-            Err(pyo3::exceptions::PyTypeError::new_err(
-                "Unsupported ephemeris type. Expected TLEEphemeris, SPICEEphemeris, GroundEphemeris, or OEMEphemeris",
-            ))
-        }
-    }
 }
 
 #[pymethods]
@@ -1648,55 +1340,15 @@ impl PyConstraint {
         };
 
         self.with_effective_evaluator(target_roll, |evaluator| {
-            if let Ok(ephem) = bound.extract::<PyRef<TLEEphemeris>>() {
-                return self.eval_with_ephemeris(
+            self.with_ephemeris(bound, |ephem_ref| {
+                self.eval_with_ephemeris(
                     evaluator,
-                    &*ephem,
+                    ephem_ref,
                     target_ra,
                     target_dec,
                     time_indices.clone(),
-                );
-            }
-            if let Ok(ephem) = bound.extract::<PyRef<SPICEEphemeris>>() {
-                return self.eval_with_ephemeris(
-                    evaluator,
-                    &*ephem,
-                    target_ra,
-                    target_dec,
-                    time_indices.clone(),
-                );
-            }
-            if let Ok(ephem) = bound.extract::<PyRef<GroundEphemeris>>() {
-                return self.eval_with_ephemeris(
-                    evaluator,
-                    &*ephem,
-                    target_ra,
-                    target_dec,
-                    time_indices.clone(),
-                );
-            }
-            if let Ok(ephem) = bound.extract::<PyRef<OEMEphemeris>>() {
-                return self.eval_with_ephemeris(
-                    evaluator,
-                    &*ephem,
-                    target_ra,
-                    target_dec,
-                    time_indices.clone(),
-                );
-            }
-            if let Ok(ephem) = bound.extract::<PyRef<FileEphemeris>>() {
-                return self.eval_with_ephemeris(
-                    evaluator,
-                    &*ephem,
-                    target_ra,
-                    target_dec,
-                    time_indices.clone(),
-                );
-            }
-
-            Err(pyo3::exceptions::PyTypeError::new_err(
-                "Unsupported ephemeris type. Expected TLEEphemeris, SPICEEphemeris, GroundEphemeris, or OEMEphemeris",
-            ))
+                )
+            })
         })
     }
 
@@ -1745,55 +1397,15 @@ impl PyConstraint {
         // If no per-target rolls, use uniform None roll for all targets
         if target_rolls.is_none() {
             return self.with_effective_evaluator(None, |evaluator| {
-                if let Ok(ephem) = bound.extract::<PyRef<TLEEphemeris>>() {
-                    return self.eval_batch_with_ephemeris(
+                self.with_ephemeris(bound, |ephem_ref| {
+                    self.eval_batch_with_ephemeris(
                         evaluator,
-                        &*ephem,
+                        ephem_ref,
                         &target_ras,
                         &target_decs,
                         time_indices.clone(),
-                    );
-                }
-                if let Ok(ephem) = bound.extract::<PyRef<SPICEEphemeris>>() {
-                    return self.eval_batch_with_ephemeris(
-                        evaluator,
-                        &*ephem,
-                        &target_ras,
-                        &target_decs,
-                        time_indices.clone(),
-                    );
-                }
-                if let Ok(ephem) = bound.extract::<PyRef<GroundEphemeris>>() {
-                    return self.eval_batch_with_ephemeris(
-                        evaluator,
-                        &*ephem,
-                        &target_ras,
-                        &target_decs,
-                        time_indices.clone(),
-                    );
-                }
-                if let Ok(ephem) = bound.extract::<PyRef<OEMEphemeris>>() {
-                    return self.eval_batch_with_ephemeris(
-                        evaluator,
-                        &*ephem,
-                        &target_ras,
-                        &target_decs,
-                        time_indices.clone(),
-                    );
-                }
-                if let Ok(ephem) = bound.extract::<PyRef<FileEphemeris>>() {
-                    return self.eval_batch_with_ephemeris(
-                        evaluator,
-                        &*ephem,
-                        &target_ras,
-                        &target_decs,
-                        time_indices.clone(),
-                    );
-                }
-
-                Err(pyo3::exceptions::PyTypeError::new_err(
-                    "Unsupported ephemeris type. Expected TLEEphemeris, SPICEEphemeris, GroundEphemeris, or OEMEphemeris",
-                ))
+                    )
+                })
             });
         }
 
@@ -1822,55 +1434,15 @@ impl PyConstraint {
             let group_decs: Vec<f64> = group_indices.iter().map(|&i| target_decs[i]).collect();
 
             let group_results = self.with_effective_evaluator(Some(target_roll), |evaluator| {
-                if let Ok(ephem) = bound.extract::<PyRef<TLEEphemeris>>() {
-                    return self.eval_batch_with_ephemeris(
+                self.with_ephemeris(bound, |ephem_ref| {
+                    self.eval_batch_with_ephemeris(
                         evaluator,
-                        &*ephem,
+                        ephem_ref,
                         &group_ras,
                         &group_decs,
                         time_indices.clone(),
-                    );
-                }
-                if let Ok(ephem) = bound.extract::<PyRef<SPICEEphemeris>>() {
-                    return self.eval_batch_with_ephemeris(
-                        evaluator,
-                        &*ephem,
-                        &group_ras,
-                        &group_decs,
-                        time_indices.clone(),
-                    );
-                }
-                if let Ok(ephem) = bound.extract::<PyRef<GroundEphemeris>>() {
-                    return self.eval_batch_with_ephemeris(
-                        evaluator,
-                        &*ephem,
-                        &group_ras,
-                        &group_decs,
-                        time_indices.clone(),
-                    );
-                }
-                if let Ok(ephem) = bound.extract::<PyRef<OEMEphemeris>>() {
-                    return self.eval_batch_with_ephemeris(
-                        evaluator,
-                        &*ephem,
-                        &group_ras,
-                        &group_decs,
-                        time_indices.clone(),
-                    );
-                }
-                if let Ok(ephem) = bound.extract::<PyRef<FileEphemeris>>() {
-                    return self.eval_batch_with_ephemeris(
-                        evaluator,
-                        &*ephem,
-                        &group_ras,
-                        &group_decs,
-                        time_indices.clone(),
-                    );
-                }
-
-                Err(pyo3::exceptions::PyTypeError::new_err(
-                    "Unsupported ephemeris type. Expected TLEEphemeris, SPICEEphemeris, GroundEphemeris, or OEMEphemeris",
-                ))
+                    )
+                })
             })?;
 
             if group_results.len() != group_indices.len() {
@@ -1990,47 +1562,28 @@ impl PyConstraint {
                 let roll_step = 360.0 / n_roll_samples as f64;
                 let mut acc: Option<ndarray::Array2<bool>> = None;
 
-                macro_rules! do_roll_sweep {
-                    ($ephem:expr) => {{
-                        let ephem_ref = &*$ephem as &dyn EphemerisBase;
-                        for step in 0..n_roll_samples {
-                            // Early break: once all targets are accessible no roll can block them.
-                            if let Some(ref a) = acc {
-                                if a.iter().all(|&b| !b) {
-                                    break;
-                                }
-                            }
-                            let roll_deg = step as f64 * roll_step;
-                            let step_result = self.evaluator.in_constraint_batch_at_roll(
-                                ephem_ref,
-                                &target_ras,
-                                &target_decs,
-                                time_indices.as_deref(),
-                                roll_deg,
-                            )?;
-                            match acc {
-                                None => acc = Some(step_result),
-                                Some(ref mut a) => a.zip_mut_with(&step_result, |x, &y| *x &= y),
+                self.with_ephemeris(bound, |ephem_ref| {
+                    for step in 0..n_roll_samples {
+                        if let Some(ref a) = acc {
+                            if a.iter().all(|&b| !b) {
+                                break;
                             }
                         }
-                    }};
-                }
-
-                if let Ok(ephem) = bound.extract::<PyRef<TLEEphemeris>>() {
-                    do_roll_sweep!(ephem);
-                } else if let Ok(ephem) = bound.extract::<PyRef<SPICEEphemeris>>() {
-                    do_roll_sweep!(ephem);
-                } else if let Ok(ephem) = bound.extract::<PyRef<GroundEphemeris>>() {
-                    do_roll_sweep!(ephem);
-                } else if let Ok(ephem) = bound.extract::<PyRef<OEMEphemeris>>() {
-                    do_roll_sweep!(ephem);
-                } else if let Ok(ephem) = bound.extract::<PyRef<FileEphemeris>>() {
-                    do_roll_sweep!(ephem);
-                } else {
-                    return Err(pyo3::exceptions::PyTypeError::new_err(
-                        "Unsupported ephemeris type",
-                    ));
-                }
+                        let roll_deg = step as f64 * roll_step;
+                        let step_result = self.evaluator.in_constraint_batch_at_roll(
+                            ephem_ref,
+                            &target_ras,
+                            &target_decs,
+                            time_indices.as_deref(),
+                            roll_deg,
+                        )?;
+                        match acc {
+                            None => acc = Some(step_result),
+                            Some(ref mut a) => a.zip_mut_with(&step_result, |x, &y| *x &= y),
+                        }
+                    }
+                    Ok(())
+                })?;
 
                 let result_array =
                     acc.unwrap_or_else(|| ndarray::Array2::from_elem((target_ras.len(), 0), false));
@@ -2040,49 +1593,14 @@ impl PyConstraint {
 
             // Roll-independent: original behaviour — evaluate with the stored evaluator.
             let result_array = self.with_effective_evaluator(None, |evaluator| {
-                if let Ok(ephem) = bound.extract::<PyRef<TLEEphemeris>>() {
-                    return evaluator.in_constraint_batch(
-                        &*ephem as &dyn EphemerisBase,
+                self.with_ephemeris(bound, |ephem_ref| {
+                    evaluator.in_constraint_batch(
+                        ephem_ref,
                         &target_ras,
                         &target_decs,
                         time_indices.as_deref(),
-                    );
-                }
-                if let Ok(ephem) = bound.extract::<PyRef<SPICEEphemeris>>() {
-                    return evaluator.in_constraint_batch(
-                        &*ephem as &dyn EphemerisBase,
-                        &target_ras,
-                        &target_decs,
-                        time_indices.as_deref(),
-                    );
-                }
-                if let Ok(ephem) = bound.extract::<PyRef<GroundEphemeris>>() {
-                    return evaluator.in_constraint_batch(
-                        &*ephem as &dyn EphemerisBase,
-                        &target_ras,
-                        &target_decs,
-                        time_indices.as_deref(),
-                    );
-                }
-                if let Ok(ephem) = bound.extract::<PyRef<OEMEphemeris>>() {
-                    return evaluator.in_constraint_batch(
-                        &*ephem as &dyn EphemerisBase,
-                        &target_ras,
-                        &target_decs,
-                        time_indices.as_deref(),
-                    );
-                }
-                if let Ok(ephem) = bound.extract::<PyRef<FileEphemeris>>() {
-                    return evaluator.in_constraint_batch(
-                        &*ephem as &dyn EphemerisBase,
-                        &target_ras,
-                        &target_decs,
-                        time_indices.as_deref(),
-                    );
-                }
-                Err(pyo3::exceptions::PyTypeError::new_err(
-                    "Unsupported ephemeris type. Expected TLEEphemeris, SPICEEphemeris, GroundEphemeris, or OEMEphemeris",
-                ))
+                    )
+                })
             })?;
 
             use numpy::IntoPyArray;
@@ -2108,50 +1626,14 @@ impl PyConstraint {
             let group_decs: Vec<f64> = group_indices.iter().map(|&i| target_decs[i]).collect();
 
             let group_array = self.with_effective_evaluator(Some(target_roll), |evaluator| {
-                if let Ok(ephem) = bound.extract::<PyRef<TLEEphemeris>>() {
-                    return evaluator.in_constraint_batch(
-                        &*ephem as &dyn EphemerisBase,
+                self.with_ephemeris(bound, |ephem_ref| {
+                    evaluator.in_constraint_batch(
+                        ephem_ref,
                         &group_ras,
                         &group_decs,
                         time_indices.as_deref(),
-                    );
-                }
-                if let Ok(ephem) = bound.extract::<PyRef<SPICEEphemeris>>() {
-                    return evaluator.in_constraint_batch(
-                        &*ephem as &dyn EphemerisBase,
-                        &group_ras,
-                        &group_decs,
-                        time_indices.as_deref(),
-                    );
-                }
-                if let Ok(ephem) = bound.extract::<PyRef<GroundEphemeris>>() {
-                    return evaluator.in_constraint_batch(
-                        &*ephem as &dyn EphemerisBase,
-                        &group_ras,
-                        &group_decs,
-                        time_indices.as_deref(),
-                    );
-                }
-                if let Ok(ephem) = bound.extract::<PyRef<OEMEphemeris>>() {
-                    return evaluator.in_constraint_batch(
-                        &*ephem as &dyn EphemerisBase,
-                        &group_ras,
-                        &group_decs,
-                        time_indices.as_deref(),
-                    );
-                }
-                if let Ok(ephem) = bound.extract::<PyRef<FileEphemeris>>() {
-                    return evaluator.in_constraint_batch(
-                        &*ephem as &dyn EphemerisBase,
-                        &group_ras,
-                        &group_decs,
-                        time_indices.as_deref(),
-                    );
-                }
-
-                Err(pyo3::exceptions::PyTypeError::new_err(
-                    "Unsupported ephemeris type. Expected TLEEphemeris, SPICEEphemeris, GroundEphemeris, or OEMEphemeris",
-                ))
+                    )
+                })
             })?;
 
             if n_times == 0 {
@@ -2507,56 +1989,16 @@ impl PyConstraint {
         // Dispatch to a typed ephemeris reference, then run the vectorized sweep.
         // roll_sweep_vec calls in_constraint_batch once per leaf constraint with all N
         // pre-rotated targets, reducing O(N × leaves) calls to O(leaves).
-        let violated: Vec<bool> = if let Ok(ephem) = bound.extract::<PyRef<TLEEphemeris>>() {
+        let violated: Vec<bool> = self.with_ephemeris(bound, |ephem_ref| {
             run_roll_sweep(
                 &base_config,
                 &target_ras,
                 &target_decs,
                 &rolls,
-                &*ephem as &dyn EphemerisBase,
+                ephem_ref,
                 time_idx,
-            )?
-        } else if let Ok(ephem) = bound.extract::<PyRef<SPICEEphemeris>>() {
-            run_roll_sweep(
-                &base_config,
-                &target_ras,
-                &target_decs,
-                &rolls,
-                &*ephem as &dyn EphemerisBase,
-                time_idx,
-            )?
-        } else if let Ok(ephem) = bound.extract::<PyRef<GroundEphemeris>>() {
-            run_roll_sweep(
-                &base_config,
-                &target_ras,
-                &target_decs,
-                &rolls,
-                &*ephem as &dyn EphemerisBase,
-                time_idx,
-            )?
-        } else if let Ok(ephem) = bound.extract::<PyRef<OEMEphemeris>>() {
-            run_roll_sweep(
-                &base_config,
-                &target_ras,
-                &target_decs,
-                &rolls,
-                &*ephem as &dyn EphemerisBase,
-                time_idx,
-            )?
-        } else if let Ok(ephem) = bound.extract::<PyRef<FileEphemeris>>() {
-            run_roll_sweep(
-                &base_config,
-                &target_ras,
-                &target_decs,
-                &rolls,
-                &*ephem as &dyn EphemerisBase,
-                time_idx,
-            )?
-        } else {
-            return Err(pyo3::exceptions::PyTypeError::new_err(
-                "Unsupported ephemeris type. Expected TLEEphemeris, SPICEEphemeris, GroundEphemeris, or OEMEphemeris",
-            ));
-        };
+            )
+        })?;
 
         // Collapse contiguous valid (not-violated) samples into (lo, hi) intervals.
         let mut intervals: Vec<(f64, f64)> = Vec::new();

--- a/src/constraints/constraint_wrapper/py_api.rs
+++ b/src/constraints/constraint_wrapper/py_api.rs
@@ -1633,7 +1633,7 @@ impl PyConstraint {
     ///     n_roll_samples (int, optional): Number of spacecraft roll angles to sweep when
     ///         computing FoR over all roll states.  Each angle is spaced uniformly over
     ///         [0°, 360°).  Ignored for fixed-roll or roll-independent constraints.
-    ///         Default 72 (5° resolution).
+    ///         Default 360 (1° resolution). Can be reduced (e.g., 72 for 5° resolution) for faster evaluation.
     ///
     /// Returns:
     ///     float: Instantaneous field of regard in steradians (range [0, 4π])
@@ -1641,8 +1641,8 @@ impl PyConstraint {
     /// Notes:
     ///     - Exactly one of `time` or `index` must be provided.
     ///     - Higher `n_points` improves accuracy at higher computational cost.
-    ///     - Spacecraft-roll sweeps scale with ``n_roll_samples``; the default 72 is
-    ///       ~72× slower than a single-roll evaluation at the same ``n_points``.
+    ///     - Spacecraft-roll sweeps scale with ``n_roll_samples``; each additional roll sample
+    ///       increases evaluation time proportionally.
     #[pyo3(signature = (ephemeris, time=None, index=None, n_points=DEFAULT_N_POINTS, n_roll_samples=DEFAULT_N_ROLL_SAMPLES))]
     fn instantaneous_field_of_regard(
         &self,

--- a/src/constraints/constraint_wrapper/py_api.rs
+++ b/src/constraints/constraint_wrapper/py_api.rs
@@ -44,6 +44,26 @@ pub struct PyConstraint {
 }
 
 impl PyConstraint {
+    fn inject_solar_roll(config: &mut serde_json::Value, roll_deg: f64) {
+        let Some(obj) = config.as_object_mut() else {
+            return;
+        };
+
+        if obj.get("type").and_then(|v| v.as_str()) == Some("solar_roll") {
+            obj.insert("roll_deg".to_string(), serde_json::json!(roll_deg));
+        }
+
+        if let Some(inner) = obj.get_mut("constraint") {
+            Self::inject_solar_roll(inner, roll_deg);
+        }
+
+        if let Some(children) = obj.get_mut("constraints").and_then(|v| v.as_array_mut()) {
+            for child in children {
+                Self::inject_solar_roll(child, roll_deg);
+            }
+        }
+    }
+
     fn in_constraint_batch_with_roll_sweep(
         &self,
         evaluator: &dyn ConstraintEvaluator,
@@ -99,6 +119,8 @@ impl PyConstraint {
         let mut config: serde_json::Value = serde_json::from_str(&self.config_json)
             .map_err(|e| pyo3::exceptions::PyValueError::new_err(e.to_string()))?;
 
+        Self::inject_solar_roll(&mut config, target_roll_deg);
+
         let constraint_type = config
             .get("type")
             .and_then(|v| v.as_str())
@@ -126,9 +148,6 @@ impl PyConstraint {
         // SolarRoll: inject the spacecraft roll so the evaluator can compare to the
         // solar-optimal roll.  Handled internally — bypass the BoresightOffset wrapper.
         if is_solar_roll {
-            if let Some(obj) = config.as_object_mut() {
-                obj.insert("roll_deg".to_string(), serde_json::json!(target_roll_deg));
-            }
             let evaluator = parse_constraint_json(&config)?;
             return f(&*evaluator);
         }

--- a/src/constraints/constraint_wrapper/py_api.rs
+++ b/src/constraints/constraint_wrapper/py_api.rs
@@ -1326,18 +1326,7 @@ impl PyConstraint {
     ) -> PyResult<ConstraintResult> {
         // Parse time filtering options
         let bound = ephemeris.bind(py);
-        let time_indices = if let Some(times_arg) = times {
-            if indices.is_some() {
-                return Err(pyo3::exceptions::PyValueError::new_err(
-                    "Cannot specify both 'times' and 'indices' parameters",
-                ));
-            }
-            Some(self.parse_times_to_indices(bound, times_arg)?)
-        } else if let Some(indices_arg) = indices {
-            Some(self.parse_indices(indices_arg)?)
-        } else {
-            None
-        };
+        let time_indices = self.resolve_time_indices(bound, times, indices)?;
 
         self.with_effective_evaluator(target_roll, |evaluator| {
             self.with_ephemeris(bound, |ephem_ref| {
@@ -1381,18 +1370,7 @@ impl PyConstraint {
         }
 
         let bound = ephemeris.bind(py);
-        let time_indices = if let Some(times_arg) = times {
-            if indices.is_some() {
-                return Err(pyo3::exceptions::PyValueError::new_err(
-                    "Cannot specify both 'times' and 'indices' parameters",
-                ));
-            }
-            Some(self.parse_times_to_indices(bound, times_arg)?)
-        } else if let Some(indices_arg) = indices {
-            Some(self.parse_indices(indices_arg)?)
-        } else {
-            None
-        };
+        let time_indices = self.resolve_time_indices(bound, times, indices)?;
 
         // If no per-target rolls, use uniform None roll for all targets
         if target_rolls.is_none() {
@@ -1411,12 +1389,7 @@ impl PyConstraint {
 
         // Group targets by roll value for efficient evaluation
         let rolls = target_rolls.unwrap();
-        let mut roll_map: std::collections::BTreeMap<String, Vec<usize>> =
-            std::collections::BTreeMap::new();
-        for (idx, roll) in rolls.iter().enumerate() {
-            let key = format!("{}", roll);
-            roll_map.entry(key).or_default().push(idx);
-        }
+        let roll_map = Self::build_roll_groups(&rolls);
 
         // Create a result vector with capacity for all targets
         let mut results: Vec<Option<ConstraintResult>> = Vec::with_capacity(target_ras.len());
@@ -1430,8 +1403,8 @@ impl PyConstraint {
             let target_roll = rolls[group_indices[0]];
 
             // Extract targets for this group
-            let group_ras: Vec<f64> = group_indices.iter().map(|&i| target_ras[i]).collect();
-            let group_decs: Vec<f64> = group_indices.iter().map(|&i| target_decs[i]).collect();
+            let (group_ras, group_decs) =
+                Self::extract_group_targets(&target_ras, &target_decs, &group_indices);
 
             let group_results = self.with_effective_evaluator(Some(target_roll), |evaluator| {
                 self.with_ephemeris(bound, |ephem_ref| {
@@ -1536,18 +1509,7 @@ impl PyConstraint {
 
         // Parse time filtering options
         let bound = ephemeris.bind(py);
-        let time_indices = if let Some(times_arg) = times {
-            if indices.is_some() {
-                return Err(pyo3::exceptions::PyValueError::new_err(
-                    "Cannot specify both 'times' and 'indices' parameters",
-                ));
-            }
-            Some(self.parse_times_to_indices(bound, times_arg)?)
-        } else if let Some(indices_arg) = indices {
-            Some(self.parse_indices(indices_arg)?)
-        } else {
-            None
-        };
+        let time_indices = self.resolve_time_indices(bound, times, indices)?;
 
         // target_rolls=None means "evaluate at all rolls and report targets constrained at every
         // roll" (i.e., no valid roll exists).  For roll-dependent constraints the sweep must be
@@ -1609,12 +1571,7 @@ impl PyConstraint {
 
         // Handle per-target rolls: group targets by roll and stack results
         let rolls = target_rolls.unwrap();
-        let mut roll_map: std::collections::BTreeMap<String, Vec<usize>> =
-            std::collections::BTreeMap::new();
-        for (idx, roll) in rolls.iter().enumerate() {
-            let key = format!("{}", roll);
-            roll_map.entry(key).or_default().push(idx);
-        }
+        let roll_map = Self::build_roll_groups(&rolls);
 
         // First pass: get dimensions and collect results
         let mut all_groups: Vec<(Vec<usize>, numpy::ndarray::Array2<bool>)> = Vec::new();
@@ -1622,8 +1579,8 @@ impl PyConstraint {
 
         for (_, group_indices) in roll_map {
             let target_roll = rolls[group_indices[0]];
-            let group_ras: Vec<f64> = group_indices.iter().map(|&i| target_ras[i]).collect();
-            let group_decs: Vec<f64> = group_indices.iter().map(|&i| target_decs[i]).collect();
+            let (group_ras, group_decs) =
+                Self::extract_group_targets(&target_ras, &target_decs, &group_indices);
 
             let group_array = self.with_effective_evaluator(Some(target_roll), |evaluator| {
                 self.with_ephemeris(bound, |ephem_ref| {

--- a/src/constraints/constraint_wrapper/py_api.rs
+++ b/src/constraints/constraint_wrapper/py_api.rs
@@ -44,6 +44,44 @@ pub struct PyConstraint {
 }
 
 impl PyConstraint {
+    fn in_constraint_batch_with_roll_sweep(
+        &self,
+        evaluator: &dyn ConstraintEvaluator,
+        ephemeris: &dyn EphemerisBase,
+        target_ras: &[f64],
+        target_decs: &[f64],
+        time_indices: Option<&[usize]>,
+    ) -> PyResult<ndarray::Array2<bool>> {
+        if !evaluator.is_roll_dependent() {
+            return evaluator.in_constraint_batch(ephemeris, target_ras, target_decs, time_indices);
+        }
+
+        // Sweep roll angles and require violation at every roll to mark a cell violated.
+        let roll_step = 360.0 / DEFAULT_N_ROLL_SAMPLES as f64;
+        let mut acc: Option<ndarray::Array2<bool>> = None;
+        for step in 0..DEFAULT_N_ROLL_SAMPLES {
+            if let Some(ref a) = acc {
+                if a.iter().all(|&b| !b) {
+                    break;
+                }
+            }
+            let roll_deg = step as f64 * roll_step;
+            let step_result = evaluator.in_constraint_batch_at_roll(
+                ephemeris,
+                target_ras,
+                target_decs,
+                time_indices,
+                roll_deg,
+            )?;
+            match acc {
+                None => acc = Some(step_result),
+                Some(ref mut a) => a.zip_mut_with(&step_result, |x, &y| *x &= y),
+            }
+        }
+
+        Ok(acc.unwrap_or_else(|| ndarray::Array2::from_elem((target_ras.len(), 0), false)))
+    }
+
     fn with_effective_evaluator<T, F>(&self, target_roll: Option<f64>, f: F) -> PyResult<T>
     where
         F: FnOnce(&dyn ConstraintEvaluator) -> PyResult<T>,
@@ -150,7 +188,8 @@ impl PyConstraint {
         // use in_constraint_batch() which is 1700x faster, then construct violations from the result
 
         // Call the fast batch evaluation for single target
-        let violation_array = evaluator.in_constraint_batch(
+        let violation_array = self.in_constraint_batch_with_roll_sweep(
+            evaluator,
             ephemeris,
             &[target_ra],
             &[target_dec],
@@ -195,7 +234,8 @@ impl PyConstraint {
         target_decs: &[f64],
         time_indices: Option<Vec<usize>>,
     ) -> PyResult<Vec<ConstraintResult>> {
-        let violation_array = evaluator.in_constraint_batch(
+        let violation_array = self.in_constraint_batch_with_roll_sweep(
+            evaluator,
             ephemeris,
             target_ras,
             target_decs,

--- a/src/constraints/constraint_wrapper/py_api_helpers.rs
+++ b/src/constraints/constraint_wrapper/py_api_helpers.rs
@@ -55,6 +55,30 @@ impl PyConstraint {
         )
     }
 
+    pub(super) fn reassemble_grouped_batch_results(
+        n_targets: usize,
+        n_times: usize,
+        all_groups: Vec<(Vec<usize>, ndarray::Array2<bool>)>,
+    ) -> PyResult<ndarray::Array2<bool>> {
+        let mut final_results: Vec<Vec<bool>> = vec![vec![false; n_times]; n_targets];
+
+        for (group_indices, group_array) in all_groups {
+            for (row_in_group, &orig_idx) in group_indices.iter().enumerate() {
+                for col in 0..n_times {
+                    final_results[orig_idx][col] = group_array[[row_in_group, col]];
+                }
+            }
+        }
+
+        ndarray::Array2::from_shape_vec(
+            (n_targets, n_times),
+            final_results.into_iter().flatten().collect(),
+        )
+        .map_err(|e| {
+            pyo3::exceptions::PyValueError::new_err(format!("Failed to create array: {}", e))
+        })
+    }
+
     pub(super) fn with_ephemeris<T, F>(&self, bound: &Bound<'_, PyAny>, mut f: F) -> PyResult<T>
     where
         F: FnMut(&dyn EphemerisBase) -> PyResult<T>,

--- a/src/constraints/constraint_wrapper/py_api_helpers.rs
+++ b/src/constraints/constraint_wrapper/py_api_helpers.rs
@@ -100,7 +100,7 @@ impl PyConstraint {
         }
 
         Err(pyo3::exceptions::PyTypeError::new_err(
-            "Unsupported ephemeris type. Expected TLEEphemeris, SPICEEphemeris, GroundEphemeris, or OEMEphemeris",
+            "Unsupported ephemeris type. Expected TLEEphemeris, SPICEEphemeris, GroundEphemeris, OEMEphemeris, or FileEphemeris",
         ))
     }
 

--- a/src/constraints/constraint_wrapper/py_api_helpers.rs
+++ b/src/constraints/constraint_wrapper/py_api_helpers.rs
@@ -7,16 +7,55 @@ use crate::ephemeris::SPICEEphemeris;
 use crate::ephemeris::TLEEphemeris;
 use pyo3::prelude::*;
 
+use super::PyConstraint;
 use crate::constraints::constraint_wrapper::field_of_regard::DEFAULT_N_ROLL_SAMPLES;
 use crate::constraints::constraint_wrapper::json_parser::parse_constraint_json;
-use super::PyConstraint;
 
 impl PyConstraint {
-    pub(super) fn with_ephemeris<T, F>(
+    pub(super) fn resolve_time_indices(
         &self,
         bound: &Bound<'_, PyAny>,
-        mut f: F,
-    ) -> PyResult<T>
+        times: Option<&Bound<'_, PyAny>>,
+        indices: Option<&Bound<'_, PyAny>>,
+    ) -> PyResult<Option<Vec<usize>>> {
+        if let Some(times_arg) = times {
+            if indices.is_some() {
+                return Err(pyo3::exceptions::PyValueError::new_err(
+                    "Cannot specify both 'times' and 'indices' parameters",
+                ));
+            }
+            Ok(Some(self.parse_times_to_indices(bound, times_arg)?))
+        } else if let Some(indices_arg) = indices {
+            Ok(Some(self.parse_indices(indices_arg)?))
+        } else {
+            Ok(None)
+        }
+    }
+
+    pub(super) fn build_roll_groups(
+        rolls: &[f64],
+    ) -> std::collections::BTreeMap<String, Vec<usize>> {
+        let mut roll_map: std::collections::BTreeMap<String, Vec<usize>> =
+            std::collections::BTreeMap::new();
+        for (idx, roll) in rolls.iter().enumerate() {
+            let key = format!("{}", roll);
+            roll_map.entry(key).or_default().push(idx);
+        }
+        roll_map
+    }
+
+    pub(super) fn extract_group_targets(
+        target_ras: &[f64],
+        target_decs: &[f64],
+        indices: &[usize],
+    ) -> (Vec<f64>, Vec<f64>) {
+        (
+            indices.iter().map(|&i| target_ras[i]).collect(),
+            indices.iter().map(|&i| target_decs[i]).collect(),
+        )
+    }
+
+    pub(super) fn with_ephemeris<T, F>(&self, bound: &Bound<'_, PyAny>, mut f: F) -> PyResult<T>
     where
         F: FnMut(&dyn EphemerisBase) -> PyResult<T>,
     {
@@ -100,7 +139,11 @@ impl PyConstraint {
         Ok(acc.unwrap_or_else(|| ndarray::Array2::from_elem((target_ras.len(), 0), false)))
     }
 
-    pub(super) fn with_effective_evaluator<T, F>(&self, target_roll: Option<f64>, f: F) -> PyResult<T>
+    pub(super) fn with_effective_evaluator<T, F>(
+        &self,
+        target_roll: Option<f64>,
+        f: F,
+    ) -> PyResult<T>
     where
         F: FnOnce(&dyn ConstraintEvaluator) -> PyResult<T>,
     {

--- a/src/constraints/constraint_wrapper/py_api_helpers.rs
+++ b/src/constraints/constraint_wrapper/py_api_helpers.rs
@@ -1,0 +1,351 @@
+use crate::constraints::core::{track_violations, ConstraintEvaluator, ConstraintResult};
+use crate::ephemeris::ephemeris_common::EphemerisBase;
+use crate::ephemeris::FileEphemeris;
+use crate::ephemeris::GroundEphemeris;
+use crate::ephemeris::OEMEphemeris;
+use crate::ephemeris::SPICEEphemeris;
+use crate::ephemeris::TLEEphemeris;
+use pyo3::prelude::*;
+
+use crate::constraints::constraint_wrapper::field_of_regard::DEFAULT_N_ROLL_SAMPLES;
+use crate::constraints::constraint_wrapper::json_parser::parse_constraint_json;
+use super::PyConstraint;
+
+impl PyConstraint {
+    pub(super) fn with_ephemeris<T, F>(
+        &self,
+        bound: &Bound<'_, PyAny>,
+        mut f: F,
+    ) -> PyResult<T>
+    where
+        F: FnMut(&dyn EphemerisBase) -> PyResult<T>,
+    {
+        if let Ok(ephem) = bound.extract::<PyRef<TLEEphemeris>>() {
+            return f(&*ephem as &dyn EphemerisBase);
+        }
+        if let Ok(ephem) = bound.extract::<PyRef<SPICEEphemeris>>() {
+            return f(&*ephem as &dyn EphemerisBase);
+        }
+        if let Ok(ephem) = bound.extract::<PyRef<GroundEphemeris>>() {
+            return f(&*ephem as &dyn EphemerisBase);
+        }
+        if let Ok(ephem) = bound.extract::<PyRef<OEMEphemeris>>() {
+            return f(&*ephem as &dyn EphemerisBase);
+        }
+        if let Ok(ephem) = bound.extract::<PyRef<FileEphemeris>>() {
+            return f(&*ephem as &dyn EphemerisBase);
+        }
+
+        Err(pyo3::exceptions::PyTypeError::new_err(
+            "Unsupported ephemeris type. Expected TLEEphemeris, SPICEEphemeris, GroundEphemeris, or OEMEphemeris",
+        ))
+    }
+
+    pub(super) fn inject_solar_roll(config: &mut serde_json::Value, roll_deg: f64) {
+        let Some(obj) = config.as_object_mut() else {
+            return;
+        };
+
+        if obj.get("type").and_then(|v| v.as_str()) == Some("solar_roll") {
+            obj.insert("roll_deg".to_string(), serde_json::json!(roll_deg));
+        }
+
+        if let Some(inner) = obj.get_mut("constraint") {
+            Self::inject_solar_roll(inner, roll_deg);
+        }
+
+        if let Some(children) = obj.get_mut("constraints").and_then(|v| v.as_array_mut()) {
+            for child in children {
+                Self::inject_solar_roll(child, roll_deg);
+            }
+        }
+    }
+
+    pub(super) fn in_constraint_batch_with_roll_sweep(
+        &self,
+        evaluator: &dyn ConstraintEvaluator,
+        ephemeris: &dyn EphemerisBase,
+        target_ras: &[f64],
+        target_decs: &[f64],
+        time_indices: Option<&[usize]>,
+        n_roll_samples: usize,
+    ) -> PyResult<ndarray::Array2<bool>> {
+        if !evaluator.is_roll_dependent() {
+            return evaluator.in_constraint_batch(ephemeris, target_ras, target_decs, time_indices);
+        }
+
+        // Sweep roll angles and require violation at every roll to mark a cell violated.
+        let roll_step = 360.0 / n_roll_samples as f64;
+        let mut acc: Option<ndarray::Array2<bool>> = None;
+        for step in 0..n_roll_samples {
+            if let Some(ref a) = acc {
+                if a.iter().all(|&b| !b) {
+                    break;
+                }
+            }
+            let roll_deg = step as f64 * roll_step;
+            let step_result = evaluator.in_constraint_batch_at_roll(
+                ephemeris,
+                target_ras,
+                target_decs,
+                time_indices,
+                roll_deg,
+            )?;
+            match acc {
+                None => acc = Some(step_result),
+                Some(ref mut a) => a.zip_mut_with(&step_result, |x, &y| *x &= y),
+            }
+        }
+
+        Ok(acc.unwrap_or_else(|| ndarray::Array2::from_elem((target_ras.len(), 0), false)))
+    }
+
+    pub(super) fn with_effective_evaluator<T, F>(&self, target_roll: Option<f64>, f: F) -> PyResult<T>
+    where
+        F: FnOnce(&dyn ConstraintEvaluator) -> PyResult<T>,
+    {
+        let Some(target_roll_deg) = target_roll else {
+            return f(&*self.evaluator);
+        };
+
+        if !target_roll_deg.is_finite() {
+            return Err(pyo3::exceptions::PyValueError::new_err(
+                "target_roll must be a finite number",
+            ));
+        }
+
+        let mut config: serde_json::Value = serde_json::from_str(&self.config_json)
+            .map_err(|e| pyo3::exceptions::PyValueError::new_err(e.to_string()))?;
+
+        Self::inject_solar_roll(&mut config, target_roll_deg);
+
+        let constraint_type = config
+            .get("type")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_owned();
+
+        let is_boresight_offset = constraint_type == "boresight_offset";
+        let is_bright_star = constraint_type == "bright_star";
+        let is_body_polygon = constraint_type == "body" && config.get("fov_polygon").is_some();
+        let is_solar_roll = constraint_type == "solar_roll";
+
+        // Bright star or body proximity with a polygon FoV: inject target_roll as roll_deg
+        // so the evaluator rotates the polygon to the requested angle.  Both constraint types
+        // handle roll internally, so we bypass the BoresightOffset wrapper.
+        if is_bright_star || is_body_polygon {
+            if config.get("fov_polygon").is_some() {
+                if let Some(obj) = config.as_object_mut() {
+                    obj.insert("roll_deg".to_string(), serde_json::json!(target_roll_deg));
+                }
+            }
+            let evaluator = parse_constraint_json(&config)?;
+            return f(&*evaluator);
+        }
+
+        // SolarRoll: inject the spacecraft roll so the evaluator can compare to the
+        // solar-optimal roll.  Handled internally — bypass the BoresightOffset wrapper.
+        if is_solar_roll {
+            let evaluator = parse_constraint_json(&config)?;
+            return f(&*evaluator);
+        }
+
+        if is_boresight_offset {
+            let base_roll_deg = config
+                .get("roll_deg")
+                .and_then(|v| v.as_f64())
+                .unwrap_or(0.0);
+            let base_clockwise = config
+                .get("roll_clockwise")
+                .and_then(|v| v.as_bool())
+                .unwrap_or(false);
+
+            // Match RustConstraintMixin semantics: add evaluation-time roll in the
+            // configured command convention.
+            let signed_target_roll = if base_clockwise {
+                -target_roll_deg
+            } else {
+                target_roll_deg
+            };
+
+            if let Some(obj) = config.as_object_mut() {
+                obj.insert(
+                    "roll_deg".to_string(),
+                    serde_json::json!(base_roll_deg + signed_target_roll),
+                );
+            }
+        } else {
+            config = serde_json::json!({
+                "type": "boresight_offset",
+                "constraint": config,
+                "roll_deg": target_roll_deg,
+                "roll_clockwise": false,
+                "roll_reference": "north",
+                "pitch_deg": 0.0,
+                "yaw_deg": 0.0
+            });
+        }
+
+        let evaluator = parse_constraint_json(&config)?;
+        f(&*evaluator)
+    }
+
+    /// Internal helper to evaluate against any Ephemeris implementing EphemerisBase
+    #[allow(deprecated)]
+    pub(super) fn eval_with_ephemeris(
+        &self,
+        evaluator: &dyn ConstraintEvaluator,
+        ephemeris: &dyn EphemerisBase,
+        target_ra: f64,
+        target_dec: f64,
+        time_indices: Option<Vec<usize>>,
+    ) -> PyResult<ConstraintResult> {
+        // PERFORMANCE OPTIMIZATION: Use fast batch path internally
+        // Instead of the slow evaluate() that tracks violations step-by-step,
+        // use in_constraint_batch() which is 1700x faster, then construct violations from the result
+
+        // Call the fast batch evaluation for single target
+        let violation_array = self.in_constraint_batch_with_roll_sweep(
+            evaluator,
+            ephemeris,
+            &[target_ra],
+            &[target_dec],
+            time_indices.as_deref(),
+            DEFAULT_N_ROLL_SAMPLES,
+        )?;
+
+        // Get the times we evaluated
+        let all_times = ephemeris.get_times()?;
+        let times: Vec<_> = if let Some(ref indices) = time_indices {
+            indices.iter().map(|&i| all_times[i]).collect()
+        } else {
+            all_times.to_vec()
+        };
+
+        // Extract the boolean array for our single target (first row)
+        // Note: in_constraint_batch now consistently returns true when VIOLATED (matches track_violations)
+        let violated: Vec<bool> = (0..violation_array.ncols())
+            .map(|i| violation_array[[0, i]])
+            .collect();
+
+        // Track violations using the same helper function
+        let violations = track_violations(
+            &times,
+            |i| (violated[i], if violated[i] { 1.0 } else { 0.0 }),
+            |_i, _is_open| evaluator.name(),
+        );
+
+        let all_satisfied = violations.is_empty();
+        Ok(ConstraintResult::new(
+            violations,
+            all_satisfied,
+            evaluator.name(),
+            times,
+        ))
+    }
+
+    pub(super) fn eval_batch_with_ephemeris(
+        &self,
+        evaluator: &dyn ConstraintEvaluator,
+        ephemeris: &dyn EphemerisBase,
+        target_ras: &[f64],
+        target_decs: &[f64],
+        time_indices: Option<Vec<usize>>,
+    ) -> PyResult<Vec<ConstraintResult>> {
+        let violation_array = self.in_constraint_batch_with_roll_sweep(
+            evaluator,
+            ephemeris,
+            target_ras,
+            target_decs,
+            time_indices.as_deref(),
+            DEFAULT_N_ROLL_SAMPLES,
+        )?;
+
+        let all_times = ephemeris.get_times()?;
+        let times: Vec<_> = if let Some(ref indices) = time_indices {
+            indices.iter().map(|&i| all_times[i]).collect()
+        } else {
+            all_times.to_vec()
+        };
+
+        let mut results = Vec::with_capacity(target_ras.len());
+        for target_index in 0..target_ras.len() {
+            let violated: Vec<bool> = (0..violation_array.ncols())
+                .map(|i| violation_array[[target_index, i]])
+                .collect();
+
+            let violations = track_violations(
+                &times,
+                |i| (violated[i], if violated[i] { 1.0 } else { 0.0 }),
+                |_i, _is_open| evaluator.name(),
+            );
+
+            let all_satisfied = violations.is_empty();
+            results.push(ConstraintResult::new(
+                violations,
+                all_satisfied,
+                evaluator.name(),
+                times.clone(),
+            ));
+        }
+
+        Ok(results)
+    }
+
+    /// Vectorized evaluation for moving bodies - evaluates all targets at their corresponding times
+    ///
+    /// For N targets at N times, this calls in_constraint_batch once with all N targets
+    /// Uses the efficient diagonal batch evaluation for moving bodies.
+    /// Each target_i is evaluated only at time_i, which is O(N) instead of O(N²).
+    pub(super) fn eval_moving_body_batch_diagonal(
+        &self,
+        py: Python,
+        ephemeris: &Py<PyAny>,
+        target_ras: &[f64],
+        target_decs: &[f64],
+    ) -> PyResult<Vec<bool>> {
+        let n = target_ras.len();
+        if n == 0 {
+            return Ok(Vec::new());
+        }
+
+        let bound = ephemeris.bind(py);
+
+        // Use the efficient diagonal batch evaluation
+        if let Ok(ephem) = bound.extract::<PyRef<TLEEphemeris>>() {
+            self.evaluator.in_constraint_batch_diagonal(
+                &*ephem as &dyn EphemerisBase,
+                target_ras,
+                target_decs,
+            )
+        } else if let Ok(ephem) = bound.extract::<PyRef<SPICEEphemeris>>() {
+            self.evaluator.in_constraint_batch_diagonal(
+                &*ephem as &dyn EphemerisBase,
+                target_ras,
+                target_decs,
+            )
+        } else if let Ok(ephem) = bound.extract::<PyRef<GroundEphemeris>>() {
+            self.evaluator.in_constraint_batch_diagonal(
+                &*ephem as &dyn EphemerisBase,
+                target_ras,
+                target_decs,
+            )
+        } else if let Ok(ephem) = bound.extract::<PyRef<OEMEphemeris>>() {
+            self.evaluator.in_constraint_batch_diagonal(
+                &*ephem as &dyn EphemerisBase,
+                target_ras,
+                target_decs,
+            )
+        } else if let Ok(ephem) = bound.extract::<PyRef<FileEphemeris>>() {
+            self.evaluator.in_constraint_batch_diagonal(
+                &*ephem as &dyn EphemerisBase,
+                target_ras,
+                target_decs,
+            )
+        } else {
+            Err(pyo3::exceptions::PyTypeError::new_err(
+                "Unsupported ephemeris type. Expected TLEEphemeris, SPICEEphemeris, GroundEphemeris, or OEMEphemeris",
+            ))
+        }
+    }
+}

--- a/src/constraints/constraint_wrapper/roll_range.rs
+++ b/src/constraints/constraint_wrapper/roll_range.rs
@@ -68,8 +68,14 @@ pub(super) fn get_sun_unit_at(ephem: &dyn EphemerisBase, time_idx: usize) -> PyR
 // ---------------------------------------------------------------------------
 
 /// Compute the north-referenced optimal roll (degrees) that maximises solar
-/// illumination of the +Y body panel, using the same frame as `boresight_rotate`.
-fn solar_optimal_roll_for_sweep(target: [f64; 3], sun_unit: &[f64; 3]) -> f64 {
+/// illumination of the panel with the given body-frame normal, using the same
+/// frame as `boresight_rotate`.  `panel_normal[1]` and `panel_normal[2]` are
+/// the Y and Z body-frame components; the X component (boresight) is ignored.
+fn solar_optimal_roll_for_sweep(
+    target: [f64; 3],
+    sun_unit: &[f64; 3],
+    panel_normal: [f64; 3],
+) -> f64 {
     const NEAR_ZERO: f64 = 1.0e-12;
     let x_axis = target;
     let z_ref = [0.0_f64, 0.0, 1.0];
@@ -111,13 +117,15 @@ fn solar_optimal_roll_for_sweep(target: [f64; 3], sun_unit: &[f64; 3]) -> f64 {
     let z_axis = rsv_cross(x_axis, y_axis);
     let sun_y = rsv_dot(*sun_unit, y_axis);
     let sun_z = rsv_dot(*sun_unit, z_axis);
-    f64::atan2(sun_z, sun_y).to_degrees()
+    let panel_angle = f64::atan2(panel_normal[2], panel_normal[1]);
+    (f64::atan2(sun_z, sun_y) - panel_angle).to_degrees()
 }
 
 /// Shortest arc between two angles (result in [0, 180]).
 #[inline]
 fn rsv_circular_diff_deg(a: f64, b: f64) -> f64 {
-    ((a - b).rem_euclid(360.0) - 180.0).abs()
+    let d = (a - b).rem_euclid(360.0);
+    180.0 - (d - 180.0).abs()
 }
 
 // ---------------------------------------------------------------------------
@@ -462,10 +470,25 @@ pub(super) fn roll_sweep_vec(
                 .get("tolerance_deg")
                 .and_then(|v| v.as_f64())
                 .unwrap_or(0.0);
+            let panel_normal: [f64; 3] = config
+                .get("panel_normal")
+                .and_then(|v| v.as_array())
+                .and_then(|a| {
+                    if a.len() == 3 {
+                        Some([
+                            a[0].as_f64().unwrap_or(0.0),
+                            a[1].as_f64().unwrap_or(1.0),
+                            a[2].as_f64().unwrap_or(0.0),
+                        ])
+                    } else {
+                        None
+                    }
+                })
+                .unwrap_or([0.0, 1.0, 0.0]);
             Ok((0..n)
                 .map(|i| {
                     let target = rsv_radec_to_unit(target_ras[i], target_decs[i]);
-                    let opt = solar_optimal_roll_for_sweep(target, sun_unit);
+                    let opt = solar_optimal_roll_for_sweep(target, sun_unit, panel_normal);
                     rsv_circular_diff_deg(rolls[i], opt) > tolerance_deg
                 })
                 .collect())

--- a/src/constraints/constraint_wrapper/roll_range.rs
+++ b/src/constraints/constraint_wrapper/roll_range.rs
@@ -64,6 +64,63 @@ pub(super) fn get_sun_unit_at(ephem: &dyn EphemerisBase, time_idx: usize) -> PyR
 }
 
 // ---------------------------------------------------------------------------
+// Solar-roll helpers (shared with roll_sweep_vec)
+// ---------------------------------------------------------------------------
+
+/// Compute the north-referenced optimal roll (degrees) that maximises solar
+/// illumination of the +Y body panel, using the same frame as `boresight_rotate`.
+fn solar_optimal_roll_for_sweep(target: [f64; 3], sun_unit: &[f64; 3]) -> f64 {
+    const NEAR_ZERO: f64 = 1.0e-12;
+    let x_axis = target;
+    let z_ref = [0.0_f64, 0.0, 1.0];
+    let zref_dot_x = rsv_dot(x_axis, z_ref);
+    let z_raw = [
+        z_ref[0] - zref_dot_x * x_axis[0],
+        z_ref[1] - zref_dot_x * x_axis[1],
+        z_ref[2] - zref_dot_x * x_axis[2],
+    ];
+    let z_n = rsv_norm(z_raw);
+    let z_axis = if z_n > NEAR_ZERO {
+        [z_raw[0] / z_n, z_raw[1] / z_n, z_raw[2] / z_n]
+    } else {
+        let fallback: [f64; 3] = if x_axis[2].abs() < 0.9 {
+            [0.0, 0.0, 1.0]
+        } else {
+            [0.0, 1.0, 0.0]
+        };
+        let d = rsv_dot(x_axis, fallback);
+        let raw = [
+            fallback[0] - d * x_axis[0],
+            fallback[1] - d * x_axis[1],
+            fallback[2] - d * x_axis[2],
+        ];
+        let n = rsv_norm(raw);
+        if n > NEAR_ZERO {
+            [raw[0] / n, raw[1] / n, raw[2] / n]
+        } else {
+            [0.0, 1.0, 0.0]
+        }
+    };
+    let y_raw = rsv_cross(z_axis, x_axis);
+    let y_n = rsv_norm(y_raw);
+    let y_axis = if y_n > NEAR_ZERO {
+        [y_raw[0] / y_n, y_raw[1] / y_n, y_raw[2] / y_n]
+    } else {
+        [0.0, 1.0, 0.0]
+    };
+    let z_axis = rsv_cross(x_axis, y_axis);
+    let sun_y = rsv_dot(*sun_unit, y_axis);
+    let sun_z = rsv_dot(*sun_unit, z_axis);
+    f64::atan2(sun_z, sun_y).to_degrees()
+}
+
+/// Shortest arc between two angles (result in [0, 180]).
+#[inline]
+fn rsv_circular_diff_deg(a: f64, b: f64) -> f64 {
+    ((a - b).rem_euclid(360.0) - 180.0).abs()
+}
+
+// ---------------------------------------------------------------------------
 // Boresight rotation
 // ---------------------------------------------------------------------------
 
@@ -397,6 +454,21 @@ pub(super) fn roll_sweep_vec(
                 result[i] = count == 1;
             }
             Ok(result)
+        }
+
+        // SolarRoll: analytically check each roll sample against the solar-optimal roll.
+        Some("solar_roll") => {
+            let tolerance_deg = config
+                .get("tolerance_deg")
+                .and_then(|v| v.as_f64())
+                .unwrap_or(0.0);
+            Ok((0..n)
+                .map(|i| {
+                    let target = rsv_radec_to_unit(target_ras[i], target_decs[i]);
+                    let opt = solar_optimal_roll_for_sweep(target, sun_unit);
+                    rsv_circular_diff_deg(rolls[i], opt) > tolerance_deg
+                })
+                .collect())
         }
 
         _ => {

--- a/src/constraints/constraint_wrapper/roll_range.rs
+++ b/src/constraints/constraint_wrapper/roll_range.rs
@@ -75,7 +75,7 @@ fn solar_optimal_roll_for_sweep(
     target: [f64; 3],
     sun_unit: &[f64; 3],
     panel_normal: [f64; 3],
-) -> f64 {
+) -> Option<f64> {
     const NEAR_ZERO: f64 = 1.0e-12;
     let x_axis = target;
     let z_ref = [0.0_f64, 0.0, 1.0];
@@ -117,8 +117,13 @@ fn solar_optimal_roll_for_sweep(
     let z_axis = rsv_cross(x_axis, y_axis);
     let sun_y = rsv_dot(*sun_unit, y_axis);
     let sun_z = rsv_dot(*sun_unit, z_axis);
+    let sun_proj = (sun_y * sun_y + sun_z * sun_z).sqrt();
+    let panel_proj = (panel_normal[1] * panel_normal[1] + panel_normal[2] * panel_normal[2]).sqrt();
+    if sun_proj <= NEAR_ZERO || panel_proj <= NEAR_ZERO {
+        return None;
+    }
     let panel_angle = f64::atan2(panel_normal[2], panel_normal[1]);
-    (f64::atan2(sun_z, sun_y) - panel_angle).to_degrees()
+    Some((f64::atan2(sun_z, sun_y) - panel_angle).to_degrees())
 }
 
 /// Shortest arc between two angles (result in [0, 180]).
@@ -489,7 +494,10 @@ pub(super) fn roll_sweep_vec(
                 .map(|i| {
                     let target = rsv_radec_to_unit(target_ras[i], target_decs[i]);
                     let opt = solar_optimal_roll_for_sweep(target, sun_unit, panel_normal);
-                    rsv_circular_diff_deg(rolls[i], opt) > tolerance_deg
+                    match opt {
+                        Some(opt) => rsv_circular_diff_deg(rolls[i], opt) > tolerance_deg,
+                        None => false,
+                    }
                 })
                 .collect())
         }

--- a/src/constraints/constraint_wrapper/roll_range.rs
+++ b/src/constraints/constraint_wrapper/roll_range.rs
@@ -5,6 +5,10 @@
 /// the constraint JSON tree and calls `in_constraint_batch` **once per leaf constraint**
 /// with all N pre-rotated target directions.  This reduces the call count from
 /// `O(N × leaves)` to `O(leaves)`.
+use crate::constraints::solar_roll::{
+    circular_diff_deg as solar_circular_diff_deg,
+    roll_is_unconstrained as solar_roll_unconstrained, solar_optimal_roll_deg,
+};
 use crate::ephemeris::ephemeris_common::EphemerisBase;
 use pyo3::PyResult;
 
@@ -61,76 +65,6 @@ pub(super) fn get_sun_unit_at(ephem: &dyn EphemerisBase, time_idx: usize) -> PyR
         return Ok([1.0, 0.0, 0.0]);
     }
     Ok([v[0] / n, v[1] / n, v[2] / n])
-}
-
-// ---------------------------------------------------------------------------
-// Solar-roll helpers (shared with roll_sweep_vec)
-// ---------------------------------------------------------------------------
-
-/// Compute the north-referenced optimal roll (degrees) that maximises solar
-/// illumination of the panel with the given body-frame normal, using the same
-/// frame as `boresight_rotate`.  `panel_normal[1]` and `panel_normal[2]` are
-/// the Y and Z body-frame components; the X component (boresight) is ignored.
-fn solar_optimal_roll_for_sweep(
-    target: [f64; 3],
-    sun_unit: &[f64; 3],
-    panel_normal: [f64; 3],
-) -> Option<f64> {
-    const NEAR_ZERO: f64 = 1.0e-12;
-    let x_axis = target;
-    let z_ref = [0.0_f64, 0.0, 1.0];
-    let zref_dot_x = rsv_dot(x_axis, z_ref);
-    let z_raw = [
-        z_ref[0] - zref_dot_x * x_axis[0],
-        z_ref[1] - zref_dot_x * x_axis[1],
-        z_ref[2] - zref_dot_x * x_axis[2],
-    ];
-    let z_n = rsv_norm(z_raw);
-    let z_axis = if z_n > NEAR_ZERO {
-        [z_raw[0] / z_n, z_raw[1] / z_n, z_raw[2] / z_n]
-    } else {
-        let fallback: [f64; 3] = if x_axis[2].abs() < 0.9 {
-            [0.0, 0.0, 1.0]
-        } else {
-            [0.0, 1.0, 0.0]
-        };
-        let d = rsv_dot(x_axis, fallback);
-        let raw = [
-            fallback[0] - d * x_axis[0],
-            fallback[1] - d * x_axis[1],
-            fallback[2] - d * x_axis[2],
-        ];
-        let n = rsv_norm(raw);
-        if n > NEAR_ZERO {
-            [raw[0] / n, raw[1] / n, raw[2] / n]
-        } else {
-            [0.0, 1.0, 0.0]
-        }
-    };
-    let y_raw = rsv_cross(z_axis, x_axis);
-    let y_n = rsv_norm(y_raw);
-    let y_axis = if y_n > NEAR_ZERO {
-        [y_raw[0] / y_n, y_raw[1] / y_n, y_raw[2] / y_n]
-    } else {
-        [0.0, 1.0, 0.0]
-    };
-    let z_axis = rsv_cross(x_axis, y_axis);
-    let sun_y = rsv_dot(*sun_unit, y_axis);
-    let sun_z = rsv_dot(*sun_unit, z_axis);
-    let sun_proj = (sun_y * sun_y + sun_z * sun_z).sqrt();
-    let panel_proj = (panel_normal[1] * panel_normal[1] + panel_normal[2] * panel_normal[2]).sqrt();
-    if sun_proj <= NEAR_ZERO || panel_proj <= NEAR_ZERO {
-        return None;
-    }
-    let panel_angle = f64::atan2(panel_normal[2], panel_normal[1]);
-    Some((f64::atan2(sun_z, sun_y) - panel_angle).to_degrees())
-}
-
-/// Shortest arc between two angles (result in [0, 180]).
-#[inline]
-fn rsv_circular_diff_deg(a: f64, b: f64) -> f64 {
-    let d = (a - b).rem_euclid(360.0);
-    180.0 - (d - 180.0).abs()
 }
 
 // ---------------------------------------------------------------------------
@@ -493,10 +427,11 @@ pub(super) fn roll_sweep_vec(
             Ok((0..n)
                 .map(|i| {
                     let target = rsv_radec_to_unit(target_ras[i], target_decs[i]);
-                    let opt = solar_optimal_roll_for_sweep(target, sun_unit, panel_normal);
-                    match opt {
-                        Some(opt) => rsv_circular_diff_deg(rolls[i], opt) > tolerance_deg,
-                        None => false,
+                    if solar_roll_unconstrained(&target, sun_unit, panel_normal) {
+                        false
+                    } else {
+                        let opt = solar_optimal_roll_deg(&target, sun_unit, panel_normal);
+                        solar_circular_diff_deg(rolls[i], opt) > tolerance_deg
                     }
                 })
                 .collect())

--- a/src/constraints/constraint_wrapper/roll_range.rs
+++ b/src/constraints/constraint_wrapper/roll_range.rs
@@ -7,7 +7,7 @@
 /// `O(N × leaves)` to `O(leaves)`.
 use crate::constraints::solar_roll::{
     circular_diff_deg as solar_circular_diff_deg,
-    roll_is_unconstrained as solar_roll_unconstrained, solar_optimal_roll_deg,
+    roll_is_unconstrained as solar_roll_unconstrained, solar_optimal_roll_deg, SolarRollConfig,
 };
 use crate::ephemeris::ephemeris_common::EphemerisBase;
 use pyo3::PyResult;
@@ -405,47 +405,19 @@ pub(super) fn roll_sweep_vec(
 
         // SolarRoll: analytically check each roll sample against the solar-optimal roll.
         Some("solar_roll") => {
-            let tolerance_deg = config
-                .get("tolerance_deg")
-                .and_then(|v| v.as_f64())
-                .unwrap_or(0.0);
-            let panel_normal: [f64; 3] = match config.get("panel_normal") {
-                None | Some(serde_json::Value::Null) => [0.0, 1.0, 0.0],
-                Some(v) => {
-                    let arr = v.as_array().ok_or_else(|| {
-                        pyo3::exceptions::PyValueError::new_err(
-                            "solar_roll: panel_normal must be a 3-element array",
-                        )
-                    })?;
-                    if arr.len() != 3 {
-                        return Err(pyo3::exceptions::PyValueError::new_err(
-                            "solar_roll: panel_normal must have exactly 3 elements",
-                        ));
-                    }
-                    let mut out = [0.0_f64; 3];
-                    for (i, item) in arr.iter().enumerate() {
-                        out[i] = item.as_f64().ok_or_else(|| {
-                            pyo3::exceptions::PyValueError::new_err(
-                                "solar_roll: panel_normal elements must be finite numbers",
-                            )
-                        })?;
-                        if !out[i].is_finite() {
-                            return Err(pyo3::exceptions::PyValueError::new_err(
-                                "solar_roll: panel_normal elements must be finite numbers",
-                            ));
-                        }
-                    }
-                    out
-                }
-            };
+            let cfg: SolarRollConfig = serde_json::from_value(config.clone()).map_err(|e| {
+                pyo3::exceptions::PyValueError::new_err(format!(
+                    "Invalid solar_roll constraint JSON: {e}"
+                ))
+            })?;
             Ok((0..n)
                 .map(|i| {
                     let target = rsv_radec_to_unit(target_ras[i], target_decs[i]);
-                    if solar_roll_unconstrained(&target, sun_unit, panel_normal) {
+                    if solar_roll_unconstrained(&target, sun_unit, cfg.panel_normal) {
                         false
                     } else {
-                        let opt = solar_optimal_roll_deg(&target, sun_unit, panel_normal);
-                        solar_circular_diff_deg(rolls[i], opt) > tolerance_deg
+                        let opt = solar_optimal_roll_deg(&target, sun_unit, cfg.panel_normal);
+                        solar_circular_diff_deg(rolls[i], opt) > cfg.tolerance_deg
                     }
                 })
                 .collect())

--- a/src/constraints/constraint_wrapper/roll_range.rs
+++ b/src/constraints/constraint_wrapper/roll_range.rs
@@ -409,21 +409,35 @@ pub(super) fn roll_sweep_vec(
                 .get("tolerance_deg")
                 .and_then(|v| v.as_f64())
                 .unwrap_or(0.0);
-            let panel_normal: [f64; 3] = config
-                .get("panel_normal")
-                .and_then(|v| v.as_array())
-                .and_then(|a| {
-                    if a.len() == 3 {
-                        Some([
-                            a[0].as_f64().unwrap_or(0.0),
-                            a[1].as_f64().unwrap_or(1.0),
-                            a[2].as_f64().unwrap_or(0.0),
-                        ])
-                    } else {
-                        None
+            let panel_normal: [f64; 3] = match config.get("panel_normal") {
+                None | Some(serde_json::Value::Null) => [0.0, 1.0, 0.0],
+                Some(v) => {
+                    let arr = v.as_array().ok_or_else(|| {
+                        pyo3::exceptions::PyValueError::new_err(
+                            "solar_roll: panel_normal must be a 3-element array",
+                        )
+                    })?;
+                    if arr.len() != 3 {
+                        return Err(pyo3::exceptions::PyValueError::new_err(
+                            "solar_roll: panel_normal must have exactly 3 elements",
+                        ));
                     }
-                })
-                .unwrap_or([0.0, 1.0, 0.0]);
+                    let mut out = [0.0_f64; 3];
+                    for (i, item) in arr.iter().enumerate() {
+                        out[i] = item.as_f64().ok_or_else(|| {
+                            pyo3::exceptions::PyValueError::new_err(
+                                "solar_roll: panel_normal elements must be finite numbers",
+                            )
+                        })?;
+                        if !out[i].is_finite() {
+                            return Err(pyo3::exceptions::PyValueError::new_err(
+                                "solar_roll: panel_normal elements must be finite numbers",
+                            ));
+                        }
+                    }
+                    out
+                }
+            };
             Ok((0..n)
                 .map(|i| {
                     let target = rsv_radec_to_unit(target_ras[i], target_decs[i]);

--- a/src/constraints/core.rs
+++ b/src/constraints/core.rs
@@ -742,6 +742,25 @@ pub trait ConstraintEvaluator: Send + Sync {
         Ok(accessible.iter().map(|&a| !a).collect())
     }
 
+    /// Evaluate constraint for the full target set at a single fixed roll angle.
+    ///
+    /// This is the hot path for the coordinated roll sweep in `target_rolls=None` mode.
+    /// Roll-independent constraints ignore `roll_deg` and delegate to `in_constraint_batch`.
+    /// Roll-dependent leaves (SolarRoll, BodyProximity polygon, BrightStar polygon) override
+    /// this to use `roll_deg` directly, eliminating JSON round-trips across 72 sweep steps.
+    ///
+    /// Returns (M × N) boolean violation array, same semantics as `in_constraint_batch`.
+    fn in_constraint_batch_at_roll(
+        &self,
+        ephemeris: &dyn crate::ephemeris::ephemeris_common::EphemerisBase,
+        target_ras: &[f64],
+        target_decs: &[f64],
+        time_indices: Option<&[usize]>,
+        _roll_deg: f64,
+    ) -> PyResult<Array2<bool>> {
+        self.in_constraint_batch(ephemeris, target_ras, target_decs, time_indices)
+    }
+
     /// Get constraint name
     fn name(&self) -> String;
 

--- a/src/constraints/mod.rs
+++ b/src/constraints/mod.rs
@@ -23,6 +23,7 @@ pub mod moon_proximity;
 pub mod orbit_pole;
 pub mod orbit_ram;
 pub mod saa;
+pub mod solar_roll;
 pub mod sun_proximity;
 
 // Python wrapper

--- a/src/constraints/solar_roll.rs
+++ b/src/constraints/solar_roll.rs
@@ -284,6 +284,79 @@ impl ConstraintEvaluator for SolarRollEvaluator {
         Ok(None)
     }
 
+    /// When no fixed roll is configured the constraint participates in the
+    /// field-of-regard roll sweep: each candidate roll angle is checked for
+    /// solar compliance, so only solar-valid rolls contribute accessible sky.
+    fn is_roll_dependent(&self) -> bool {
+        self.roll_deg.is_none()
+    }
+
+    /// For the free-roll case: violated when the sweep candidate `roll_deg` is
+    /// outside the solar-tolerance band for the given target direction.
+    /// For the fixed-roll case: fall through to the default (calls `in_constraint_batch`).
+    fn field_of_regard_violated_at_roll(
+        &self,
+        ephemeris: &dyn EphemerisBase,
+        target_unit_vectors: &Array2<f64>,
+        time_index: usize,
+        roll_deg: f64,
+    ) -> PyResult<Vec<bool>> {
+        if self.roll_deg.is_some() {
+            // Fixed roll — the default implementation calls in_constraint_batch,
+            // which already uses self.roll_deg.
+            let n_targets = target_unit_vectors.nrows();
+            let result = self.in_constraint_batch(
+                ephemeris,
+                &(0..n_targets)
+                    .map(|i| {
+                        target_unit_vectors[[i, 1]]
+                            .atan2(target_unit_vectors[[i, 0]])
+                            .to_degrees()
+                            .rem_euclid(360.0)
+                    })
+                    .collect::<Vec<_>>(),
+                &(0..n_targets)
+                    .map(|i| {
+                        target_unit_vectors[[i, 2]]
+                            .clamp(-1.0, 1.0)
+                            .asin()
+                            .to_degrees()
+                    })
+                    .collect::<Vec<_>>(),
+                Some(&[time_index]),
+            )?;
+            return Ok((0..n_targets).map(|i| result[[i, 0]]).collect());
+        }
+
+        // Free-roll: check whether this sweep roll is within solar tolerance for each target.
+        let sun = ephemeris.get_sun_positions()?;
+        let obs = ephemeris.get_gcrs_positions()?;
+        let v = [
+            sun[[time_index, 0]] - obs[[time_index, 0]],
+            sun[[time_index, 1]] - obs[[time_index, 1]],
+            sun[[time_index, 2]] - obs[[time_index, 2]],
+        ];
+        let n = norm3(v);
+        let sun_unit = if n < NEAR_ZERO {
+            [1.0, 0.0, 0.0]
+        } else {
+            [v[0] / n, v[1] / n, v[2] / n]
+        };
+
+        let n_targets = target_unit_vectors.nrows();
+        let mut result = Vec::with_capacity(n_targets);
+        for i in 0..n_targets {
+            let target = [
+                target_unit_vectors[[i, 0]],
+                target_unit_vectors[[i, 1]],
+                target_unit_vectors[[i, 2]],
+            ];
+            let opt = solar_optimal_roll_deg(&target, &sun_unit, self.panel_normal);
+            result.push(circular_diff_deg(roll_deg, opt) > self.tolerance_deg);
+        }
+        Ok(result)
+    }
+
     fn name(&self) -> String {
         self.name_str()
     }

--- a/src/constraints/solar_roll.rs
+++ b/src/constraints/solar_roll.rs
@@ -10,11 +10,17 @@ use ndarray::Array2;
 use pyo3::PyResult;
 use serde::{Deserialize, Serialize};
 
+pub fn default_panel_normal() -> [f64; 3] {
+    [0.0, 1.0, 0.0]
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SolarRollConfig {
     pub tolerance_deg: f64,
     #[serde(default)]
     pub roll_deg: Option<f64>,
+    #[serde(default = "default_panel_normal")]
+    pub panel_normal: [f64; 3],
 }
 
 impl ConstraintConfig for SolarRollConfig {
@@ -22,6 +28,7 @@ impl ConstraintConfig for SolarRollConfig {
         Box::new(SolarRollEvaluator {
             tolerance_deg: self.tolerance_deg,
             roll_deg: self.roll_deg,
+            panel_normal: self.panel_normal,
         })
     }
 }
@@ -29,6 +36,7 @@ impl ConstraintConfig for SolarRollConfig {
 struct SolarRollEvaluator {
     tolerance_deg: f64,
     roll_deg: Option<f64>,
+    panel_normal: [f64; 3],
 }
 
 const NEAR_ZERO: f64 = 1.0e-12;
@@ -72,17 +80,23 @@ fn radec_to_unit(ra_deg: f64, dec_deg: f64) -> [f64; 3] {
 }
 
 /// Compute the north-referenced spacecraft roll (degrees, CCW positive) that maximises
-/// solar illumination of the +Y body panel.
+/// solar illumination of the panel with the given body-frame normal.
 ///
 /// North-referenced body frame (same convention as `boresight_rotate` in roll_range.rs):
 ///   x = boresight (target direction)
 ///   z = celestial north projected onto the plane perpendicular to x
 ///   y = z × x  (recomputed for orthonormality)
 ///
-/// At roll θ the +Y body axis is:  y·cos(θ) + z·sin(θ)
-/// Illumination of +Y panel:       s_y(θ) = sun_y·cos(θ) + sun_z·sin(θ)
-/// Optimal roll (d/dθ = 0):        θ_opt = atan2(sun_z, sun_y)
-pub fn solar_optimal_roll_deg(target: &[f64; 3], sun_unit: &[f64; 3]) -> f64 {
+/// At roll θ the body Y-axis is:  y_ref·cos(θ) + z_ref·sin(θ)
+/// For panel normal n = [nx, ny, nz] (body frame, x = boresight), the panel
+/// illumination is maximised at:
+///   θ_opt = atan2(sun_z, sun_y) - atan2(nz, ny)
+/// The +Y default (ny=1, nz=0) recovers the original formula.
+pub fn solar_optimal_roll_deg(
+    target: &[f64; 3],
+    sun_unit: &[f64; 3],
+    panel_normal: [f64; 3],
+) -> f64 {
     let x_axis = *target;
     let z_ref = [0.0_f64, 0.0, 1.0];
 
@@ -116,13 +130,16 @@ pub fn solar_optimal_roll_deg(target: &[f64; 3], sun_unit: &[f64; 3]) -> f64 {
     let sun_y = dot3(*sun_unit, y_axis);
     let sun_z = dot3(*sun_unit, z_axis);
 
-    f64::atan2(sun_z, sun_y).to_degrees()
+    // Shift by the angle of the panel normal in the body Y-Z plane.
+    let panel_angle = f64::atan2(panel_normal[2], panel_normal[1]);
+    (f64::atan2(sun_z, sun_y) - panel_angle).to_degrees()
 }
 
 /// Shortest angular arc between two roll angles (result in [0, 180]).
 #[inline]
 pub fn circular_diff_deg(a: f64, b: f64) -> f64 {
-    ((a - b).rem_euclid(360.0) - 180.0).abs()
+    let d = (a - b).rem_euclid(360.0);
+    180.0 - (d - 180.0).abs()
 }
 
 impl SolarRollEvaluator {
@@ -181,7 +198,7 @@ impl ConstraintEvaluator for SolarRollEvaluator {
         let violations = track_violations(
             &times_filtered,
             |i| {
-                let opt = solar_optimal_roll_deg(&target, &sun_units[i]);
+                let opt = solar_optimal_roll_deg(&target, &sun_units[i], self.panel_normal);
                 let diff = circular_diff_deg(roll, opt);
                 let violated = diff > self.tolerance_deg;
                 (
@@ -197,7 +214,7 @@ impl ConstraintEvaluator for SolarRollEvaluator {
                 if !violated {
                     return "".to_string();
                 }
-                let opt = solar_optimal_roll_deg(&target, &sun_units[i]);
+                let opt = solar_optimal_roll_deg(&target, &sun_units[i], self.panel_normal);
                 let diff = circular_diff_deg(roll, opt);
                 format!(
                     "Roll {:.1}° deviates {:.1}° from solar-optimal {:.1}° (tolerance {:.1}°)",
@@ -250,7 +267,7 @@ impl ConstraintEvaluator for SolarRollEvaluator {
                 } else {
                     [v[0] / n, v[1] / n, v[2] / n]
                 };
-                let opt = solar_optimal_roll_deg(&target, &sun_unit);
+                let opt = solar_optimal_roll_deg(&target, &sun_unit, self.panel_normal);
                 result[[j, i]] = circular_diff_deg(roll, opt) > self.tolerance_deg;
             }
         }
@@ -273,5 +290,123 @@ impl ConstraintEvaluator for SolarRollEvaluator {
 
     fn as_any(&self) -> &dyn std::any::Any {
         self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Boresight along GCRS +X gives a clean reference frame:
+    //   x_axis = [1, 0, 0]
+    //   z_ref  = [0, 0, 1]  → z_raw = [0, 0, 1] (z_ref fully perpendicular to x)
+    //   z_axis = [0, 0, 1]
+    //   y_raw  = z × x = [0, 1, 0]
+    //   y_axis = [0, 1, 0]
+    // So sun_y = sun·ŷ and sun_z = sun·ẑ are just the sun's Y and Z GCRS components.
+    const X_BORESIGHT: [f64; 3] = [1.0, 0.0, 0.0];
+
+    fn approx_eq(a: f64, b: f64) -> bool {
+        (a - b).abs() < 1e-8
+    }
+
+    // --- solar_optimal_roll_deg ---
+
+    #[test]
+    fn test_optimal_roll_default_panel_sun_along_y() {
+        // Sun on +Y, panel normal +Y → sun is already on the panel → optimal roll = 0°
+        let opt = solar_optimal_roll_deg(&X_BORESIGHT, &[0.0, 1.0, 0.0], [0.0, 1.0, 0.0]);
+        assert!(approx_eq(opt, 0.0), "expected 0°, got {opt}");
+    }
+
+    #[test]
+    fn test_optimal_roll_default_panel_sun_along_z() {
+        // Sun on +Z, panel normal +Y → need 90° roll to face the sun
+        let opt = solar_optimal_roll_deg(&X_BORESIGHT, &[0.0, 0.0, 1.0], [0.0, 1.0, 0.0]);
+        assert!(approx_eq(opt, 90.0), "expected 90°, got {opt}");
+    }
+
+    #[test]
+    fn test_optimal_roll_default_panel_sun_along_neg_y() {
+        // Sun on -Y, panel normal +Y → need ±180° roll
+        let opt = solar_optimal_roll_deg(&X_BORESIGHT, &[0.0, -1.0, 0.0], [0.0, 1.0, 0.0]);
+        assert!(approx_eq(opt.abs(), 180.0), "expected ±180°, got {opt}");
+    }
+
+    #[test]
+    fn test_optimal_roll_panel_z_sun_along_z() {
+        // Sun on +Z, panel normal +Z → no roll needed, optimal = 0°
+        let opt = solar_optimal_roll_deg(&X_BORESIGHT, &[0.0, 0.0, 1.0], [0.0, 0.0, 1.0]);
+        assert!(approx_eq(opt, 0.0), "expected 0°, got {opt}");
+    }
+
+    #[test]
+    fn test_optimal_roll_panel_z_sun_along_y() {
+        // Sun on +Y, panel normal +Z → optimal is -90° (panel must roll -90° to face +Y)
+        let opt = solar_optimal_roll_deg(&X_BORESIGHT, &[0.0, 1.0, 0.0], [0.0, 0.0, 1.0]);
+        assert!(approx_eq(opt, -90.0), "expected -90°, got {opt}");
+    }
+
+    #[test]
+    fn test_optimal_roll_panel_45deg_sun_along_z() {
+        // Panel tilted 45° from +Y toward +Z, sun on +Z → need 45° roll
+        let c = 45.0_f64.to_radians().cos();
+        let s = 45.0_f64.to_radians().sin();
+        let opt = solar_optimal_roll_deg(&X_BORESIGHT, &[0.0, 0.0, 1.0], [0.0, c, s]);
+        assert!(approx_eq(opt, 45.0), "expected 45°, got {opt}");
+    }
+
+    #[test]
+    fn test_panel_normal_shift_is_90deg() {
+        // Rotating the panel 90° in the Y-Z plane shifts the optimal roll by exactly -90°
+        // for any sun direction in the Y-Z plane.
+        let sun = [0.0, 1.0_f64 / 2.0_f64.sqrt(), 1.0_f64 / 2.0_f64.sqrt()];
+        let opt_y = solar_optimal_roll_deg(&X_BORESIGHT, &sun, [0.0, 1.0, 0.0]);
+        let opt_z = solar_optimal_roll_deg(&X_BORESIGHT, &sun, [0.0, 0.0, 1.0]);
+        // +Z panel needs 90° less roll than +Y panel to face the same sun direction.
+        assert!(
+            approx_eq(opt_y - opt_z, 90.0),
+            "expected 90° shift, got {opt_y} - {opt_z} = {}",
+            opt_y - opt_z
+        );
+    }
+
+    #[test]
+    fn test_panel_x_component_ignored() {
+        // The X component of the panel normal (along boresight) does not affect the result.
+        let sun = [0.0, 0.0, 1.0];
+        let opt_no_x = solar_optimal_roll_deg(&X_BORESIGHT, &sun, [0.0, 1.0, 0.0]);
+        let opt_with_x = solar_optimal_roll_deg(&X_BORESIGHT, &sun, [5.0, 1.0, 0.0]);
+        assert!(
+            approx_eq(opt_no_x, opt_with_x),
+            "X component changed result: {opt_no_x} vs {opt_with_x}"
+        );
+    }
+
+    // --- circular_diff_deg ---
+
+    #[test]
+    fn test_circular_diff_identical() {
+        assert!(approx_eq(circular_diff_deg(45.0, 45.0), 0.0));
+    }
+
+    #[test]
+    fn test_circular_diff_antipodal() {
+        assert!(approx_eq(circular_diff_deg(0.0, 180.0), 180.0));
+        assert!(approx_eq(circular_diff_deg(180.0, 0.0), 180.0));
+    }
+
+    #[test]
+    fn test_circular_diff_wraparound() {
+        // 350° and 10° differ by 20° across the 0/360 boundary.
+        assert!(approx_eq(circular_diff_deg(350.0, 10.0), 20.0));
+        assert!(approx_eq(circular_diff_deg(10.0, 350.0), 20.0));
+    }
+
+    #[test]
+    fn test_circular_diff_symmetric() {
+        let a = 270.0_f64;
+        let b = 90.0_f64;
+        assert!(approx_eq(circular_diff_deg(a, b), circular_diff_deg(b, a)));
     }
 }

--- a/src/constraints/solar_roll.rs
+++ b/src/constraints/solar_roll.rs
@@ -1,0 +1,277 @@
+/// Solar roll constraint implementation.
+///
+/// Violated when the spacecraft's actual roll deviates from the solar-optimal roll
+/// (the roll that maximises solar illumination of the +Y body panel) by more than
+/// `tolerance_deg` degrees.  The optimal roll is computed using the north-referenced
+/// body frame convention shared with `boresight_rotate` in roll_range.rs.
+use super::core::{track_violations, ConstraintConfig, ConstraintEvaluator, ConstraintResult};
+use crate::ephemeris::ephemeris_common::EphemerisBase;
+use ndarray::Array2;
+use pyo3::PyResult;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SolarRollConfig {
+    pub tolerance_deg: f64,
+    #[serde(default)]
+    pub roll_deg: Option<f64>,
+}
+
+impl ConstraintConfig for SolarRollConfig {
+    fn to_evaluator(&self) -> Box<dyn ConstraintEvaluator> {
+        Box::new(SolarRollEvaluator {
+            tolerance_deg: self.tolerance_deg,
+            roll_deg: self.roll_deg,
+        })
+    }
+}
+
+struct SolarRollEvaluator {
+    tolerance_deg: f64,
+    roll_deg: Option<f64>,
+}
+
+const NEAR_ZERO: f64 = 1.0e-12;
+
+#[inline]
+fn dot3(a: [f64; 3], b: [f64; 3]) -> f64 {
+    a[0] * b[0] + a[1] * b[1] + a[2] * b[2]
+}
+
+#[inline]
+fn norm3(v: [f64; 3]) -> f64 {
+    (v[0] * v[0] + v[1] * v[1] + v[2] * v[2]).sqrt()
+}
+
+#[inline]
+fn cross3(a: [f64; 3], b: [f64; 3]) -> [f64; 3] {
+    [
+        a[1] * b[2] - a[2] * b[1],
+        a[2] * b[0] - a[0] * b[2],
+        a[0] * b[1] - a[1] * b[0],
+    ]
+}
+
+#[inline]
+fn normalize3(v: [f64; 3]) -> Option<[f64; 3]> {
+    let n = norm3(v);
+    if n <= NEAR_ZERO {
+        None
+    } else {
+        Some([v[0] / n, v[1] / n, v[2] / n])
+    }
+}
+
+#[inline]
+fn radec_to_unit(ra_deg: f64, dec_deg: f64) -> [f64; 3] {
+    let ra = ra_deg.to_radians();
+    let dec = dec_deg.to_radians();
+    let (sd, cd) = dec.sin_cos();
+    let (sr, cr) = ra.sin_cos();
+    [cd * cr, cd * sr, sd]
+}
+
+/// Compute the north-referenced spacecraft roll (degrees, CCW positive) that maximises
+/// solar illumination of the +Y body panel.
+///
+/// North-referenced body frame (same convention as `boresight_rotate` in roll_range.rs):
+///   x = boresight (target direction)
+///   z = celestial north projected onto the plane perpendicular to x
+///   y = z × x  (recomputed for orthonormality)
+///
+/// At roll θ the +Y body axis is:  y·cos(θ) + z·sin(θ)
+/// Illumination of +Y panel:       s_y(θ) = sun_y·cos(θ) + sun_z·sin(θ)
+/// Optimal roll (d/dθ = 0):        θ_opt = atan2(sun_z, sun_y)
+pub fn solar_optimal_roll_deg(target: &[f64; 3], sun_unit: &[f64; 3]) -> f64 {
+    let x_axis = *target;
+    let z_ref = [0.0_f64, 0.0, 1.0];
+
+    let zref_dot_x = dot3(x_axis, z_ref);
+    let z_raw = [
+        z_ref[0] - zref_dot_x * x_axis[0],
+        z_ref[1] - zref_dot_x * x_axis[1],
+        z_ref[2] - zref_dot_x * x_axis[2],
+    ];
+
+    let z_axis = normalize3(z_raw).unwrap_or_else(|| {
+        // Boresight near the celestial pole — pick a stable orthogonal fallback.
+        let fallback: [f64; 3] = if x_axis[2].abs() < 0.9 {
+            [0.0, 0.0, 1.0]
+        } else {
+            [0.0, 1.0, 0.0]
+        };
+        let d = dot3(x_axis, fallback);
+        let raw = [
+            fallback[0] - d * x_axis[0],
+            fallback[1] - d * x_axis[1],
+            fallback[2] - d * x_axis[2],
+        ];
+        normalize3(raw).unwrap_or([0.0, 1.0, 0.0])
+    });
+
+    let y_raw = cross3(z_axis, x_axis);
+    let y_axis = normalize3(y_raw).unwrap_or([0.0, 1.0, 0.0]);
+    let z_axis = cross3(x_axis, y_axis); // recomputed for strict orthonormality
+
+    let sun_y = dot3(*sun_unit, y_axis);
+    let sun_z = dot3(*sun_unit, z_axis);
+
+    f64::atan2(sun_z, sun_y).to_degrees()
+}
+
+/// Shortest angular arc between two roll angles (result in [0, 180]).
+#[inline]
+pub fn circular_diff_deg(a: f64, b: f64) -> f64 {
+    ((a - b).rem_euclid(360.0) - 180.0).abs()
+}
+
+impl SolarRollEvaluator {
+    fn name_str(&self) -> String {
+        format!("SolarRollConstraint(tolerance={:.1}°)", self.tolerance_deg)
+    }
+}
+
+impl ConstraintEvaluator for SolarRollEvaluator {
+    fn evaluate(
+        &self,
+        ephemeris: &dyn EphemerisBase,
+        target_ra: f64,
+        target_dec: f64,
+        time_indices: Option<&[usize]>,
+    ) -> PyResult<ConstraintResult> {
+        let times = ephemeris.get_times().expect("Ephemeris must have times");
+        let times_filtered: Vec<_> = if let Some(idx) = time_indices {
+            idx.iter().map(|&i| times[i]).collect()
+        } else {
+            times.to_vec()
+        };
+
+        let Some(roll) = self.roll_deg else {
+            // No roll provided — constraint is not applicable; report always satisfied.
+            return Ok(ConstraintResult::new(
+                vec![],
+                true,
+                self.name_str(),
+                times_filtered,
+            ));
+        };
+
+        let target = radec_to_unit(target_ra, target_dec);
+
+        // Pre-compute sun unit vectors with correct ephemeris index mapping.
+        let sun = ephemeris.get_sun_positions()?;
+        let obs = ephemeris.get_gcrs_positions()?;
+        let sun_units: Vec<[f64; 3]> = (0..times_filtered.len())
+            .map(|i| {
+                let idx = time_indices.map_or(i, |indices| indices[i]);
+                let v = [
+                    sun[[idx, 0]] - obs[[idx, 0]],
+                    sun[[idx, 1]] - obs[[idx, 1]],
+                    sun[[idx, 2]] - obs[[idx, 2]],
+                ];
+                let n = norm3(v);
+                if n < NEAR_ZERO {
+                    [1.0, 0.0, 0.0]
+                } else {
+                    [v[0] / n, v[1] / n, v[2] / n]
+                }
+            })
+            .collect();
+
+        let violations = track_violations(
+            &times_filtered,
+            |i| {
+                let opt = solar_optimal_roll_deg(&target, &sun_units[i]);
+                let diff = circular_diff_deg(roll, opt);
+                let violated = diff > self.tolerance_deg;
+                (
+                    violated,
+                    if violated {
+                        diff - self.tolerance_deg
+                    } else {
+                        0.0
+                    },
+                )
+            },
+            |i, violated| {
+                if !violated {
+                    return "".to_string();
+                }
+                let opt = solar_optimal_roll_deg(&target, &sun_units[i]);
+                let diff = circular_diff_deg(roll, opt);
+                format!(
+                    "Roll {:.1}° deviates {:.1}° from solar-optimal {:.1}° (tolerance {:.1}°)",
+                    roll, diff, opt, self.tolerance_deg
+                )
+            },
+        );
+
+        let all_satisfied = violations.is_empty();
+        Ok(ConstraintResult::new(
+            violations,
+            all_satisfied,
+            self.name_str(),
+            times_filtered,
+        ))
+    }
+
+    fn in_constraint_batch(
+        &self,
+        ephemeris: &dyn EphemerisBase,
+        target_ras: &[f64],
+        target_decs: &[f64],
+        time_indices: Option<&[usize]>,
+    ) -> PyResult<Array2<bool>> {
+        let (times_filtered,) = extract_time_data!(ephemeris, time_indices);
+        let n_targets = target_ras.len();
+        let n_times = times_filtered.len();
+        let mut result = Array2::<bool>::from_elem((n_targets, n_times), false);
+
+        let Some(roll) = self.roll_deg else {
+            // No roll — always satisfied (not violated).
+            return Ok(result);
+        };
+
+        let sun = ephemeris.get_sun_positions()?;
+        let obs = ephemeris.get_gcrs_positions()?;
+
+        for j in 0..n_targets {
+            let target = radec_to_unit(target_ras[j], target_decs[j]);
+            for i in 0..n_times {
+                let source_i = time_indices.map_or(i, |indices| indices[i]);
+                let v = [
+                    sun[[source_i, 0]] - obs[[source_i, 0]],
+                    sun[[source_i, 1]] - obs[[source_i, 1]],
+                    sun[[source_i, 2]] - obs[[source_i, 2]],
+                ];
+                let n = norm3(v);
+                let sun_unit = if n < NEAR_ZERO {
+                    [1.0, 0.0, 0.0]
+                } else {
+                    [v[0] / n, v[1] / n, v[2] / n]
+                };
+                let opt = solar_optimal_roll_deg(&target, &sun_unit);
+                result[[j, i]] = circular_diff_deg(roll, opt) > self.tolerance_deg;
+            }
+        }
+
+        Ok(result)
+    }
+
+    fn in_constraint_batch_unit_vectors(
+        &self,
+        _ephemeris: &dyn EphemerisBase,
+        _target_unit_vectors: &Array2<f64>,
+        _time_indices: Option<&[usize]>,
+    ) -> PyResult<Option<Array2<bool>>> {
+        Ok(None)
+    }
+
+    fn name(&self) -> String {
+        self.name_str()
+    }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+}

--- a/src/constraints/solar_roll.rs
+++ b/src/constraints/solar_roll.rs
@@ -284,6 +284,52 @@ impl ConstraintEvaluator for SolarRollEvaluator {
         Ok(None)
     }
 
+    /// Hot path for coordinated roll sweep: evaluate at `roll_deg` without any
+    /// JSON round-trip.  Fixed-roll mode delegates to `in_constraint_batch` unchanged.
+    fn in_constraint_batch_at_roll(
+        &self,
+        ephemeris: &dyn EphemerisBase,
+        target_ras: &[f64],
+        target_decs: &[f64],
+        time_indices: Option<&[usize]>,
+        roll_deg: f64,
+    ) -> PyResult<Array2<bool>> {
+        if self.roll_deg.is_some() {
+            // Fixed roll — in_constraint_batch already evaluates at self.roll_deg.
+            return self.in_constraint_batch(ephemeris, target_ras, target_decs, time_indices);
+        }
+        // Free roll: evaluate at the sweep-provided roll_deg.
+        let (times_filtered,) = extract_time_data!(ephemeris, time_indices);
+        let n_targets = target_ras.len();
+        let n_times = times_filtered.len();
+        let mut result = Array2::<bool>::from_elem((n_targets, n_times), false);
+
+        let sun = ephemeris.get_sun_positions()?;
+        let obs = ephemeris.get_gcrs_positions()?;
+
+        for j in 0..n_targets {
+            let target = radec_to_unit(target_ras[j], target_decs[j]);
+            for i in 0..n_times {
+                let source_i = time_indices.map_or(i, |indices| indices[i]);
+                let v = [
+                    sun[[source_i, 0]] - obs[[source_i, 0]],
+                    sun[[source_i, 1]] - obs[[source_i, 1]],
+                    sun[[source_i, 2]] - obs[[source_i, 2]],
+                ];
+                let n = norm3(v);
+                let sun_unit = if n < NEAR_ZERO {
+                    [1.0, 0.0, 0.0]
+                } else {
+                    [v[0] / n, v[1] / n, v[2] / n]
+                };
+                let opt = solar_optimal_roll_deg(&target, &sun_unit, self.panel_normal);
+                result[[j, i]] = circular_diff_deg(roll_deg, opt) > self.tolerance_deg;
+            }
+        }
+
+        Ok(result)
+    }
+
     /// When no fixed roll is configured the constraint participates in the
     /// field-of-regard roll sweep: each candidate roll angle is checked for
     /// solar compliance, so only solar-valid rolls contribute accessible sky.

--- a/src/constraints/solar_roll.rs
+++ b/src/constraints/solar_roll.rs
@@ -79,6 +79,13 @@ fn radec_to_unit(ra_deg: f64, dec_deg: f64) -> [f64; 3] {
     [cd * cr, cd * sr, sd]
 }
 
+#[inline]
+fn roll_is_unconstrained(sun_y: f64, sun_z: f64, panel_normal: [f64; 3]) -> bool {
+    let sun_proj = (sun_y * sun_y + sun_z * sun_z).sqrt();
+    let panel_proj = (panel_normal[1] * panel_normal[1] + panel_normal[2] * panel_normal[2]).sqrt();
+    sun_proj <= NEAR_ZERO || panel_proj <= NEAR_ZERO
+}
+
 /// Compute the north-referenced spacecraft roll (degrees, CCW positive) that maximises
 /// solar illumination of the panel with the given body-frame normal.
 ///
@@ -198,6 +205,11 @@ impl ConstraintEvaluator for SolarRollEvaluator {
         let violations = track_violations(
             &times_filtered,
             |i| {
+                let sun_y = dot3(sun_units[i], [0.0, 1.0, 0.0]);
+                let sun_z = dot3(sun_units[i], [0.0, 0.0, 1.0]);
+                if roll_is_unconstrained(sun_y, sun_z, self.panel_normal) {
+                    return (false, 0.0);
+                }
                 let opt = solar_optimal_roll_deg(&target, &sun_units[i], self.panel_normal);
                 let diff = circular_diff_deg(roll, opt);
                 let violated = diff > self.tolerance_deg;
@@ -267,8 +279,14 @@ impl ConstraintEvaluator for SolarRollEvaluator {
                 } else {
                     [v[0] / n, v[1] / n, v[2] / n]
                 };
-                let opt = solar_optimal_roll_deg(&target, &sun_unit, self.panel_normal);
-                result[[j, i]] = circular_diff_deg(roll, opt) > self.tolerance_deg;
+                let sun_y = dot3(sun_unit, [0.0, 1.0, 0.0]);
+                let sun_z = dot3(sun_unit, [0.0, 0.0, 1.0]);
+                if roll_is_unconstrained(sun_y, sun_z, self.panel_normal) {
+                    result[[j, i]] = false;
+                } else {
+                    let opt = solar_optimal_roll_deg(&target, &sun_unit, self.panel_normal);
+                    result[[j, i]] = circular_diff_deg(roll, opt) > self.tolerance_deg;
+                }
             }
         }
 
@@ -322,8 +340,14 @@ impl ConstraintEvaluator for SolarRollEvaluator {
                 } else {
                     [v[0] / n, v[1] / n, v[2] / n]
                 };
-                let opt = solar_optimal_roll_deg(&target, &sun_unit, self.panel_normal);
-                result[[j, i]] = circular_diff_deg(roll_deg, opt) > self.tolerance_deg;
+                let sun_y = dot3(sun_unit, [0.0, 1.0, 0.0]);
+                let sun_z = dot3(sun_unit, [0.0, 0.0, 1.0]);
+                if roll_is_unconstrained(sun_y, sun_z, self.panel_normal) {
+                    result[[j, i]] = false;
+                } else {
+                    let opt = solar_optimal_roll_deg(&target, &sun_unit, self.panel_normal);
+                    result[[j, i]] = circular_diff_deg(roll_deg, opt) > self.tolerance_deg;
+                }
             }
         }
 
@@ -388,6 +412,11 @@ impl ConstraintEvaluator for SolarRollEvaluator {
         } else {
             [v[0] / n, v[1] / n, v[2] / n]
         };
+        let sun_y = dot3(sun_unit, [0.0, 1.0, 0.0]);
+        let sun_z = dot3(sun_unit, [0.0, 0.0, 1.0]);
+        if roll_is_unconstrained(sun_y, sun_z, self.panel_normal) {
+            return Ok(vec![false; target_unit_vectors.nrows()]);
+        }
 
         let n_targets = target_unit_vectors.nrows();
         let mut result = Vec::with_capacity(n_targets);

--- a/src/constraints/solar_roll.rs
+++ b/src/constraints/solar_roll.rs
@@ -80,7 +80,11 @@ fn radec_to_unit(ra_deg: f64, dec_deg: f64) -> [f64; 3] {
 }
 
 #[inline]
-fn roll_is_unconstrained(target: &[f64; 3], sun_unit: &[f64; 3], panel_normal: [f64; 3]) -> bool {
+pub fn roll_is_unconstrained(
+    target: &[f64; 3],
+    sun_unit: &[f64; 3],
+    panel_normal: [f64; 3],
+) -> bool {
     // Roll is unconstrained when sun is along the boresight (target direction).
     // In that case the panel is edge-on to the sun regardless of roll angle.
     let sun_along_boresight = dot3(*sun_unit, *target).abs() > 1.0 - NEAR_ZERO;
@@ -169,7 +173,7 @@ impl ConstraintEvaluator for SolarRollEvaluator {
         target_dec: f64,
         time_indices: Option<&[usize]>,
     ) -> PyResult<ConstraintResult> {
-        let times = ephemeris.get_times().expect("Ephemeris must have times");
+        let times = ephemeris.get_times()?;
         let times_filtered: Vec<_> = if let Some(idx) = time_indices {
             idx.iter().map(|&i| times[i]).collect()
         } else {

--- a/src/constraints/solar_roll.rs
+++ b/src/constraints/solar_roll.rs
@@ -80,10 +80,16 @@ fn radec_to_unit(ra_deg: f64, dec_deg: f64) -> [f64; 3] {
 }
 
 #[inline]
-fn roll_is_unconstrained(sun_y: f64, sun_z: f64, panel_normal: [f64; 3]) -> bool {
-    let sun_proj = (sun_y * sun_y + sun_z * sun_z).sqrt();
+fn roll_is_unconstrained(target: &[f64; 3], sun_unit: &[f64; 3], panel_normal: [f64; 3]) -> bool {
+    // Roll is unconstrained when sun is along the boresight (target direction).
+    // In that case the panel is edge-on to the sun regardless of roll angle.
+    let sun_along_boresight = dot3(*sun_unit, *target).abs() > 1.0 - NEAR_ZERO;
+
+    // Also unconstrained if panel normal has no Y/Z component in body frame
+    // (perpendicular to the Y-Z plane, so roll can't change illumination).
     let panel_proj = (panel_normal[1] * panel_normal[1] + panel_normal[2] * panel_normal[2]).sqrt();
-    sun_proj <= NEAR_ZERO || panel_proj <= NEAR_ZERO
+
+    sun_along_boresight || panel_proj <= NEAR_ZERO
 }
 
 /// Compute the north-referenced spacecraft roll (degrees, CCW positive) that maximises
@@ -205,9 +211,7 @@ impl ConstraintEvaluator for SolarRollEvaluator {
         let violations = track_violations(
             &times_filtered,
             |i| {
-                let sun_y = dot3(sun_units[i], [0.0, 1.0, 0.0]);
-                let sun_z = dot3(sun_units[i], [0.0, 0.0, 1.0]);
-                if roll_is_unconstrained(sun_y, sun_z, self.panel_normal) {
+                if roll_is_unconstrained(&target, &sun_units[i], self.panel_normal) {
                     return (false, 0.0);
                 }
                 let opt = solar_optimal_roll_deg(&target, &sun_units[i], self.panel_normal);
@@ -279,9 +283,7 @@ impl ConstraintEvaluator for SolarRollEvaluator {
                 } else {
                     [v[0] / n, v[1] / n, v[2] / n]
                 };
-                let sun_y = dot3(sun_unit, [0.0, 1.0, 0.0]);
-                let sun_z = dot3(sun_unit, [0.0, 0.0, 1.0]);
-                if roll_is_unconstrained(sun_y, sun_z, self.panel_normal) {
+                if roll_is_unconstrained(&target, &sun_unit, self.panel_normal) {
                     result[[j, i]] = false;
                 } else {
                     let opt = solar_optimal_roll_deg(&target, &sun_unit, self.panel_normal);
@@ -340,9 +342,7 @@ impl ConstraintEvaluator for SolarRollEvaluator {
                 } else {
                     [v[0] / n, v[1] / n, v[2] / n]
                 };
-                let sun_y = dot3(sun_unit, [0.0, 1.0, 0.0]);
-                let sun_z = dot3(sun_unit, [0.0, 0.0, 1.0]);
-                if roll_is_unconstrained(sun_y, sun_z, self.panel_normal) {
+                if roll_is_unconstrained(&target, &sun_unit, self.panel_normal) {
                     result[[j, i]] = false;
                 } else {
                     let opt = solar_optimal_roll_deg(&target, &sun_unit, self.panel_normal);
@@ -412,12 +412,8 @@ impl ConstraintEvaluator for SolarRollEvaluator {
         } else {
             [v[0] / n, v[1] / n, v[2] / n]
         };
-        let sun_y = dot3(sun_unit, [0.0, 1.0, 0.0]);
-        let sun_z = dot3(sun_unit, [0.0, 0.0, 1.0]);
-        if roll_is_unconstrained(sun_y, sun_z, self.panel_normal) {
-            return Ok(vec![false; target_unit_vectors.nrows()]);
-        }
 
+        // Check each target individually since roll_is_unconstrained depends on target direction
         let n_targets = target_unit_vectors.nrows();
         let mut result = Vec::with_capacity(n_targets);
         for i in 0..n_targets {
@@ -426,8 +422,12 @@ impl ConstraintEvaluator for SolarRollEvaluator {
                 target_unit_vectors[[i, 1]],
                 target_unit_vectors[[i, 2]],
             ];
-            let opt = solar_optimal_roll_deg(&target, &sun_unit, self.panel_normal);
-            result.push(circular_diff_deg(roll_deg, opt) > self.tolerance_deg);
+            if roll_is_unconstrained(&target, &sun_unit, self.panel_normal) {
+                result.push(false);
+            } else {
+                let opt = solar_optimal_roll_deg(&target, &sun_unit, self.panel_normal);
+                result.push(circular_diff_deg(roll_deg, opt) > self.tolerance_deg);
+            }
         }
         Ok(result)
     }

--- a/src/ephemeris/ephemeris_common.rs
+++ b/src/ephemeris/ephemeris_common.rs
@@ -520,6 +520,26 @@ pub trait EphemerisBase {
         Ok(moon_data.slice(s![.., 0..3]).to_owned())
     }
 
+    /// Get geocentric GCRS positions (N x 3, km) for any body supported by the
+    /// loaded DE440 almanac or SPICE kernels.  Body can be a name ("Jupiter",
+    /// "Mars") or a NAIF ID string ("599", "499").
+    fn get_any_body_gcrs_positions(&self, body_identifier: &str) -> PyResult<Array2<f64>> {
+        use crate::utils::celestial::calculate_body_by_id_or_name;
+        use crate::utils::config::EARTH_NAIF_ID;
+
+        let times = self
+            .data()
+            .times
+            .as_ref()
+            .ok_or_else(|| pyo3::exceptions::PyValueError::new_err("No times available."))?;
+
+        let pv = calculate_body_by_id_or_name(times, body_identifier, EARTH_NAIF_ID, None, false)
+            .map_err(pyo3::exceptions::PyValueError::new_err)?;
+
+        // First 3 columns are positions (km); velocities are not needed here.
+        Ok(pv.slice(s![.., 0..3]).to_owned())
+    }
+
     /// Calculate Moon illumination fraction for all ephemeris times
     ///
     /// Returns the fraction of the Moon's illuminated surface as seen from the

--- a/tests/constraints/conftest.py
+++ b/tests/constraints/conftest.py
@@ -166,8 +166,11 @@ class DummyConstraintBackend:
         target_decs: object,
         times: object,
         indices: object,
+        n_roll_samples: object = None,
     ) -> npt.NDArray[np.bool_]:
-        self.batch_calls.append((ephemeris, target_ras, target_decs, times, indices))
+        self.batch_calls.append(
+            (ephemeris, target_ras, target_decs, times, indices, n_roll_samples)
+        )
         return np.array([[True], [False]])
 
     def in_constraint(

--- a/tests/constraints/solar_roll_constraint/test_solar_roll_constraint.py
+++ b/tests/constraints/solar_roll_constraint/test_solar_roll_constraint.py
@@ -1,0 +1,363 @@
+"""Tests for SolarRollConstraint, including the panel_normal parameter.
+
+The constraint is satisfied when the spacecraft roll is within tolerance_deg of
+the solar-optimal roll — the roll that maximises illumination of the panel whose
+body-frame normal is given by panel_normal.
+
+Key relationship tested:  rotating panel_normal by α degrees in the body Y-Z
+plane shifts the optimal roll by -α degrees.  The default panel_normal (0,1,0)
+recovers the pre-existing +Y-panel behaviour.
+"""
+
+from __future__ import annotations
+
+import math
+from datetime import datetime
+from typing import cast
+
+import pytest
+from pydantic import ValidationError
+
+import rust_ephem
+from rust_ephem.constraints import SolarRollConstraint
+
+# ---------------------------------------------------------------------------
+# Model creation and validation
+# ---------------------------------------------------------------------------
+
+
+class TestSolarRollConstraintModel:
+    def test_creation_basic(self) -> None:
+        c = SolarRollConstraint(tolerance_deg=10.0)
+        assert c.tolerance_deg == 10.0
+
+    def test_type_field(self) -> None:
+        c = SolarRollConstraint(tolerance_deg=5.0)
+        assert c.type == "solar_roll"
+
+    def test_panel_normal_default(self) -> None:
+        c = SolarRollConstraint(tolerance_deg=5.0)
+        assert c.panel_normal == (0.0, 1.0, 0.0)
+
+    def test_panel_normal_explicit(self) -> None:
+        c = SolarRollConstraint(tolerance_deg=5.0, panel_normal=(0.0, 0.0, 1.0))
+        assert c.panel_normal == (0.0, 0.0, 1.0)
+
+    def test_panel_normal_arbitrary_angle(self) -> None:
+        alpha = math.radians(30.0)
+        n = (0.0, math.cos(alpha), math.sin(alpha))
+        c = SolarRollConstraint(tolerance_deg=5.0, panel_normal=n)
+        assert c.panel_normal[0] == pytest.approx(0.0)
+        assert c.panel_normal[1] == pytest.approx(math.cos(alpha))
+        assert c.panel_normal[2] == pytest.approx(math.sin(alpha))
+
+    def test_tolerance_deg_zero_valid(self) -> None:
+        SolarRollConstraint(tolerance_deg=0.0)
+
+    def test_tolerance_deg_180_valid(self) -> None:
+        SolarRollConstraint(tolerance_deg=180.0)
+
+    def test_tolerance_deg_below_zero_raises(self) -> None:
+        with pytest.raises(ValidationError):
+            SolarRollConstraint(tolerance_deg=-1.0)
+
+    def test_tolerance_deg_above_180_raises(self) -> None:
+        with pytest.raises(ValidationError):
+            SolarRollConstraint(tolerance_deg=181.0)
+
+    def test_json_round_trip_default_panel_normal(self) -> None:
+        c = SolarRollConstraint(tolerance_deg=15.0)
+        json_str = c.model_dump_json()
+        c2 = SolarRollConstraint.model_validate_json(json_str)
+        assert c2.tolerance_deg == c.tolerance_deg
+        assert c2.panel_normal == c.panel_normal
+
+    def test_json_round_trip_custom_panel_normal(self) -> None:
+        alpha = math.radians(45.0)
+        n = (0.0, math.cos(alpha), math.sin(alpha))
+        c = SolarRollConstraint(tolerance_deg=10.0, panel_normal=n)
+        json_str = c.model_dump_json()
+        c2 = SolarRollConstraint.model_validate_json(json_str)
+        assert c2.panel_normal[1] == pytest.approx(math.cos(alpha))
+        assert c2.panel_normal[2] == pytest.approx(math.sin(alpha))
+
+
+# ---------------------------------------------------------------------------
+# Evaluation without a roll (target_roll=None → always satisfied)
+# ---------------------------------------------------------------------------
+
+
+class TestSolarRollConstraintNoRoll:
+    def test_no_roll_always_satisfied(
+        self, tle_ephemeris: rust_ephem.TLEEphemeris
+    ) -> None:
+        """Without a target_roll the constraint reports all_satisfied."""
+        c = SolarRollConstraint(tolerance_deg=10.0)
+        result = c.evaluate(tle_ephemeris, target_ra=30.0, target_dec=10.0)
+        assert result.all_satisfied
+
+    def test_no_roll_always_satisfied_custom_panel_normal(
+        self, tle_ephemeris: rust_ephem.TLEEphemeris
+    ) -> None:
+        """panel_normal has no effect when roll is not evaluated."""
+        c = SolarRollConstraint(tolerance_deg=10.0, panel_normal=(0.0, 0.0, 1.0))
+        result = c.evaluate(tle_ephemeris, target_ra=30.0, target_dec=10.0)
+        assert result.all_satisfied
+
+
+# ---------------------------------------------------------------------------
+# Wide tolerance — always satisfied for any roll
+# ---------------------------------------------------------------------------
+
+
+class TestSolarRollConstraintWideTolerance:
+    def test_wide_tolerance_satisfied_at_zero_roll(
+        self, tle_ephemeris: rust_ephem.TLEEphemeris
+    ) -> None:
+        """tolerance_deg=180 covers the full circle; any roll is within tolerance."""
+        c = SolarRollConstraint(tolerance_deg=180.0)
+        result = c.evaluate(
+            tle_ephemeris, target_ra=30.0, target_dec=10.0, target_roll=0.0
+        )
+        assert result.all_satisfied
+
+    def test_wide_tolerance_satisfied_at_arbitrary_roll(
+        self, tle_ephemeris: rust_ephem.TLEEphemeris
+    ) -> None:
+        for roll in [0.0, 45.0, 90.0, 135.0, 180.0, 270.0, 359.0]:
+            c = SolarRollConstraint(tolerance_deg=180.0)
+            result = c.evaluate(
+                tle_ephemeris, target_ra=30.0, target_dec=10.0, target_roll=roll
+            )
+            assert result.all_satisfied, f"Wide tolerance violated at roll={roll}°"
+
+    def test_wide_tolerance_custom_panel_normal_satisfied(
+        self, tle_ephemeris: rust_ephem.TLEEphemeris
+    ) -> None:
+        c = SolarRollConstraint(tolerance_deg=180.0, panel_normal=(0.0, 0.0, 1.0))
+        result = c.evaluate(
+            tle_ephemeris, target_ra=30.0, target_dec=10.0, target_roll=90.0
+        )
+        assert result.all_satisfied
+
+
+# ---------------------------------------------------------------------------
+# Default panel_normal matches explicit (0, 1, 0)
+# ---------------------------------------------------------------------------
+
+
+class TestSolarRollConstraintDefaultMatchesExplicit:
+    def test_default_panel_normal_matches_explicit_y(
+        self, tle_ephemeris: rust_ephem.TLEEphemeris
+    ) -> None:
+        """panel_normal=(0,1,0) must produce identical results to the default."""
+        c_default = SolarRollConstraint(tolerance_deg=20.0)
+        c_explicit = SolarRollConstraint(
+            tolerance_deg=20.0, panel_normal=(0.0, 1.0, 0.0)
+        )
+
+        for roll in [0.0, 45.0, 90.0, 135.0, 180.0, 270.0]:
+            r_default = c_default.evaluate(
+                tle_ephemeris, target_ra=30.0, target_dec=10.0, target_roll=roll
+            )
+            r_explicit = c_explicit.evaluate(
+                tle_ephemeris, target_ra=30.0, target_dec=10.0, target_roll=roll
+            )
+            assert r_default.all_satisfied == r_explicit.all_satisfied, (
+                f"Mismatch at roll={roll}°: default={r_default.all_satisfied}, "
+                f"explicit={r_explicit.all_satisfied}"
+            )
+
+
+# ---------------------------------------------------------------------------
+# Panel normal shift observable in roll_range
+# ---------------------------------------------------------------------------
+
+
+class TestSolarRollConstraintPanelNormalShift:
+    """Rotating panel_normal by 90° in the body Y-Z plane should shift the
+    optimal roll window by 90°.
+    """
+
+    @pytest.fixture
+    def sample_time(self, tle_ephemeris: rust_ephem.TLEEphemeris) -> datetime:
+        times = tle_ephemeris.timestamp
+        return cast(datetime, times[len(times) // 2])
+
+    def _window_center(self, intervals: list[tuple[float, float]]) -> float | None:
+        """Return the midpoint of the widest valid interval, or None if empty."""
+        if not intervals:
+            return None
+        lo, hi = max(intervals, key=lambda iv: iv[1] - iv[0])
+        return (lo + hi) / 2.0
+
+    def test_panel_normal_90deg_shifts_optimal_roll(
+        self,
+        tle_ephemeris: rust_ephem.TLEEphemeris,
+        sample_time: datetime,
+    ) -> None:
+        """Rotating panel from +Y to +Z shifts the optimal roll by ~90°."""
+        c_y = SolarRollConstraint(tolerance_deg=5.0, panel_normal=(0.0, 1.0, 0.0))
+        c_z = SolarRollConstraint(tolerance_deg=5.0, panel_normal=(0.0, 0.0, 1.0))
+
+        n = 360
+        intervals_y = c_y.roll_range(
+            sample_time,
+            ephemeris=tle_ephemeris,
+            target_ra=30.0,
+            target_dec=10.0,
+            n_roll_samples=n,
+        )
+        intervals_z = c_z.roll_range(
+            sample_time,
+            ephemeris=tle_ephemeris,
+            target_ra=30.0,
+            target_dec=10.0,
+            n_roll_samples=n,
+        )
+
+        center_y = self._window_center(intervals_y)
+        center_z = self._window_center(intervals_z)
+
+        assert center_y is not None, (
+            "panel_normal=(0,1,0) produced no valid roll window"
+        )
+        assert center_z is not None, (
+            "panel_normal=(0,0,1) produced no valid roll window"
+        )
+
+        # The +Z panel window should be ~90° away from the +Y panel window.
+        diff = abs(((center_z - center_y + 180.0) % 360.0) - 180.0)
+        assert diff == pytest.approx(90.0, abs=5.0), (
+            f"Expected ~90° shift between +Y and +Z panels, "
+            f"got {diff:.1f}° (center_y={center_y:.1f}°, center_z={center_z:.1f}°)"
+        )
+
+    def test_panel_normal_180deg_shifts_optimal_roll(
+        self,
+        tle_ephemeris: rust_ephem.TLEEphemeris,
+        sample_time: datetime,
+    ) -> None:
+        """Panel normal -Y (180° from +Y) shifts the optimal roll by ~180°."""
+        c_y = SolarRollConstraint(tolerance_deg=5.0, panel_normal=(0.0, 1.0, 0.0))
+        c_neg_y = SolarRollConstraint(tolerance_deg=5.0, panel_normal=(0.0, -1.0, 0.0))
+
+        n = 360
+        intervals_y = c_y.roll_range(
+            sample_time,
+            ephemeris=tle_ephemeris,
+            target_ra=30.0,
+            target_dec=10.0,
+            n_roll_samples=n,
+        )
+        intervals_neg_y = c_neg_y.roll_range(
+            sample_time,
+            ephemeris=tle_ephemeris,
+            target_ra=30.0,
+            target_dec=10.0,
+            n_roll_samples=n,
+        )
+
+        center_y = self._window_center(intervals_y)
+        center_neg_y = self._window_center(intervals_neg_y)
+
+        assert center_y is not None
+        assert center_neg_y is not None
+
+        diff = abs(((center_neg_y - center_y + 180.0) % 360.0) - 180.0)
+        assert diff == pytest.approx(180.0, abs=5.0), (
+            f"Expected ~180° shift between +Y and -Y panels, got {diff:.1f}°"
+        )
+
+    def test_panel_normal_arbitrary_angle_shift(
+        self,
+        tle_ephemeris: rust_ephem.TLEEphemeris,
+        sample_time: datetime,
+    ) -> None:
+        """A 30° panel rotation should shift the optimal roll by ~30°."""
+        alpha = 30.0
+        c_y = SolarRollConstraint(tolerance_deg=5.0, panel_normal=(0.0, 1.0, 0.0))
+        c_tilted = SolarRollConstraint(
+            tolerance_deg=5.0,
+            panel_normal=(
+                0.0,
+                math.cos(math.radians(alpha)),
+                math.sin(math.radians(alpha)),
+            ),
+        )
+
+        n = 360
+        intervals_y = c_y.roll_range(
+            sample_time,
+            ephemeris=tle_ephemeris,
+            target_ra=30.0,
+            target_dec=10.0,
+            n_roll_samples=n,
+        )
+        intervals_tilted = c_tilted.roll_range(
+            sample_time,
+            ephemeris=tle_ephemeris,
+            target_ra=30.0,
+            target_dec=10.0,
+            n_roll_samples=n,
+        )
+
+        center_y = self._window_center(intervals_y)
+        center_tilted = self._window_center(intervals_tilted)
+
+        assert center_y is not None
+        assert center_tilted is not None
+
+        # Tilted panel needs alpha° less roll than +Y panel.
+        diff = abs(((center_y - center_tilted + 180.0) % 360.0) - 180.0)
+        assert diff == pytest.approx(alpha, abs=5.0), (
+            f"Expected ~{alpha}° shift for {alpha}° panel tilt, got {diff:.1f}°"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Batch evaluation
+# ---------------------------------------------------------------------------
+
+
+class TestSolarRollConstraintBatch:
+    def test_in_constraint_batch_shape(
+        self, tle_ephemeris: rust_ephem.TLEEphemeris
+    ) -> None:
+        """in_constraint_batch must return (n_targets, n_times) shape."""
+        c = SolarRollConstraint(tolerance_deg=10.0)
+        n_targets = 3
+        ras = [0.0, 90.0, 180.0]
+        decs = [0.0, 30.0, -30.0]
+        result = c.in_constraint_batch(
+            tle_ephemeris, ras, decs, target_rolls=[0.0] * n_targets
+        )
+        assert result.shape == (n_targets, len(tle_ephemeris.timestamp))
+
+    def test_in_constraint_batch_wide_tolerance_no_violations(
+        self, tle_ephemeris: rust_ephem.TLEEphemeris
+    ) -> None:
+        """tolerance_deg=180 → no time step is violated for any target."""
+        import numpy as np
+
+        c = SolarRollConstraint(tolerance_deg=180.0)
+        n_targets = 4
+        ras = [0.0, 90.0, 180.0, 270.0]
+        decs = [0.0, 45.0, -45.0, 0.0]
+        result = c.in_constraint_batch(
+            tle_ephemeris, ras, decs, target_rolls=[45.0] * n_targets
+        )
+        # in_constraint_batch returns True where VIOLATED; wide tolerance → never violated
+        assert not np.any(result), "Wide tolerance should never produce a violation"
+
+    def test_in_constraint_batch_custom_panel_normal_shape(
+        self, tle_ephemeris: rust_ephem.TLEEphemeris
+    ) -> None:
+        c = SolarRollConstraint(tolerance_deg=10.0, panel_normal=(0.0, 0.0, 1.0))
+        n_targets = 2
+        ras = [15.0, 45.0]
+        decs = [5.0, -10.0]
+        result = c.in_constraint_batch(
+            tle_ephemeris, ras, decs, target_rolls=[0.0] * n_targets
+        )
+        assert result.shape == (n_targets, len(tle_ephemeris.timestamp))

--- a/tests/constraints/solar_roll_constraint/test_solar_roll_constraint.py
+++ b/tests/constraints/solar_roll_constraint/test_solar_roll_constraint.py
@@ -341,7 +341,7 @@ class TestSolarRollConstraintNestedInjection:
     ) -> None:
         solar = SolarRollConstraint(tolerance_deg=2.0)
         always_ok = rust_ephem.constraints.SunConstraint(min_angle=0.0)
-        combined = solar & always_ok
+        combined = solar | always_ok
 
         intervals = solar.roll_range(
             sample_time,

--- a/tests/constraints/solar_roll_constraint/test_solar_roll_constraint.py
+++ b/tests/constraints/solar_roll_constraint/test_solar_roll_constraint.py
@@ -316,6 +316,70 @@ class TestSolarRollConstraintPanelNormalShift:
 
 
 # ---------------------------------------------------------------------------
+# Nested solar_roll roll injection
+# ---------------------------------------------------------------------------
+
+
+class TestSolarRollConstraintNestedInjection:
+    @pytest.fixture
+    def sample_time(self, tle_ephemeris: rust_ephem.TLEEphemeris) -> datetime:
+        times = tle_ephemeris.timestamp
+        return cast(datetime, times[len(times) // 2])
+
+    def _roll_in_intervals(
+        self, roll_deg: float, intervals: list[tuple[float, float]]
+    ) -> bool:
+        for lo, hi in intervals:
+            if lo <= roll_deg <= hi:
+                return True
+        return False
+
+    def test_nested_solar_roll_honors_target_roll(
+        self,
+        tle_ephemeris: rust_ephem.TLEEphemeris,
+        sample_time: datetime,
+    ) -> None:
+        solar = SolarRollConstraint(tolerance_deg=2.0)
+        always_ok = rust_ephem.constraints.SunConstraint(min_angle=0.0)
+        combined = solar & always_ok
+
+        intervals = solar.roll_range(
+            sample_time,
+            ephemeris=tle_ephemeris,
+            target_ra=30.0,
+            target_dec=10.0,
+            n_roll_samples=360,
+        )
+
+        invalid_roll = None
+        for roll in range(0, 360):
+            if not self._roll_in_intervals(float(roll), intervals):
+                invalid_roll = float(roll)
+                break
+
+        if invalid_roll is None:
+            pytest.skip("No invalid roll found for this ephemeris sample")
+
+        solar_violation = solar.in_constraint(
+            sample_time,
+            ephemeris=tle_ephemeris,
+            target_ra=30.0,
+            target_dec=10.0,
+            target_roll=invalid_roll,
+        )
+        combined_violation = combined.in_constraint(
+            sample_time,
+            ephemeris=tle_ephemeris,
+            target_ra=30.0,
+            target_dec=10.0,
+            target_roll=invalid_roll,
+        )
+
+        assert solar_violation is True, "Expected a violating roll for solar_roll"
+        assert combined_violation == solar_violation
+
+
+# ---------------------------------------------------------------------------
 # Batch evaluation
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
This pull request introduces a new "solar roll" constraint to the `rust_ephem` package, enabling the system to check whether a spacecraft's roll angle remains within a specified tolerance of the solar-optimal roll (the orientation that maximizes solar illumination of the +Y body panel). The change is implemented across Python and Rust code, including constraint definition, serialization, evaluation logic, and API exposure.

**Key changes:**

#### Solar Roll Constraint Implementation

* Added the `SolarRollConstraint` class in Python (`constraints.py` and `constraints.pyi`), which defines the new constraint and its parameters, including `tolerance_deg` and `roll_deg`. The constraint is only active when a specific roll angle is provided and uses the sun direction to compute the optimal roll. [[1]](diffhunk://#diff-3dba367a5f087cea43ad0c5fbf3566683f951c8c54401173472d5b6bf22c07b3R1588-R1627) [[2]](diffhunk://#diff-5a41ff46843312c1bbeebbea63a22a87f5b99c7a96f464279697e3a2f5a2c888R241-R245) [[3]](diffhunk://#diff-5a41ff46843312c1bbeebbea63a22a87f5b99c7a96f464279697e3a2f5a2c888R303)
* Implemented the underlying Rust logic in a new file, `solar_roll.rs`, providing the algorithm to compute the solar-optimal roll and evaluate constraint violations both for single and batch evaluations.
* Integrated the new constraint into the Rust constraint wrapper and JSON parser, including serialization/deserialization, evaluator creation, and batch roll sweep logic. [[1]](diffhunk://#diff-572f890fabecdd973d28f1a6fe99b3dac7a340291e1359f07f493e53e663e8a8R14) [[2]](diffhunk://#diff-572f890fabecdd973d28f1a6fe99b3dac7a340291e1359f07f493e53e663e8a8R186-R191) [[3]](diffhunk://#diff-572f890fabecdd973d28f1a6fe99b3dac7a340291e1359f07f493e53e663e8a8R417-R424) [[4]](diffhunk://#diff-fa11270a46b63868477eb3427c577ffabfd1afc44234ecd402046cc4c896ef35R26) [[5]](diffhunk://#diff-26f61f6de1acf3c31f0a955e17bf69cb12c4fbff038d378f141d50dbdf75bb27R66-R122) [[6]](diffhunk://#diff-26f61f6de1acf3c31f0a955e17bf69cb12c4fbff038d378f141d50dbdf75bb27R459-R473)

#### API and Evaluation Pipeline Updates

* Updated the Python and Rust APIs to recognize and correctly handle the new `solar_roll` constraint type, including automatic injection of the current roll angle during evaluation and bypassing unnecessary wrappers. [[1]](diffhunk://#diff-3dba367a5f087cea43ad0c5fbf3566683f951c8c54401173472d5b6bf22c07b3R460-R467) [[2]](diffhunk://#diff-719cf3da4af36c14bc67d2a34f5626dda464d9fd8685f8144102f463e9ac5d66R73) [[3]](diffhunk://#diff-719cf3da4af36c14bc67d2a34f5626dda464d9fd8685f8144102f463e9ac5d66R88-R97)
* Registered the new constraint in all relevant module exports and configuration type unions, making it available for use in combined constraint configurations and as a top-level constraint type. [[1]](diffhunk://#diff-1c620d65e824d1b356a2ba35492ab5783b7697b72d6bbc8021cce190fd151284R48) [[2]](diffhunk://#diff-1c620d65e824d1b356a2ba35492ab5783b7697b72d6bbc8021cce190fd151284R69) [[3]](diffhunk://#diff-3dba367a5f087cea43ad0c5fbf3566683f951c8c54401173472d5b6bf22c07b3R1749)

These changes collectively enable scheduling and planning tools to enforce solar roll constraints generically for any spacecraft with a +Y primary solar panel, improving mission safety and power management.