### PR TITLE
fix: add tle_record property to TLEEphemeris

### DIFF
--- a/docs/ephemeris_tle.rst
+++ b/docs/ephemeris_tle.rst
@@ -155,6 +155,10 @@ which returns a ``TLERecord`` object. This is useful when you need to:
         step_size=60
     )
 
+    # Access the exact TLERecord used for propagation
+    used_tle = sat.tle_record
+    print(used_tle.source, used_tle.epoch)
+
 **Benefits of using fetch_tle:**
 
 - **Metadata access**: Inspect TLE epoch, source, and satellite name before propagation

--- a/rust_ephem/_rust_ephem.pyi
+++ b/rust_ephem/_rust_ephem.pyi
@@ -1,13 +1,16 @@
 """Type stubs for the Rust extension module _rust_ephem"""
 
 from datetime import datetime
-from typing import Any, Literal, Protocol, runtime_checkable
+from typing import TYPE_CHECKING, Any, Literal, Protocol, runtime_checkable
 
 import numpy as np
 import numpy.typing as npt
 
 from .constraints import DEFAULT_N_POINTS, DEFAULT_N_ROLL_SAMPLES
 from .ephemeris import Ephemeris
+
+if TYPE_CHECKING:
+    from .tle import TLERecord
 
 @runtime_checkable
 class TLELike(Protocol):
@@ -932,6 +935,11 @@ class TLEEphemeris(Ephemeris):
     @property
     def tle_epoch(self) -> datetime:
         """Epoch timestamp extracted from the TLE (UTC datetime)"""
+        ...
+
+    @property
+    def tle_record(self) -> "TLERecord":
+        """TLERecord used to construct this ephemeris"""
         ...
 
     @property

--- a/src/ephemeris/tle_ephemeris.rs
+++ b/src/ephemeris/tle_ephemeris.rs
@@ -17,6 +17,8 @@ use crate::utils::to_skycoord::AstropyModules;
 pub struct TLEEphemeris {
     tle1: String,
     tle2: String,
+    tle_name: Option<String>,
+    tle_source: Option<String>,
     tle_epoch: chrono::DateTime<chrono::Utc>, // TLE epoch timestamp
     teme: Option<Array2<f64>>,
     itrs: Option<Array2<f64>>,
@@ -52,20 +54,44 @@ impl TLEEphemeris {
             begin.and_then(|b| crate::utils::time_utils::python_datetime_to_utc(b).ok());
 
         // Determine which method to use for getting TLE data
-        let fetched = if let (Some(l1), Some(l2)) = (tle1, tle2) {
+        let (fetched, source_override) = if let (Some(l1), Some(l2)) = (tle1, tle2) {
             // Legacy method: tle1 and tle2 parameters (direct TLE lines)
-            tle_utils::FetchedTLE::from_lines(l1, l2, None, None)
-                .map_err(|e| pyo3::exceptions::PyValueError::new_err(e.to_string()))?
+            (
+                tle_utils::FetchedTLE::from_lines(l1, l2, None, None)
+                    .map_err(|e| pyo3::exceptions::PyValueError::new_err(e.to_string()))?,
+                None,
+            )
         } else if let Some(tle_obj) = tle {
             // tle parameter: can be a string (file path/URL) or a TLERecord object
             if let Ok(tle_string) = tle_obj.extract::<String>() {
                 // String: file path or URL - use unified function
-                tle_utils::fetch_tle_unified(Some(&tle_string), None, None, None, None, None, None)
-                    .map_err(|e| pyo3::exceptions::PyValueError::new_err(e.to_string()))?
+                (
+                    tle_utils::fetch_tle_unified(
+                        Some(&tle_string),
+                        None,
+                        None,
+                        None,
+                        None,
+                        None,
+                        None,
+                    )
+                    .map_err(|e| pyo3::exceptions::PyValueError::new_err(e.to_string()))?,
+                    None,
+                )
             } else if tle_obj.hasattr("line1")? && tle_obj.hasattr("line2")? {
                 // Object with line1/line2 attributes (TLERecord or similar)
                 let line1: String = tle_obj.getattr("line1")?.extract()?;
                 let line2: String = tle_obj.getattr("line2")?.extract()?;
+                let name = if tle_obj.hasattr("name")? {
+                    tle_obj.getattr("name")?.extract::<Option<String>>()?
+                } else {
+                    None
+                };
+                let source = if tle_obj.hasattr("source")? {
+                    tle_obj.getattr("source")?.extract::<Option<String>>()?
+                } else {
+                    None
+                };
                 let epoch = if tle_obj.hasattr("epoch")? {
                     let epoch_obj = tle_obj.getattr("epoch")?;
                     if let Ok(epoch_dt) = epoch_obj.downcast::<PyDateTime>() {
@@ -76,8 +102,11 @@ impl TLEEphemeris {
                 } else {
                     None
                 };
-                tle_utils::FetchedTLE::from_lines(line1, line2, None, epoch)
-                    .map_err(|e| pyo3::exceptions::PyValueError::new_err(e.to_string()))?
+                (
+                    tle_utils::FetchedTLE::from_lines(line1, line2, name, epoch)
+                        .map_err(|e| pyo3::exceptions::PyValueError::new_err(e.to_string()))?,
+                    source,
+                )
             } else {
                 return Err(pyo3::exceptions::PyTypeError::new_err(
                     "tle parameter must be a string (file path or URL) or an object with line1/line2 attributes"
@@ -102,16 +131,19 @@ impl TLEEphemeris {
                 begin_for_epoch
             };
 
-            tle_utils::fetch_tle_unified(
+            (
+                tle_utils::fetch_tle_unified(
+                    None,
+                    norad_id,
+                    norad_name.as_deref(),
+                    target_epoch.as_ref(),
+                    credentials,
+                    epoch_tolerance_days,
+                    enforce_source.as_deref(),
+                )
+                .map_err(|e| pyo3::exceptions::PyValueError::new_err(e.to_string()))?,
                 None,
-                norad_id,
-                norad_name.as_deref(),
-                target_epoch.as_ref(),
-                credentials,
-                epoch_tolerance_days,
-                enforce_source.as_deref(),
             )
-            .map_err(|e| pyo3::exceptions::PyValueError::new_err(e.to_string()))?
         } else {
             return Err(pyo3::exceptions::PyValueError::new_err(
                 "Must provide either (tle1, tle2), tle, norad_id, or norad_name parameters",
@@ -132,6 +164,8 @@ impl TLEEphemeris {
         let mut ephemeris: TLEEphemeris = TLEEphemeris {
             tle1: fetched.line1,
             tle2: fetched.line2,
+            tle_name: fetched.name,
+            tle_source: source_override.or_else(|| Some(fetched.source.to_string())),
             tle_epoch: fetched.epoch,
             teme: None,
             itrs: None,
@@ -194,6 +228,27 @@ impl TLEEphemeris {
     #[getter]
     fn tle2(&self) -> &str {
         &self.tle2
+    }
+
+    /// Get the TLERecord used to generate this ephemeris
+    #[getter]
+    fn tle_record(&self, py: Python) -> PyResult<Py<PyAny>> {
+        let tle_module = py.import("rust_ephem.tle")?;
+        let tle_record_class = tle_module.getattr("TLERecord")?;
+
+        let kwargs = pyo3::types::PyDict::new(py);
+        kwargs.set_item("line1", &self.tle1)?;
+        kwargs.set_item("line2", &self.tle2)?;
+        kwargs.set_item("epoch", self.tle_epoch(py)?)?;
+
+        if let Some(name) = &self.tle_name {
+            kwargs.set_item("name", name)?;
+        }
+        if let Some(source) = &self.tle_source {
+            kwargs.set_item("source", source)?;
+        }
+
+        Ok(tle_record_class.call((), Some(&kwargs))?.into())
     }
 
     /// Get the start time of the ephemeris

--- a/tests/ephemeris/tle_reading/test_tle_reading.py
+++ b/tests/ephemeris/tle_reading/test_tle_reading.py
@@ -40,6 +40,15 @@ class TestLegacyTLEMethod:
         # Check it has timezone info
         assert legacy_ephem.tle_epoch.tzinfo is not None
 
+    def test_legacy_exposes_tle_record(self, legacy_ephem) -> None:
+        """Test that legacy constructor still exposes a TLERecord."""
+        tle_record = legacy_ephem.tle_record
+        assert tle_record is not None
+        assert tle_record.line1 == legacy_ephem.tle1
+        assert tle_record.line2 == legacy_ephem.tle2
+        assert tle_record.epoch == legacy_ephem.tle_epoch
+        assert tle_record.source == "direct"
+
 
 class TestFileReading:
     """Test reading TLEs from files."""
@@ -425,6 +434,20 @@ class TestFetchTLE:
         assert len(ephem.timestamp) == 61
         # Epoch should match
         assert ephem.tle_epoch.year == tle_record.epoch.year
+
+    def test_ephemeris_exposes_input_tle_record(self, tle_3line_file) -> None:
+        """Test that TLEEphemeris exposes the TLERecord used for construction."""
+        tle_record = rust_ephem.fetch_tle(tle=tle_3line_file)
+        ephem = rust_ephem.TLEEphemeris(
+            tle=tle_record, begin=BEGIN, end=END, step_size=STEP_SIZE
+        )
+
+        ephem_record = ephem.tle_record
+        assert ephem_record.line1 == tle_record.line1
+        assert ephem_record.line2 == tle_record.line2
+        assert ephem_record.epoch == tle_record.epoch
+        assert ephem_record.name == tle_record.name
+        assert ephem_record.source == tle_record.source
 
     def test_fetch_tle_missing_params(self) -> None:
         """Test that fetch_tle raises error with no params."""


### PR DESCRIPTION
This pull request enhances the `TLEEphemeris` class to expose the exact `TLERecord` object used for its construction, making it easier to access TLE metadata after ephemeris creation. It also updates the documentation and adds tests to ensure this new feature works as expected.

**Enhancements to TLEEphemeris metadata and API:**

* Added a `tle_record` property to the `TLEEphemeris` class that returns the `TLERecord` used for propagation, including all relevant metadata such as name, source, and epoch. [[1]](diffhunk://#diff-2b70288c7bb781fa1cb0b71ae1193e3e1643bd019d646c1239900e7999e95a34R233-R253) [[2]](diffhunk://#diff-7ed8034838678ab42bb592e27c3315872651998aec8719d99640b9bdd2ade077R940-R944)
* Updated the constructor logic in `TLEEphemeris` to capture and store the TLE name and source, supporting richer metadata from different input types (direct lines, objects, or fetched data). [[1]](diffhunk://#diff-2b70288c7bb781fa1cb0b71ae1193e3e1643bd019d646c1239900e7999e95a34L55-R94) [[2]](diffhunk://#diff-2b70288c7bb781fa1cb0b71ae1193e3e1643bd019d646c1239900e7999e95a34L79-R109) [[3]](diffhunk://#diff-2b70288c7bb781fa1cb0b71ae1193e3e1643bd019d646c1239900e7999e95a34R167-R168)
* Updated type stubs in `rust_ephem/_rust_ephem.pyi` to reflect the new `tle_record` property and ensure correct type checking. [[1]](diffhunk://#diff-7ed8034838678ab42bb592e27c3315872651998aec8719d99640b9bdd2ade077L4-R14) [[2]](diffhunk://#diff-7ed8034838678ab42bb592e27c3315872651998aec8719d99640b9bdd2ade077R940-R944)

**Documentation improvements:**

* Updated the documentation in `docs/ephemeris_tle.rst` to show how to access the `tle_record` property and inspect TLE metadata after propagation.

**Testing improvements:**

* Added new tests to verify that the `tle_record` property is correctly exposed and matches the input TLE data, both for legacy and new construction methods. [[1]](diffhunk://#diff-cdaf2179060cac63e7ace3eefdae10eb95a8d4e7fa1e09c10cda4b0cc4ac976eR43-R51) [[2]](diffhunk://#diff-cdaf2179060cac63e7ace3eefdae10eb95a8d4e7fa1e09c10cda4b0cc4ac976eR438-R451)