### PR TITLE
fix(constraints): Solar roll optimization

### DIFF
--- a/rust_ephem/constraints.py
+++ b/rust_ephem/constraints.py
@@ -333,31 +333,12 @@ class RustConstraintMixin(BaseModel):
         n_roll_samples: int = DEFAULT_N_ROLL_SAMPLES,
     ) -> npt.NDArray[np.bool_]:
         """Evaluate a batch where all targets share the same roll semantics."""
-        if target_roll is None and self._is_roll_dependent():
-            # Sweep all spacecraft roll angles; a cell is violated only if blocked at
-            # every roll (AND across the sweep).
-            roll_step = 360.0 / n_roll_samples
-            combined: npt.NDArray[np.bool_] | None = None
-            for i in range(n_roll_samples):
-                r = i * roll_step
-                arr = np.asarray(
-                    self._resolve_rust_constraint(target_roll=r).in_constraint_batch(
-                        ephemeris, target_ras, target_decs, times, indices
-                    ),
-                    dtype=bool,
-                )
-                combined = (
-                    arr
-                    if combined is None
-                    else cast(npt.NDArray[np.bool_], combined & arr)
-                )
-            return cast(
-                npt.NDArray[np.bool_],
-                combined
-                if combined is not None
-                else np.ones((len(target_ras), 0), dtype=bool),
-            )
-
+        # When target_roll is None and the tree is roll-dependent the Rust backend
+        # performs the coordinated roll sweep internally (combinators hoist
+        # roll-independent siblings out of the loop, BrightStar caches its gnomonic
+        # projections, SolarRoll computes the optimal roll once per cell).  Delegate
+        # to it directly instead of looping in Python and rebuilding a fresh Rust
+        # constraint per roll step.
         rust_constraint = self._resolve_rust_constraint(
             target_roll=target_roll,
         )

--- a/src/constraints/bright_star.rs
+++ b/src/constraints/bright_star.rs
@@ -528,6 +528,7 @@ impl ConstraintEvaluator for BrightStarEvaluator {
             FovDefinition::Circle { cos_radius } => {
                 // Circle mode is not roll-dependent; evaluate normally.
                 return Ok((0..n_targets)
+                    .into_par_iter()
                     .map(|i| {
                         let target_unit = [
                             target_unit_vectors[[i, 0]],
@@ -545,6 +546,7 @@ impl ConstraintEvaluator for BrightStarEvaluator {
         let (sin_roll, cos_roll) = effective_roll_rad.sin_cos();
 
         Ok((0..n_targets)
+            .into_par_iter()
             .map(|i| {
                 let ux = target_unit_vectors[[i, 0]];
                 let uy = target_unit_vectors[[i, 1]];
@@ -561,6 +563,109 @@ impl ConstraintEvaluator for BrightStarEvaluator {
                 })
             })
             .collect())
+    }
+
+    /// Cached-projection FoR sweep: project nearby stars per target ONCE, then test
+    /// `n_roll_samples` rolls against the cached tangent-plane offsets.  Mirrors
+    /// `in_constraint_batch_constrained_at_every_roll` but operates on the unit-vector
+    /// grid that the FoR pipeline supplies, avoiding the 360× re-projection that the
+    /// default core-trait sweep would otherwise do via `field_of_regard_violated_at_roll`.
+    fn field_of_regard_violated_batch(
+        &self,
+        _ephemeris: &dyn crate::ephemeris::ephemeris_common::EphemerisBase,
+        target_unit_vectors: &Array2<f64>,
+        _time_index: usize,
+        n_roll_samples: usize,
+    ) -> PyResult<Vec<bool>> {
+        let n_targets = target_unit_vectors.nrows();
+
+        match &self.fov {
+            FovDefinition::Circle { cos_radius } => Ok((0..n_targets)
+                .into_par_iter()
+                .map(|i| {
+                    let target_unit = [
+                        target_unit_vectors[[i, 0]],
+                        target_unit_vectors[[i, 1]],
+                        target_unit_vectors[[i, 2]],
+                    ];
+                    self.any_star_in_circle(target_unit, *cos_radius)
+                })
+                .collect()),
+
+            FovDefinition::Polygon {
+                vertices,
+                roll_rad: Some(roll),
+            } => {
+                let (sin_roll, cos_roll) = roll.sin_cos();
+                Ok((0..n_targets)
+                    .into_par_iter()
+                    .map(|i| {
+                        let ux = target_unit_vectors[[i, 0]];
+                        let uy = target_unit_vectors[[i, 1]];
+                        let uz = target_unit_vectors[[i, 2]];
+                        let target_ra_rad = uy.atan2(ux);
+                        let target_dec_rad = uz.clamp(-1.0, 1.0).asin();
+                        let (sin_tdec, cos_tdec) = target_dec_rad.sin_cos();
+                        let nearby = self.nearby_tangent_offsets(
+                            [ux, uy, uz],
+                            target_ra_rad,
+                            sin_tdec,
+                            cos_tdec,
+                        );
+                        nearby.iter().any(|&(east, north)| {
+                            let (u, v) = Self::to_instrument(east, north, sin_roll, cos_roll);
+                            Self::point_in_polygon(u.to_degrees(), v.to_degrees(), vertices)
+                        })
+                    })
+                    .collect())
+            }
+
+            FovDefinition::Polygon {
+                vertices,
+                roll_rad: None,
+            } => {
+                if n_roll_samples == 0 {
+                    return Ok(vec![false; n_targets]);
+                }
+                let roll_table: Vec<(f64, f64)> = (0..n_roll_samples)
+                    .map(|step| {
+                        let roll = step as f64 * (2.0 * PI / n_roll_samples as f64);
+                        roll.sin_cos()
+                    })
+                    .collect();
+
+                Ok((0..n_targets)
+                    .into_par_iter()
+                    .map(|i| {
+                        let ux = target_unit_vectors[[i, 0]];
+                        let uy = target_unit_vectors[[i, 1]];
+                        let uz = target_unit_vectors[[i, 2]];
+                        let target_ra_rad = uy.atan2(ux);
+                        let target_dec_rad = uz.clamp(-1.0, 1.0).asin();
+                        let (sin_tdec, cos_tdec) = target_dec_rad.sin_cos();
+                        let nearby = self.nearby_tangent_offsets(
+                            [ux, uy, uz],
+                            target_ra_rad,
+                            sin_tdec,
+                            cos_tdec,
+                        );
+                        if nearby.is_empty() {
+                            return false; // accessible at every roll
+                        }
+                        for &(sin_roll, cos_roll) in &roll_table {
+                            let any_blocked = nearby.iter().any(|&(east, north)| {
+                                let (u, v) = Self::to_instrument(east, north, sin_roll, cos_roll);
+                                Self::point_in_polygon(u.to_degrees(), v.to_degrees(), vertices)
+                            });
+                            if !any_blocked {
+                                return false; // a clear roll exists for this target
+                            }
+                        }
+                        true // every roll blocked
+                    })
+                    .collect())
+            }
+        }
     }
 
     fn name(&self) -> String {

--- a/src/constraints/bright_star.rs
+++ b/src/constraints/bright_star.rs
@@ -374,6 +374,81 @@ impl ConstraintEvaluator for BrightStarEvaluator {
         Ok(result)
     }
 
+    /// Cached-projection sweep: project nearby stars per target ONCE, then test
+    /// `n_roll_samples` rolls against the cached tangent-plane offsets.  Returns
+    /// (n_targets × n_times) where true = violated at every sampled roll.
+    /// Falls back to `in_constraint_batch` for circle and fixed-roll polygon modes.
+    fn in_constraint_batch_constrained_at_every_roll(
+        &self,
+        ephemeris: &dyn crate::ephemeris::ephemeris_common::EphemerisBase,
+        target_ras: &[f64],
+        target_decs: &[f64],
+        time_indices: Option<&[usize]>,
+        n_roll_samples: usize,
+    ) -> PyResult<Array2<bool>> {
+        let vertices = match &self.fov {
+            FovDefinition::Polygon {
+                vertices,
+                roll_rad: None,
+            } => vertices,
+            _ => return self.in_constraint_batch(ephemeris, target_ras, target_decs, time_indices),
+        };
+
+        let all_times = ephemeris.get_times()?;
+        let n_times = match time_indices {
+            Some(idx) => idx.len(),
+            None => all_times.len(),
+        };
+        let n_targets = target_ras.len();
+
+        // Pre-compute (sin, cos) of each candidate roll once.
+        let roll_table: Vec<(f64, f64)> = (0..n_roll_samples)
+            .map(|step| {
+                let roll = step as f64 * (2.0 * PI / n_roll_samples as f64);
+                roll.sin_cos()
+            })
+            .collect();
+
+        // Each target is independent and time-invariant: parallelise across targets,
+        // do gnomonic projection ONCE per target, then sweep cached rolls.
+        let violated: Vec<bool> = target_ras
+            .par_iter()
+            .zip(target_decs.par_iter())
+            .map(|(&ra_deg, &dec_deg)| {
+                let target_ra_rad = ra_deg.to_radians();
+                let target_dec_rad = dec_deg.to_radians();
+                let (sin_tdec, cos_tdec) = target_dec_rad.sin_cos();
+                let (sin_tra, cos_tra) = target_ra_rad.sin_cos();
+                let target_unit = [cos_tdec * cos_tra, cos_tdec * sin_tra, sin_tdec];
+                let nearby =
+                    self.nearby_tangent_offsets(target_unit, target_ra_rad, sin_tdec, cos_tdec);
+                if nearby.is_empty() {
+                    return false;
+                }
+                for &(sin_roll, cos_roll) in &roll_table {
+                    let any_blocked = nearby.iter().any(|&(east, north)| {
+                        let (u, v) = Self::to_instrument(east, north, sin_roll, cos_roll);
+                        Self::point_in_polygon(u.to_degrees(), v.to_degrees(), vertices)
+                    });
+                    if !any_blocked {
+                        return false; // clear roll exists for this target
+                    }
+                }
+                true
+            })
+            .collect();
+
+        let mut result = Array2::from_elem((n_targets, n_times), false);
+        for (i, &v) in violated.iter().enumerate() {
+            if v {
+                for j in 0..n_times {
+                    result[[i, j]] = true;
+                }
+            }
+        }
+        Ok(result)
+    }
+
     /// Hot path for coordinated roll sweep: evaluate polygon at `roll_deg` without
     /// JSON round-trips.  Circle mode and fixed-roll polygon delegate unchanged.
     fn in_constraint_batch_at_roll(

--- a/src/constraints/bright_star.rs
+++ b/src/constraints/bright_star.rs
@@ -394,10 +394,9 @@ impl ConstraintEvaluator for BrightStarEvaluator {
             _ => return self.in_constraint_batch(ephemeris, target_ras, target_decs, time_indices),
         };
 
-        let all_times = ephemeris.get_times()?;
         let n_times = match time_indices {
             Some(idx) => idx.len(),
-            None => all_times.len(),
+            None => ephemeris.get_times()?.len(),
         };
         let n_targets = target_ras.len();
 

--- a/src/constraints/constraint_wrapper/combinators.rs
+++ b/src/constraints/constraint_wrapper/combinators.rs
@@ -445,6 +445,47 @@ impl ConstraintEvaluator for AndEvaluator {
         Ok(result)
     }
 
+    /// AND decomposes trivially through the universal quantifier:
+    /// `∀θ. ⋀_c c(θ) violated  =  ⋀_c (∀θ. c(θ) violated)`,
+    /// i.e. the AND combinator's FoR-violation is the AND of each child's FoR-violation.
+    /// Each child therefore gets to use its own optimised `field_of_regard_violated_batch`
+    /// (e.g. bright_star's cached gnomonic projection), avoiding the default coupled sweep
+    /// that would re-call every child once per roll step.
+    fn field_of_regard_violated_batch(
+        &self,
+        ephemeris: &dyn crate::ephemeris::ephemeris_common::EphemerisBase,
+        target_unit_vectors: &Array2<f64>,
+        time_index: usize,
+        n_roll_samples: usize,
+    ) -> PyResult<Vec<bool>> {
+        let n_targets = target_unit_vectors.nrows();
+        if self.constraints.is_empty() {
+            return Ok(vec![true; n_targets]);
+        }
+
+        let mut result = self.constraints[0].field_of_regard_violated_batch(
+            ephemeris,
+            target_unit_vectors,
+            time_index,
+            n_roll_samples,
+        )?;
+        for c in &self.constraints[1..] {
+            if result.iter().all(|&v| !v) {
+                return Ok(result); // every target already accessible — AND can't flip it back
+            }
+            let sub = c.field_of_regard_violated_batch(
+                ephemeris,
+                target_unit_vectors,
+                time_index,
+                n_roll_samples,
+            )?;
+            for i in 0..n_targets {
+                result[i] = result[i] && sub[i];
+            }
+        }
+        Ok(result)
+    }
+
     fn name(&self) -> String {
         format!(
             "AND({})",
@@ -821,6 +862,95 @@ impl ConstraintEvaluator for OrEvaluator {
             }
         }
         Ok(result)
+    }
+
+    /// Mirror of `in_constraint_batch_constrained_at_every_roll` for the FoR path.
+    ///
+    /// Hoist roll-independent children out of the sweep — they evaluate to a constant
+    /// `V_indep_or` per target, so a target with `V_indep_or[i] = true` is FoR-violated
+    /// regardless of θ and is removed from the dep sweep entirely.  When there is exactly
+    /// one roll-dependent child left, delegate to its own optimised
+    /// `field_of_regard_violated_batch` (this is the `OR(sun_prox, bright_star)` shape that
+    /// users typically write).  Multiple dep children stay coupled and sweep together.
+    fn field_of_regard_violated_batch(
+        &self,
+        ephemeris: &dyn crate::ephemeris::ephemeris_common::EphemerisBase,
+        target_unit_vectors: &Array2<f64>,
+        time_index: usize,
+        n_roll_samples: usize,
+    ) -> PyResult<Vec<bool>> {
+        let n_targets = target_unit_vectors.nrows();
+        if self.constraints.is_empty() {
+            return Ok(vec![false; n_targets]);
+        }
+
+        let (indep_children, dep_children): (Vec<_>, Vec<_>) = self
+            .constraints
+            .iter()
+            .partition(|c| !c.is_roll_dependent());
+
+        // V_indep_or — OR of all roll-independent children, evaluated once each.
+        let mut v_indep = vec![false; n_targets];
+        for c in &indep_children {
+            let sub = c.field_of_regard_violated_batch(
+                ephemeris,
+                target_unit_vectors,
+                time_index,
+                n_roll_samples,
+            )?;
+            for i in 0..n_targets {
+                v_indep[i] = v_indep[i] || sub[i];
+            }
+        }
+
+        if dep_children.is_empty() {
+            return Ok(v_indep);
+        }
+
+        // Singleton dep-child: result[i] = V_indep_or[i] || dep_for_violated[i].
+        if dep_children.len() == 1 {
+            let dep_for = dep_children[0].field_of_regard_violated_batch(
+                ephemeris,
+                target_unit_vectors,
+                time_index,
+                n_roll_samples,
+            )?;
+            return Ok((0..n_targets).map(|i| v_indep[i] || dep_for[i]).collect());
+        }
+
+        // Multiple dep children: must couple at each θ.
+        // accessible[i] = ∃θ: every dep child not violated at θ; targets with v_indep[i]
+        // are excluded from this — they're already FoR-violated.
+        let roll_step_deg = 360.0 / n_roll_samples as f64;
+        let mut accessible = vec![false; n_targets];
+        for step in 0..n_roll_samples {
+            // Early-exit when every non-pre-violated target has found a clear roll.
+            if (0..n_targets).all(|i| v_indep[i] || accessible[i]) {
+                break;
+            }
+            let roll_deg = step as f64 * roll_step_deg;
+            let mut step_or_violated = vec![false; n_targets];
+            for c in &dep_children {
+                let r = c.field_of_regard_violated_at_roll(
+                    ephemeris,
+                    target_unit_vectors,
+                    time_index,
+                    roll_deg,
+                )?;
+                for i in 0..n_targets {
+                    step_or_violated[i] = step_or_violated[i] || r[i];
+                }
+            }
+            for i in 0..n_targets {
+                if !accessible[i] && !v_indep[i] && !step_or_violated[i] {
+                    accessible[i] = true;
+                }
+            }
+        }
+
+        Ok((0..n_targets)
+            .map(|i| v_indep[i] || !accessible[i])
+            .collect())
     }
 
     fn name(&self) -> String {

--- a/src/constraints/constraint_wrapper/combinators.rs
+++ b/src/constraints/constraint_wrapper/combinators.rs
@@ -325,6 +325,95 @@ impl ConstraintEvaluator for AndEvaluator {
         self.constraints.iter().any(|c| c.is_roll_dependent())
     }
 
+    /// Hoist roll-independent children: `AND_step (V_indep ∧ V_dep_at_step)
+    /// = V_indep ∧ AND_step (V_dep_at_step)` since V_indep doesn't depend on the roll.
+    fn in_constraint_batch_constrained_at_every_roll(
+        &self,
+        ephemeris: &dyn crate::ephemeris::ephemeris_common::EphemerisBase,
+        target_ras: &[f64],
+        target_decs: &[f64],
+        time_indices: Option<&[usize]>,
+        n_roll_samples: usize,
+    ) -> PyResult<Array2<bool>> {
+        if !self.is_roll_dependent() {
+            return self.in_constraint_batch(ephemeris, target_ras, target_decs, time_indices);
+        }
+
+        let times = ephemeris.get_times()?;
+        let n_times = time_indices.map(|idx| idx.len()).unwrap_or(times.len());
+        let n_targets = target_ras.len();
+
+        let (indep_children, dep_children): (Vec<_>, Vec<_>) = self
+            .constraints
+            .iter()
+            .partition(|c| !c.is_roll_dependent());
+
+        // V_indep_and — AND over all roll-independent children, computed once.
+        let mut v_indep: Option<Array2<bool>> = None;
+        for c in &indep_children {
+            let r = c.in_constraint_batch(ephemeris, target_ras, target_decs, time_indices)?;
+            match v_indep {
+                None => v_indep = Some(r),
+                Some(ref mut a) => a.zip_mut_with(&r, |x, &y| *x &= y),
+            }
+        }
+
+        if dep_children.is_empty() {
+            return Ok(
+                v_indep.unwrap_or_else(|| Array2::<bool>::from_elem((n_targets, n_times), true))
+            );
+        }
+
+        if dep_children.len() == 1 && indep_children.is_empty() {
+            return dep_children[0].in_constraint_batch_constrained_at_every_roll(
+                ephemeris,
+                target_ras,
+                target_decs,
+                time_indices,
+                n_roll_samples,
+            );
+        }
+
+        // AND_step (AND over dep_children of in_constraint_batch_at_roll).
+        let roll_step = 360.0 / n_roll_samples as f64;
+        let mut acc: Option<Array2<bool>> = None;
+        for step in 0..n_roll_samples {
+            if let Some(ref a) = acc {
+                if a.iter().all(|&b| !b) {
+                    break;
+                }
+            }
+            let roll_deg = step as f64 * roll_step;
+            let mut step_and: Option<Array2<bool>> = None;
+            for c in &dep_children {
+                let r = c.in_constraint_batch_at_roll(
+                    ephemeris,
+                    target_ras,
+                    target_decs,
+                    time_indices,
+                    roll_deg,
+                )?;
+                match step_and {
+                    None => step_and = Some(r),
+                    Some(ref mut a) => a.zip_mut_with(&r, |x, &y| *x &= y),
+                }
+            }
+            let step_and =
+                step_and.unwrap_or_else(|| Array2::<bool>::from_elem((n_targets, n_times), true));
+            match acc {
+                None => acc = Some(step_and),
+                Some(ref mut a) => a.zip_mut_with(&step_and, |x, &y| *x &= y),
+            }
+        }
+
+        let mut result =
+            acc.unwrap_or_else(|| Array2::<bool>::from_elem((n_targets, n_times), false));
+        if let Some(v) = v_indep {
+            result.zip_mut_with(&v, |x, &y| *x &= y);
+        }
+        Ok(result)
+    }
+
     fn field_of_regard_violated_at_roll(
         &self,
         ephemeris: &dyn crate::ephemeris::ephemeris_common::EphemerisBase,
@@ -620,6 +709,87 @@ impl ConstraintEvaluator for OrEvaluator {
 
     fn is_roll_dependent(&self) -> bool {
         self.constraints.iter().any(|c| c.is_roll_dependent())
+    }
+
+    /// Hoist roll-independent children: `AND_step (V_indep ∨ V_dep_at_step)
+    /// = V_indep ∨ AND_step (V_dep_at_step)` since V_indep doesn't depend on the roll.
+    /// Avoids re-evaluating roll-independent siblings 360 times in the outer sweep.
+    fn in_constraint_batch_constrained_at_every_roll(
+        &self,
+        ephemeris: &dyn crate::ephemeris::ephemeris_common::EphemerisBase,
+        target_ras: &[f64],
+        target_decs: &[f64],
+        time_indices: Option<&[usize]>,
+        n_roll_samples: usize,
+    ) -> PyResult<Array2<bool>> {
+        if !self.is_roll_dependent() {
+            return self.in_constraint_batch(ephemeris, target_ras, target_decs, time_indices);
+        }
+
+        let times = ephemeris.get_times()?;
+        let n_times = time_indices.map(|idx| idx.len()).unwrap_or(times.len());
+        let n_targets = target_ras.len();
+
+        let (indep_children, dep_children): (Vec<_>, Vec<_>) = self
+            .constraints
+            .iter()
+            .partition(|c| !c.is_roll_dependent());
+
+        // V_indep_or — OR of all roll-independent children, computed once.
+        let mut v_indep = Array2::<bool>::from_elem((n_targets, n_times), false);
+        for c in &indep_children {
+            let r = c.in_constraint_batch(ephemeris, target_ras, target_decs, time_indices)?;
+            v_indep.zip_mut_with(&r, |x, &y| *x |= y);
+        }
+
+        if dep_children.is_empty() {
+            return Ok(v_indep);
+        }
+
+        // For roll-dependent children, recurse into their swept method when possible —
+        // BUT only when there's a single dep child, since we need per-step values to OR
+        // across siblings.  With multiple dep children we must loop step-by-step.
+        if dep_children.len() == 1 && indep_children.is_empty() {
+            return dep_children[0].in_constraint_batch_constrained_at_every_roll(
+                ephemeris,
+                target_ras,
+                target_decs,
+                time_indices,
+                n_roll_samples,
+            );
+        }
+
+        // AND_step (OR over dep_children of in_constraint_batch_at_roll).
+        let roll_step = 360.0 / n_roll_samples as f64;
+        let mut acc: Option<Array2<bool>> = None;
+        for step in 0..n_roll_samples {
+            if let Some(ref a) = acc {
+                if a.iter().all(|&b| !b) {
+                    break;
+                }
+            }
+            let roll_deg = step as f64 * roll_step;
+            let mut step_or = Array2::<bool>::from_elem((n_targets, n_times), false);
+            for c in &dep_children {
+                let r = c.in_constraint_batch_at_roll(
+                    ephemeris,
+                    target_ras,
+                    target_decs,
+                    time_indices,
+                    roll_deg,
+                )?;
+                step_or.zip_mut_with(&r, |x, &y| *x |= y);
+            }
+            match acc {
+                None => acc = Some(step_or),
+                Some(ref mut a) => a.zip_mut_with(&step_or, |x, &y| *x &= y),
+            }
+        }
+
+        let mut result =
+            acc.unwrap_or_else(|| Array2::<bool>::from_elem((n_targets, n_times), false));
+        result.zip_mut_with(&v_indep, |x, &y| *x |= y);
+        Ok(result)
     }
 
     fn field_of_regard_violated_at_roll(

--- a/src/constraints/constraint_wrapper/combinators.rs
+++ b/src/constraints/constraint_wrapper/combinators.rs
@@ -339,8 +339,10 @@ impl ConstraintEvaluator for AndEvaluator {
             return self.in_constraint_batch(ephemeris, target_ras, target_decs, time_indices);
         }
 
-        let times = ephemeris.get_times()?;
-        let n_times = time_indices.map(|idx| idx.len()).unwrap_or(times.len());
+        let n_times = match time_indices {
+            Some(idx) => idx.len(),
+            None => ephemeris.get_times()?.len(),
+        };
         let n_targets = target_ras.len();
 
         let (indep_children, dep_children): (Vec<_>, Vec<_>) = self
@@ -767,8 +769,10 @@ impl ConstraintEvaluator for OrEvaluator {
             return self.in_constraint_batch(ephemeris, target_ras, target_decs, time_indices);
         }
 
-        let times = ephemeris.get_times()?;
-        let n_times = time_indices.map(|idx| idx.len()).unwrap_or(times.len());
+        let n_times = match time_indices {
+            Some(idx) => idx.len(),
+            None => ephemeris.get_times()?.len(),
+        };
         let n_targets = target_ras.len();
 
         let (indep_children, dep_children): (Vec<_>, Vec<_>) = self

--- a/src/constraints/constraint_wrapper/json_parser.rs
+++ b/src/constraints/constraint_wrapper/json_parser.rs
@@ -335,6 +335,11 @@ impl ConstraintSpec {
                     ));
                 }
                 let flattened = ConstraintSpec::flatten_and(constraints);
+                if flattened.is_empty() {
+                    return Err(pyo3::exceptions::PyValueError::new_err(
+                        "AND requires at least one sub-constraint",
+                    ));
+                }
                 let evaluators = ConstraintSpec::into_sub_evaluators(flattened)?;
                 Ok(Box::new(AndEvaluator {
                     constraints: evaluators,
@@ -347,6 +352,11 @@ impl ConstraintSpec {
                     ));
                 }
                 let flattened = ConstraintSpec::flatten_or(constraints);
+                if flattened.is_empty() {
+                    return Err(pyo3::exceptions::PyValueError::new_err(
+                        "OR requires at least one sub-constraint",
+                    ));
+                }
                 let evaluators = ConstraintSpec::into_sub_evaluators(flattened)?;
                 Ok(Box::new(OrEvaluator {
                     constraints: evaluators,

--- a/src/constraints/constraint_wrapper/json_parser.rs
+++ b/src/constraints/constraint_wrapper/json_parser.rs
@@ -203,6 +203,41 @@ impl ConstraintSpec {
             .collect()
     }
 
+    /// Flatten nested same-kind chains into a single n-ary node.  The Python `|`/`&`
+    /// operators produce left-deep binary trees (e.g. `OR(OR(OR(a,b),c),d)`); flattening
+    /// gives a single OR/AND with all siblings, which lets the per-level
+    /// `in_constraint_batch_constrained_at_every_roll` hoist all roll-independent siblings
+    /// out of the outer roll sweep instead of only the ones at the topmost level.
+    fn flatten_or(constraints: Vec<ConstraintSpec>) -> Vec<ConstraintSpec> {
+        let mut out = Vec::with_capacity(constraints.len());
+        for c in constraints {
+            match c {
+                ConstraintSpec::Or {
+                    constraints: nested,
+                } => {
+                    out.extend(Self::flatten_or(nested));
+                }
+                other => out.push(other),
+            }
+        }
+        out
+    }
+
+    fn flatten_and(constraints: Vec<ConstraintSpec>) -> Vec<ConstraintSpec> {
+        let mut out = Vec::with_capacity(constraints.len());
+        for c in constraints {
+            match c {
+                ConstraintSpec::And {
+                    constraints: nested,
+                } => {
+                    out.extend(Self::flatten_and(nested));
+                }
+                other => out.push(other),
+            }
+        }
+        out
+    }
+
     fn into_evaluator(self) -> PyResult<Box<dyn ConstraintEvaluator>> {
         match self {
             ConstraintSpec::Sun {
@@ -299,7 +334,8 @@ impl ConstraintSpec {
                         "AND requires at least one sub-constraint",
                     ));
                 }
-                let evaluators = ConstraintSpec::into_sub_evaluators(constraints)?;
+                let flattened = ConstraintSpec::flatten_and(constraints);
+                let evaluators = ConstraintSpec::into_sub_evaluators(flattened)?;
                 Ok(Box::new(AndEvaluator {
                     constraints: evaluators,
                 }))
@@ -310,7 +346,8 @@ impl ConstraintSpec {
                         "OR requires at least one sub-constraint",
                     ));
                 }
-                let evaluators = ConstraintSpec::into_sub_evaluators(constraints)?;
+                let flattened = ConstraintSpec::flatten_or(constraints);
+                let evaluators = ConstraintSpec::into_sub_evaluators(flattened)?;
                 Ok(Box::new(OrEvaluator {
                     constraints: evaluators,
                 }))

--- a/src/constraints/constraint_wrapper/py_api.rs
+++ b/src/constraints/constraint_wrapper/py_api.rs
@@ -1516,53 +1516,18 @@ impl PyConstraint {
         // coordinated: the same roll angle is injected into every sub-constraint simultaneously
         // so that, e.g., SolarRollConstraint and BodyConstraint share the same roll value.
         if target_rolls.is_none() {
-            if self.evaluator.is_roll_dependent() {
-                // Sweep roll angles.  A target is constrained (true) only when EVERY roll
-                // violates at least one sub-constraint, meaning no valid roll exists.
-                // Extract the ephemeris once and call in_constraint_batch_at_roll in the
-                // loop — no JSON round-trips, no evaluator reconstruction per step.
-                let roll_step = 360.0 / n_roll_samples as f64;
-                let mut acc: Option<ndarray::Array2<bool>> = None;
-
-                self.with_ephemeris(bound, |ephem_ref| {
-                    for step in 0..n_roll_samples {
-                        if let Some(ref a) = acc {
-                            if a.iter().all(|&b| !b) {
-                                break;
-                            }
-                        }
-                        let roll_deg = step as f64 * roll_step;
-                        let step_result = self.evaluator.in_constraint_batch_at_roll(
-                            ephem_ref,
-                            &target_ras,
-                            &target_decs,
-                            time_indices.as_deref(),
-                            roll_deg,
-                        )?;
-                        match acc {
-                            None => acc = Some(step_result),
-                            Some(ref mut a) => a.zip_mut_with(&step_result, |x, &y| *x &= y),
-                        }
-                    }
-                    Ok(())
-                })?;
-
-                let result_array =
-                    acc.unwrap_or_else(|| ndarray::Array2::from_elem((target_ras.len(), 0), false));
-                use numpy::IntoPyArray;
-                return Ok(result_array.into_pyarray(py).into());
-            }
-
-            // Roll-independent: original behaviour — evaluate with the stored evaluator.
-            let result_array = self.with_effective_evaluator(None, |evaluator| {
-                self.with_ephemeris(bound, |ephem_ref| {
-                    evaluator.in_constraint_batch(
+            // Single dispatch: evaluators that aren't roll-dependent take the fast path
+            // inside the trait method; combinators hoist roll-independent children; leaves
+            // like BrightStar reuse cached projections across the sweep.
+            let result_array = self.with_ephemeris(bound, |ephem_ref| {
+                self.evaluator
+                    .in_constraint_batch_constrained_at_every_roll(
                         ephem_ref,
                         &target_ras,
                         &target_decs,
                         time_indices.as_deref(),
+                        n_roll_samples,
                     )
-                })
             })?;
 
             use numpy::IntoPyArray;

--- a/src/constraints/constraint_wrapper/py_api_helpers.rs
+++ b/src/constraints/constraint_wrapper/py_api_helpers.rs
@@ -133,34 +133,13 @@ impl PyConstraint {
         time_indices: Option<&[usize]>,
         n_roll_samples: usize,
     ) -> PyResult<ndarray::Array2<bool>> {
-        if !evaluator.is_roll_dependent() {
-            return evaluator.in_constraint_batch(ephemeris, target_ras, target_decs, time_indices);
-        }
-
-        // Sweep roll angles and require violation at every roll to mark a cell violated.
-        let roll_step = 360.0 / n_roll_samples as f64;
-        let mut acc: Option<ndarray::Array2<bool>> = None;
-        for step in 0..n_roll_samples {
-            if let Some(ref a) = acc {
-                if a.iter().all(|&b| !b) {
-                    break;
-                }
-            }
-            let roll_deg = step as f64 * roll_step;
-            let step_result = evaluator.in_constraint_batch_at_roll(
-                ephemeris,
-                target_ras,
-                target_decs,
-                time_indices,
-                roll_deg,
-            )?;
-            match acc {
-                None => acc = Some(step_result),
-                Some(ref mut a) => a.zip_mut_with(&step_result, |x, &y| *x &= y),
-            }
-        }
-
-        Ok(acc.unwrap_or_else(|| ndarray::Array2::from_elem((target_ras.len(), 0), false)))
+        evaluator.in_constraint_batch_constrained_at_every_roll(
+            ephemeris,
+            target_ras,
+            target_decs,
+            time_indices,
+            n_roll_samples,
+        )
     }
 
     pub(super) fn with_effective_evaluator<T, F>(

--- a/src/constraints/core.rs
+++ b/src/constraints/core.rs
@@ -761,6 +761,48 @@ pub trait ConstraintEvaluator: Send + Sync {
         self.in_constraint_batch(ephemeris, target_ras, target_decs, time_indices)
     }
 
+    /// Sweep `n_roll_samples` roll angles and return targets that are violated at *every* roll
+    /// (i.e., no clear roll exists).  Used by `in_constraint_batch(target_rolls=None)`.
+    ///
+    /// Default: roll-independent evaluators bypass the sweep with a single
+    /// `in_constraint_batch` call; roll-dependent ones loop calling `in_constraint_batch_at_roll`
+    /// and AND-accumulate.  Combinators override this to hoist roll-independent children out
+    /// of the loop, and BrightStar overrides it to reuse its cached gnomonic projections.
+    fn in_constraint_batch_constrained_at_every_roll(
+        &self,
+        ephemeris: &dyn crate::ephemeris::ephemeris_common::EphemerisBase,
+        target_ras: &[f64],
+        target_decs: &[f64],
+        time_indices: Option<&[usize]>,
+        n_roll_samples: usize,
+    ) -> PyResult<Array2<bool>> {
+        if !self.is_roll_dependent() {
+            return self.in_constraint_batch(ephemeris, target_ras, target_decs, time_indices);
+        }
+        let roll_step = 360.0 / n_roll_samples as f64;
+        let mut acc: Option<Array2<bool>> = None;
+        for step in 0..n_roll_samples {
+            if let Some(ref a) = acc {
+                if a.iter().all(|&b| !b) {
+                    break;
+                }
+            }
+            let roll_deg = step as f64 * roll_step;
+            let step_result = self.in_constraint_batch_at_roll(
+                ephemeris,
+                target_ras,
+                target_decs,
+                time_indices,
+                roll_deg,
+            )?;
+            match acc {
+                None => acc = Some(step_result),
+                Some(ref mut a) => a.zip_mut_with(&step_result, |x, &y| *x &= y),
+            }
+        }
+        Ok(acc.unwrap_or_else(|| Array2::from_elem((target_ras.len(), 0), false)))
+    }
+
     /// Get constraint name
     fn name(&self) -> String;
 

--- a/src/constraints/solar_roll.rs
+++ b/src/constraints/solar_roll.rs
@@ -358,6 +358,130 @@ impl ConstraintEvaluator for SolarRollEvaluator {
         Ok(result)
     }
 
+    /// Whether a (target, time) pair is violated at *every* sampled roll over [0°, 360°)
+    /// is fully determined by the optimal roll — independent of the candidate roll.
+    /// The default trait implementation re-runs `in_constraint_batch_at_roll` `n_roll_samples`
+    /// times (recomputing every optimal roll from scratch on each pass); here we compute
+    /// the optimum once per cell and reduce the per-cell test to a single mod operation.
+    fn in_constraint_batch_constrained_at_every_roll(
+        &self,
+        ephemeris: &dyn EphemerisBase,
+        target_ras: &[f64],
+        target_decs: &[f64],
+        time_indices: Option<&[usize]>,
+        n_roll_samples: usize,
+    ) -> PyResult<Array2<bool>> {
+        if self.roll_deg.is_some() {
+            // Fixed roll: roll-independent — the trait default already returns
+            // `in_constraint_batch` directly for non-roll-dependent leaves.
+            return self.in_constraint_batch(ephemeris, target_ras, target_decs, time_indices);
+        }
+
+        let (times_filtered,) = extract_time_data!(ephemeris, time_indices);
+        let n_targets = target_ras.len();
+        let n_times = times_filtered.len();
+        let mut result = Array2::<bool>::from_elem((n_targets, n_times), false);
+
+        if n_targets == 0 || n_times == 0 || n_roll_samples == 0 {
+            return Ok(result);
+        }
+
+        let sun = ephemeris.get_sun_positions()?;
+        let obs = ephemeris.get_gcrs_positions()?;
+        let step = 360.0 / n_roll_samples as f64;
+
+        for j in 0..n_targets {
+            let target = radec_to_unit(target_ras[j], target_decs[j]);
+            for i in 0..n_times {
+                let source_i = time_indices.map_or(i, |indices| indices[i]);
+                let v = [
+                    sun[[source_i, 0]] - obs[[source_i, 0]],
+                    sun[[source_i, 1]] - obs[[source_i, 1]],
+                    sun[[source_i, 2]] - obs[[source_i, 2]],
+                ];
+                let n = norm3(v);
+                let sun_unit = if n < NEAR_ZERO {
+                    [1.0, 0.0, 0.0]
+                } else {
+                    [v[0] / n, v[1] / n, v[2] / n]
+                };
+                if roll_is_unconstrained(&target, &sun_unit, self.panel_normal) {
+                    continue;
+                }
+                let opt = solar_optimal_roll_deg(&target, &sun_unit, self.panel_normal);
+                let phase = opt.rem_euclid(step);
+                let min_dist = phase.min(step - phase);
+                if min_dist > self.tolerance_deg {
+                    result[[j, i]] = true;
+                }
+            }
+        }
+
+        Ok(result)
+    }
+
+    /// Same optimisation as `in_constraint_batch_constrained_at_every_roll` for the
+    /// FoR sweep path: compute the optimal roll once per target and reduce the
+    /// per-roll test to a constant-time modular comparison.
+    fn field_of_regard_violated_batch(
+        &self,
+        ephemeris: &dyn EphemerisBase,
+        target_unit_vectors: &Array2<f64>,
+        time_index: usize,
+        n_roll_samples: usize,
+    ) -> PyResult<Vec<bool>> {
+        if self.roll_deg.is_some() {
+            // Fixed roll: result is identical at every candidate roll, so a single
+            // evaluation suffices — matches the default fast path for roll-independent
+            // constraints.
+            return self.field_of_regard_violated_at_roll(
+                ephemeris,
+                target_unit_vectors,
+                time_index,
+                0.0,
+            );
+        }
+
+        let n_targets = target_unit_vectors.nrows();
+        if n_targets == 0 || n_roll_samples == 0 {
+            return Ok(vec![false; n_targets]);
+        }
+
+        let sun = ephemeris.get_sun_positions()?;
+        let obs = ephemeris.get_gcrs_positions()?;
+        let v = [
+            sun[[time_index, 0]] - obs[[time_index, 0]],
+            sun[[time_index, 1]] - obs[[time_index, 1]],
+            sun[[time_index, 2]] - obs[[time_index, 2]],
+        ];
+        let n = norm3(v);
+        let sun_unit = if n < NEAR_ZERO {
+            [1.0, 0.0, 0.0]
+        } else {
+            [v[0] / n, v[1] / n, v[2] / n]
+        };
+
+        let step = 360.0 / n_roll_samples as f64;
+        let mut result = vec![false; n_targets];
+        for i in 0..n_targets {
+            let target = [
+                target_unit_vectors[[i, 0]],
+                target_unit_vectors[[i, 1]],
+                target_unit_vectors[[i, 2]],
+            ];
+            if roll_is_unconstrained(&target, &sun_unit, self.panel_normal) {
+                continue;
+            }
+            let opt = solar_optimal_roll_deg(&target, &sun_unit, self.panel_normal);
+            let phase = opt.rem_euclid(step);
+            let min_dist = phase.min(step - phase);
+            if min_dist > self.tolerance_deg {
+                result[i] = true;
+            }
+        }
+        Ok(result)
+    }
+
     /// When no fixed roll is configured the constraint participates in the
     /// field-of-regard roll sweep: each candidate roll angle is checked for
     /// solar compliance, so only solar-valid rolls contribute accessible sky.

--- a/tests/constraints/roll_sweep_batch/test_roll_sweep_batch.py
+++ b/tests/constraints/roll_sweep_batch/test_roll_sweep_batch.py
@@ -1,0 +1,191 @@
+"""Regression tests for the ``target_rolls=None`` roll-sweep batch path.
+
+The Rust ``in_constraint_batch_constrained_at_every_roll`` entrypoint is
+overridden by ``BrightStar`` (cached projections), ``SolarRoll`` (closed-form
+optimum), and the ``AND``/``OR`` combinators (roll-independent child
+hoisting).  Each override should agree with a simpler "AND across
+``n_roll_samples`` fixed-roll batches" oracle, since both compute "violated
+at every sampled roll" over the same uniformly-spaced roll grid.
+
+The grid is kept small (3 times, 4-5 targets, 12 rolls) so the
+``O(n_roll_samples)`` oracle stays cheap.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+import numpy.typing as npt
+import pytest
+
+import rust_ephem
+from rust_ephem.constraints import (
+    BrightStarConstraint,
+    SolarRollConstraint,
+    SunConstraint,
+)
+
+# 12 samples → 30° grid step, fine enough to mix True/False without making the
+# oracle's per-step batch the dominant cost in the suite.
+_N_ROLL_SAMPLES = 12
+_INDICES = [0, 20, 40]
+
+# ±0.25° u, ±0.15° v polygon: inscribed radius 0.15°, circumradius ≈0.292°.
+_POLYGON = [(-0.25, -0.15), (0.25, -0.15), (0.25, 0.15), (-0.25, 0.15)]
+
+
+def _per_roll_and(
+    constraint: Any,
+    ephem: rust_ephem.TLEEphemeris,
+    ras: list[float],
+    decs: list[float],
+    n_roll_samples: int,
+    indices: list[int],
+) -> npt.NDArray[np.bool_]:
+    """AND-reduce per-roll fixed-roll batches across the same grid the override uses."""
+    n_targets = len(ras)
+    step = 360.0 / n_roll_samples
+    acc: npt.NDArray[np.bool_] | None = None
+    for i in range(n_roll_samples):
+        roll = i * step
+        result = constraint.in_constraint_batch(
+            ephem,
+            ras,
+            decs,
+            indices=indices,
+            target_rolls=[roll] * n_targets,
+        )
+        acc = result if acc is None else (acc & result)
+    assert acc is not None
+    return acc
+
+
+def _swept(
+    constraint: Any,
+    ephem: rust_ephem.TLEEphemeris,
+    ras: list[float],
+    decs: list[float],
+    n_roll_samples: int,
+    indices: list[int],
+) -> npt.NDArray[np.bool_]:
+    result: npt.NDArray[np.bool_] = constraint.in_constraint_batch(
+        ephem,
+        ras,
+        decs,
+        indices=indices,
+        target_rolls=None,
+        n_roll_samples=n_roll_samples,
+    )
+    return result
+
+
+def _offset_ra(ra: float, dec: float, delta_deg: float) -> float:
+    cos_dec = np.cos(np.radians(dec))
+    if abs(cos_dec) < 1e-9:
+        return ra
+    return float((ra + delta_deg / cos_dec) % 360.0)
+
+
+class TestBareBrightStarSweep:
+    """Polygon mode with ``roll_deg=None`` drives the cached-projection override."""
+
+    def test_swept_matches_oracle(self, tle_ephemeris: rust_ephem.TLEEphemeris) -> None:
+        # One always-blocked star (within inscribed radius), one sometimes-blocked
+        # (between inscribed and circumradius), one never-blocked (beyond
+        # circumradius), one with no nearby star.  Mix guarantees the swept
+        # result has both True and False rows.
+        targets = [(10.0, 5.0), (40.0, -15.0), (80.0, 30.0), (200.0, 0.0)]
+        ras = [t[0] for t in targets]
+        decs = [t[1] for t in targets]
+        stars = [
+            (_offset_ra(ras[0], decs[0], 0.05), decs[0]),
+            (_offset_ra(ras[1], decs[1], 0.20), decs[1]),
+            (_offset_ra(ras[2], decs[2], 0.40), decs[2]),
+        ]
+        c = BrightStarConstraint(stars=stars, fov_polygon=_POLYGON, roll_deg=None)
+
+        swept = _swept(c, tle_ephemeris, ras, decs, _N_ROLL_SAMPLES, _INDICES)
+        oracle = _per_roll_and(c, tle_ephemeris, ras, decs, _N_ROLL_SAMPLES, _INDICES)
+
+        assert swept.shape == (len(ras), len(_INDICES))
+        np.testing.assert_array_equal(swept, oracle)
+        # Sanity: mixed True/False is required for the equality to be a real
+        # test of the override rather than a degenerate all-same result.
+        assert swept.any() and not swept.all()
+
+
+class TestBareSolarRollSweep:
+    """``SolarRoll`` with ``roll_deg=None`` drives its closed-form override."""
+
+    @pytest.mark.parametrize(
+        "panel_normal",
+        [(0.0, 1.0, 0.0), (0.0, 0.0, 1.0)],
+    )
+    def test_swept_matches_oracle(
+        self,
+        tle_ephemeris: rust_ephem.TLEEphemeris,
+        panel_normal: tuple[float, float, float],
+    ) -> None:
+        # tolerance_deg=5° with a 30° grid: violated when the optimum's phase
+        # mod 30° lies in (5°, 25°), giving mixed True/False over the target
+        # grid below.
+        c = SolarRollConstraint(tolerance_deg=5.0, panel_normal=panel_normal)
+        ras = [10.0, 90.0, 170.0, 250.0, 330.0]
+        decs = [0.0, 30.0, -30.0, 60.0, -60.0]
+
+        swept = _swept(c, tle_ephemeris, ras, decs, _N_ROLL_SAMPLES, _INDICES)
+        oracle = _per_roll_and(c, tle_ephemeris, ras, decs, _N_ROLL_SAMPLES, _INDICES)
+
+        assert swept.shape == (len(ras), len(_INDICES))
+        np.testing.assert_array_equal(swept, oracle)
+        assert swept.any() and not swept.all()
+
+
+class TestAndMixedHoisting:
+    """``AND`` of a roll-dependent and roll-independent child exercises
+    ``AndEvaluator``'s override: the sun child is hoisted out of the sweep
+    loop and AND-combined once with the per-step solar-roll result."""
+
+    def test_solar_roll_and_sun(self, tle_ephemeris: rust_ephem.TLEEphemeris) -> None:
+        roll_dep = SolarRollConstraint(tolerance_deg=5.0)
+        # min_angle=90° → roughly the sunward hemisphere is violated, giving a
+        # ~50% mix that overlaps the solar-roll pattern below.
+        roll_indep = SunConstraint(min_angle=90.0)
+        combined = roll_dep & roll_indep
+
+        ras = [10.0, 90.0, 170.0, 250.0, 330.0]
+        decs = [0.0, 30.0, -30.0, 60.0, -60.0]
+
+        swept = _swept(combined, tle_ephemeris, ras, decs, _N_ROLL_SAMPLES, _INDICES)
+        oracle = _per_roll_and(
+            combined, tle_ephemeris, ras, decs, _N_ROLL_SAMPLES, _INDICES
+        )
+
+        np.testing.assert_array_equal(swept, oracle)
+        assert swept.any() and not swept.all()
+
+
+class TestOrMixedHoisting:
+    """``OR`` of a roll-dependent and roll-independent child exercises
+    ``OrEvaluator``'s override: the indep result is OR'd in once after the
+    AND-across-rolls of the dep result."""
+
+    def test_solar_roll_or_sun(self, tle_ephemeris: rust_ephem.TLEEphemeris) -> None:
+        roll_dep = SolarRollConstraint(tolerance_deg=5.0)
+        # min_angle=90° gives a ~50% mix that exercises the
+        # `result |= v_indep` post-step in the override (and is neither all-True
+        # — which would mask any sweep bug — nor all-False).
+        roll_indep = SunConstraint(min_angle=90.0)
+        combined = roll_dep | roll_indep
+
+        ras = [10.0, 90.0, 170.0, 250.0, 330.0]
+        decs = [0.0, 30.0, -30.0, 60.0, -60.0]
+
+        swept = _swept(combined, tle_ephemeris, ras, decs, _N_ROLL_SAMPLES, _INDICES)
+        oracle = _per_roll_and(
+            combined, tle_ephemeris, ras, decs, _N_ROLL_SAMPLES, _INDICES
+        )
+
+        np.testing.assert_array_equal(swept, oracle)
+        assert swept.any() and not swept.all()


### PR DESCRIPTION
This pull request significantly optimizes and refactors the evaluation of roll-dependent constraints, especially for the Bright Star constraint and logical combinators (AND/OR), by hoisting roll-independent children out of roll sweeps and introducing efficient batch methods. The changes improve performance by avoiding redundant computation, leveraging parallelism, and delegating roll sweeps to the Rust backend where possible.

**Optimizations for Bright Star constraint:**

- Added a new method `in_constraint_batch_constrained_at_every_roll` to `BrightStarEvaluator`, which caches star projections and efficiently sweeps over roll angles, reducing redundant calculations and leveraging parallelism.
- Implemented a similar batch-optimized method `field_of_regard_violated_batch` for the field-of-regard path, which avoids repeated gnomonic projections and efficiently tests all rolls.
- Updated existing methods to use parallel iterators for improved performance. [[1]](diffhunk://#diff-f212e2dd4266f5727707bebaced77f03a74d9debe825a2f24cd4592c4699db78R531) [[2]](diffhunk://#diff-f212e2dd4266f5727707bebaced77f03a74d9debe825a2f24cd4592c4699db78R549)

**Optimizations for logical combinators:**

- For `AndEvaluator`, added `in_constraint_batch_constrained_at_every_roll` to hoist roll-independent children out of the roll sweep, compute them once, and only sweep roll-dependent children, greatly reducing redundant evaluations.
- For `OrEvaluator`, implemented a similar hoisting and optimization in `in_constraint_batch_constrained_at_every_roll`, as well as in the field-of-regard logic, enabling efficient evaluation and early exits when possible. [[1]](diffhunk://#diff-f780567fa269d812da54f788c25ef1c447b7990616f57cfe7fadb498969be7dbR755-R835) [[2]](diffhunk://#diff-f780567fa269d812da54f788c25ef1c447b7990616f57cfe7fadb498969be7dbR867-R955)
- Both AND and OR combinators now have optimized `field_of_regard_violated_batch` methods that delegate to children's batch methods and exploit short-circuiting. [[1]](diffhunk://#diff-f780567fa269d812da54f788c25ef1c447b7990616f57cfe7fadb498969be7dbR448-R488) [[2]](diffhunk://#diff-f780567fa269d812da54f788c25ef1c447b7990616f57cfe7fadb498969be7dbR867-R955)

**Python API integration:**

- Updated the Python-side `rust_ephem/constraints.py` to delegate roll sweeps to the Rust backend, removing the Python loop and leveraging the new optimized Rust methods for roll-dependent constraints.

These changes together provide a substantial performance boost and clearer separation of roll-dependent and independent logic in constraint evaluation.