### PR TITLE
feat: record constraint values in output

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,14 +31,14 @@ repos:
         description: Verify that pyproject.toml adheres to the established schema.
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.15.6
+    rev: v0.15.22
     hooks:
       - id: ruff-check
         name: Lint code using ruff; sort and organize imports
         types_or: [python, pyi]
         args: [--extend-select, "I", --fixable, "I,F", --fix]
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.6
+    rev: v0.15.22
     hooks:
       - id: ruff-format
   - repo: local
@@ -63,7 +63,7 @@ repos:
           - -D
           - exclude_patterns=notebooks/*
   - repo: https://github.com/python-jsonschema/check-jsonschema
-    rev: 0.37.0
+    rev: 0.37.4
     hooks:
       - id: check-github-workflows
         args:

--- a/docs/constraints_api.rst
+++ b/docs/constraints_api.rst
@@ -14,10 +14,10 @@ Overview
 
 The constraint system provides two complementary APIs:
 
-1. **Rust-backed Constraint class** — Low-level interface with factory methods
+1. **Rust-backed Constraint class**: Low-level interface with factory methods
    for creating constraints directly in Rust. Faster for simple use cases.
 
-2. **Pydantic configuration models** — Type-safe Python models that serialize
+2. **Pydantic configuration models**: Type-safe Python models that serialize
    to/from JSON and support operator-based composition. Recommended for most users.
 
 Both APIs can be used interchangeably and produce identical results.
@@ -128,7 +128,7 @@ Factory Methods
 
    Create a generic solar system body avoidance constraint.
 
-   :param str body: Body identifier — NAIF ID or name (e.g., "Jupiter", "499", "Mars")
+   :param str body: Body identifier - NAIF ID or name (e.g., "Jupiter", "499", "Mars")
    :param float min_angle: Minimum allowed angular separation in degrees (0-180)
    :param float max_angle: Maximum allowed angular separation in degrees (optional)
    :returns: A new Constraint instance
@@ -538,7 +538,8 @@ Evaluation Methods
       violated only when **every** roll is blocked (no valid spacecraft orientation exists).
       Pass an explicit float to evaluate at a fixed roll.
    :type target_roll: float or None
-   :returns: ConstraintResult containing violation windows
+   :returns: ConstraintResult containing violation windows and computed
+      :ref:`constraint_values <constraint-values>`
    :rtype: ConstraintResult
    :raises ValueError: If both times and indices are provided, or if times/indices not found
    :raises TypeError: If ephemeris type is not supported
@@ -627,7 +628,8 @@ Evaluation Methods
       Must be a list of the same length as ``target_ras``. Pass ``None`` to evaluate
       without any fixed spacecraft roll.
    :type target_rolls: list[float] or None
-   :returns: List of :class:`ConstraintResult` objects, one per input target
+   :returns: List of :class:`ConstraintResult` objects, one per input target, each with
+      its own computed :ref:`constraint_values <constraint-values>`
    :rtype: list[ConstraintResult]
 
 .. py:method:: Constraint.in_constraint(time, ephemeris, target_ra, target_dec, target_roll=None, n_roll_samples=DEFAULT_N_ROLL_SAMPLES)
@@ -793,9 +795,9 @@ Sun proximity constraint ensuring target maintains minimum angular separation fr
 
    **Attributes:**
 
-   - ``type`` — Always ``"sun"`` (Literal)
-   - ``min_angle`` — Minimum angle from Sun in degrees
-   - ``max_angle`` — Maximum angle from Sun in degrees (or None)
+   - ``type``: Always ``"sun"`` (Literal)
+   - ``min_angle``: Minimum angle from Sun in degrees
+   - ``max_angle``: Maximum angle from Sun in degrees (or None)
 
    **Example:**
 
@@ -821,9 +823,9 @@ Moon proximity constraint ensuring target maintains minimum angular separation f
 
    **Attributes:**
 
-   - ``type`` — Always ``"moon"`` (Literal)
-   - ``min_angle`` — Minimum angle from Moon in degrees
-   - ``max_angle`` — Maximum angle from Moon in degrees (or None)
+   - ``type``: Always ``"moon"`` (Literal)
+   - ``min_angle``: Minimum angle from Moon in degrees
+   - ``max_angle``: Maximum angle from Moon in degrees (or None)
 
    **Example:**
 
@@ -847,11 +849,11 @@ Earth limb avoidance constraint ensuring target is above Earth's horizon/limb.
 
    **Attributes:**
 
-   - ``type`` — Always ``"earth_limb"`` (Literal)
-   - ``min_angle`` — Minimum angle from Earth's limb in degrees
-   - ``max_angle`` — Maximum angle from Earth's limb in degrees (or None)
-   - ``include_refraction`` — Whether to include atmospheric refraction
-   - ``horizon_dip`` — Whether to include geometric horizon dip
+   - ``type``: Always ``"earth_limb"`` (Literal)
+   - ``min_angle``: Minimum angle from Earth's limb in degrees
+   - ``max_angle``: Maximum angle from Earth's limb in degrees (or None)
+   - ``include_refraction``: Whether to include atmospheric refraction
+   - ``horizon_dip``: Whether to include geometric horizon dip
 
    **Example:**
 
@@ -882,10 +884,10 @@ Generic solar system body proximity constraint.
 
    **Attributes:**
 
-   - ``type`` — Always ``"body"`` (Literal)
-   - ``body`` — Name of the solar system body
-   - ``min_angle`` — Minimum angle from body in degrees
-   - ``max_angle`` — Maximum angle from body in degrees (or None)
+   - ``type``: Always ``"body"`` (Literal)
+   - ``body``: Name of the solar system body
+   - ``min_angle``: Minimum angle from body in degrees
+   - ``max_angle``: Maximum angle from body in degrees (or None)
 
    **Example:**
 
@@ -912,8 +914,8 @@ Results are undefined for other centers.
 
    **Attributes:**
 
-   - ``type`` — Always ``"eclipse"`` (Literal)
-   - ``umbra_only`` — Whether only umbra counts as eclipse
+   - ``type``: Always ``"eclipse"`` (Literal)
+   - ``umbra_only``: Whether only umbra counts as eclipse
 
    **Example:**
 
@@ -939,9 +941,9 @@ Airmass constraint limiting observations based on atmospheric path length.
 
    **Attributes:**
 
-   - ``type`` — Always ``"airmass"`` (Literal)
-   - ``max_airmass`` — Maximum allowed airmass
-   - ``min_airmass`` — Minimum allowed airmass (or None)
+   - ``type``: Always ``"airmass"`` (Literal)
+   - ``max_airmass``: Maximum allowed airmass
+   - ``min_airmass``: Minimum allowed airmass (or None)
 
    Airmass represents the optical path length through Earth's atmosphere:
 
@@ -972,8 +974,8 @@ Daytime constraint preventing observations during daylight hours.
 
    **Attributes:**
 
-   - ``type`` — Always ``"daytime"`` (Literal)
-   - ``twilight`` — Twilight definition
+   - ``type``: Always ``"daytime"`` (Literal)
+   - ``twilight``: Twilight definition
 
    Twilight definitions:
 
@@ -1010,13 +1012,13 @@ Moon phase constraint with optional distance filtering.
 
    **Attributes:**
 
-   - ``type`` — Always ``"moon_phase"`` (Literal)
-   - ``max_illumination`` — Maximum allowed Moon illumination
-   - ``min_illumination`` — Minimum allowed Moon illumination (or None)
-   - ``min_distance`` — Minimum Moon distance from target (or None)
-   - ``max_distance`` — Maximum Moon distance from target (or None)
-   - ``enforce_when_below_horizon`` — Whether to enforce when Moon is below horizon
-   - ``moon_visibility`` — Moon visibility requirement
+   - ``type``: Always ``"moon_phase"`` (Literal)
+   - ``max_illumination``: Maximum allowed Moon illumination
+   - ``min_illumination``: Minimum allowed Moon illumination (or None)
+   - ``min_distance``: Minimum Moon distance from target (or None)
+   - ``max_distance``: Maximum Moon distance from target (or None)
+   - ``enforce_when_below_horizon``: Whether to enforce when Moon is below horizon
+   - ``moon_visibility``: Moon visibility requirement
 
    Moon illumination ranges from 0.0 (new moon) to 1.0 (full moon).
 
@@ -1047,8 +1049,8 @@ South Atlantic Anomaly constraint with polygon-defined region.
 
    **Attributes:**
 
-   - ``type`` — Always ``"saa"`` (Literal)
-   - ``polygon`` — List of (longitude, latitude) pairs defining the region boundary
+   - ``type``: Always ``"saa"`` (Literal)
+   - ``polygon``: List of (longitude, latitude) pairs defining the region boundary
 
    The polygon should be defined as a list of (longitude, latitude) coordinate pairs
    in degrees, defining the boundary of the region. The polygon is assumed to be
@@ -1090,12 +1092,12 @@ Altitude/Azimuth constraint restricting observations based on local horizon coor
 
    **Attributes:**
 
-   - ``type`` — Always ``"alt_az"`` (Literal)
-   - ``min_altitude`` — Minimum allowed altitude in degrees
-   - ``max_altitude`` — Maximum allowed altitude in degrees (optional)
-   - ``min_azimuth`` — Minimum allowed azimuth in degrees (optional)
-   - ``max_azimuth`` — Maximum allowed azimuth in degrees (optional)
-   - ``polygon`` — List of (altitude, azimuth) pairs defining allowed region (optional)
+   - ``type``: Always ``"alt_az"`` (Literal)
+   - ``min_altitude``: Minimum allowed altitude in degrees
+   - ``max_altitude``: Maximum allowed altitude in degrees (optional)
+   - ``min_azimuth``: Minimum allowed azimuth in degrees (optional)
+   - ``max_azimuth``: Maximum allowed azimuth in degrees (optional)
+   - ``polygon``: List of (altitude, azimuth) pairs defining allowed region (optional)
 
    **Coordinate System:**
 
@@ -1149,9 +1151,9 @@ Orbit RAM direction constraint ensuring target maintains minimum angular separat
 
    **Attributes:**
 
-   - ``type`` — Always ``"orbit_ram"`` (Literal)
-   - ``min_angle`` — Minimum angle from RAM direction in degrees
-   - ``max_angle`` — Maximum angle from RAM direction in degrees (or None)
+   - ``type``: Always ``"orbit_ram"`` (Literal)
+   - ``min_angle``: Minimum angle from RAM direction in degrees
+   - ``max_angle``: Maximum angle from RAM direction in degrees (or None)
 
    **Requirements:**
 
@@ -1181,9 +1183,9 @@ Orbit pole direction constraint ensuring target maintains minimum angular separa
 
    **Attributes:**
 
-   - ``type`` — Always ``"orbit_pole"`` (Literal)
-   - ``min_angle`` — Minimum angle from orbital pole in degrees
-   - ``max_angle`` — Maximum angle from orbital pole in degrees (or None)
+   - ``type``: Always ``"orbit_pole"`` (Literal)
+   - ``min_angle``: Minimum angle from orbital pole in degrees
+   - ``max_angle``: Maximum angle from orbital pole in degrees (or None)
 
    **Requirements:**
 
@@ -1204,7 +1206,7 @@ Orbit pole direction constraint ensuring target maintains minimum angular separa
 BrightStarConstraint
 ^^^^^^^^^^^^^^^^^^^^
 
-Bright star avoidance constraint — violated when any catalog star falls within
+Bright star avoidance constraint - violated when any catalog star falls within
 the telescope field of view.  Useful for preventing stray light or detector
 saturation from bright stars.
 
@@ -1214,9 +1216,9 @@ catalog.
 
 Two FoV shapes are supported:
 
-- **Circular** (``fov_radius``) — roll-independent; a star is inside whenever
+- **Circular** (``fov_radius``): roll-independent; a star is inside whenever
   its angular separation from the boresight is less than ``fov_radius``.
-- **Polygon** (``fov_polygon``) — the polygon is defined in instrument frame
+- **Polygon** (``fov_polygon``): the polygon is defined in instrument frame
   coordinates and rotates with spacecraft roll.  At roll = 0° the +v axis
   points north and the +u axis points east on the sky.  When ``roll_deg`` is
   ``None``, all roll angles are swept (72 samples, ≈5° resolution) and the
@@ -1230,22 +1232,22 @@ Two FoV shapes are supported:
        At roll = 0° the +u axis points east and the +v axis points north.
        Mutually exclusive with ``fov_radius``.  Minimum 3 vertices.
    :param float roll_deg: Position angle (degrees east of north) of the instrument +v axis.
-       ``None`` (default) sweeps all roll angles — the constraint is violated only
+       ``None`` (default) sweeps all roll angles - the constraint is violated only
        when no clear roll exists.  Only meaningful with ``fov_polygon``.
 
    **Attributes:**
 
-   - ``type`` — Always ``"bright_star"`` (Literal)
-   - ``stars`` — List of ``(ra_deg, dec_deg)`` catalog entries
-   - ``fov_radius`` — Circular FoV radius in degrees (or ``None``)
-   - ``fov_polygon`` — Polygon vertices in instrument frame (or ``None``)
-   - ``roll_deg`` — Fixed roll angle (or ``None`` for roll sweep)
+   - ``type``: Always ``"bright_star"`` (Literal)
+   - ``stars``: List of ``(ra_deg, dec_deg)`` catalog entries
+   - ``fov_radius``: Circular FoV radius in degrees (or ``None``)
+   - ``fov_polygon``: Polygon vertices in instrument frame (or ``None``)
+   - ``roll_deg``: Fixed roll angle (or ``None`` for roll sweep)
 
    **Coordinate frame for polygon vertices:**
 
    Vertices are in degrees relative to the boresight in the *instrument frame*:
 
-   - ``u = 0, v = 0`` — boresight
+   - ``u = 0, v = 0``: boresight
    - At roll = 0°: +u points east, +v points north
    - Roll is the position angle of +v from north, measured east of north
 
@@ -1258,7 +1260,7 @@ Two FoV shapes are supported:
 
       v = \Delta_\text{east} \sin\theta + \Delta_\text{north} \cos\theta
 
-   **Example — circular FoV:**
+   **Example - circular FoV:**
 
    .. code-block:: python
 
@@ -1274,7 +1276,7 @@ Two FoV shapes are supported:
       c = Constraint.bright_star(stars=stars, fov_radius=0.5)
       result = c.evaluate(ephem, target_ra, target_dec)
 
-   **Example — polygon FoV with roll sweep:**
+   **Example - polygon FoV with roll sweep:**
 
    .. code-block:: python
 
@@ -1349,7 +1351,7 @@ Catalog Utilities
 AndConstraint
 ^^^^^^^^^^^^^
 
-Logical AND combination — satisfied only if ALL sub-constraints are satisfied.
+Logical AND combination - satisfied only if ALL sub-constraints are satisfied.
 
 .. py:class:: AndConstraint(constraints)
 
@@ -1357,8 +1359,8 @@ Logical AND combination — satisfied only if ALL sub-constraints are satisfied.
 
    **Attributes:**
 
-   - ``type`` — Always ``"and"`` (Literal)
-   - ``constraints`` — List of constraints to AND together
+   - ``type``: Always ``"and"`` (Literal)
+   - ``constraints``: List of constraints to AND together
 
    **Example:**
 
@@ -1374,7 +1376,7 @@ Logical AND combination — satisfied only if ALL sub-constraints are satisfied.
 OrConstraint
 ^^^^^^^^^^^^
 
-Logical OR combination — satisfied if ANY sub-constraint is satisfied.
+Logical OR combination - satisfied if ANY sub-constraint is satisfied.
 
 .. py:class:: OrConstraint(constraints)
 
@@ -1382,8 +1384,8 @@ Logical OR combination — satisfied if ANY sub-constraint is satisfied.
 
    **Attributes:**
 
-   - ``type`` — Always ``"or"`` (Literal)
-   - ``constraints`` — List of constraints to OR together
+   - ``type``: Always ``"or"`` (Literal)
+   - ``constraints``: List of constraints to OR together
 
    **Example:**
 
@@ -1399,7 +1401,7 @@ Logical OR combination — satisfied if ANY sub-constraint is satisfied.
 XorConstraint
 ^^^^^^^^^^^^^
 
-Logical XOR combination — violated when EXACTLY ONE sub-constraint is violated.
+Logical XOR combination - violated when EXACTLY ONE sub-constraint is violated.
 
 .. py:class:: XorConstraint(constraints)
 
@@ -1412,8 +1414,8 @@ Logical XOR combination — violated when EXACTLY ONE sub-constraint is violated
 
    **Attributes:**
 
-   - ``type`` — Always ``"xor"`` (Literal)
-   - ``constraints`` — List of constraints (minimum 2) evaluated with XOR semantics
+   - ``type``: Always ``"xor"`` (Literal)
+   - ``constraints``: List of constraints (minimum 2) evaluated with XOR semantics
 
    **Example:**
 
@@ -1429,7 +1431,7 @@ Logical XOR combination — violated when EXACTLY ONE sub-constraint is violated
 NotConstraint
 ^^^^^^^^^^^^^
 
-Logical NOT — inverts a constraint (satisfied when inner constraint is violated).
+Logical NOT - inverts a constraint (satisfied when inner constraint is violated).
 
 .. py:class:: NotConstraint(constraint)
 
@@ -1437,8 +1439,8 @@ Logical NOT — inverts a constraint (satisfied when inner constraint is violate
 
    **Attributes:**
 
-   - ``type`` — Always ``"not"`` (Literal)
-   - ``constraint`` — Constraint to negate
+   - ``type``: Always ``"not"`` (Literal)
+   - ``constraint``: Constraint to negate
 
    **Example:**
 
@@ -1465,16 +1467,16 @@ composition:
      - Description
    * - ``a & b``
      - ``AndConstraint([a, b])``
-     - Logical AND — both must be satisfied
+     - Logical AND: both must be satisfied
    * - ``a | b``
      - ``OrConstraint([a, b])``
-     - Logical OR — at least one must be satisfied
+     - Logical OR: at least one must be satisfied
    * - ``a ^ b``
      - ``XorConstraint([a, b])``
-     - Logical XOR — violated when exactly one is violated
+     - Logical XOR: violated when exactly one is violated
    * - ``~a``
      - ``NotConstraint(a)``
-     - Logical NOT — inverts the constraint
+     - Logical NOT: inverts the constraint
 
 **Example:**
 
@@ -1531,7 +1533,8 @@ All Pydantic constraint models inherit these methods:
       and the constraint is roll-dependent.  Default
       :data:`~rust_ephem.constraints.DEFAULT_N_ROLL_SAMPLES` (360 ≈ 1° resolution).
       Ignored when ``target_roll`` is given or no pitch/yaw offset is present.
-   :returns: ConstraintResult containing violation windows
+   :returns: ConstraintResult containing violation windows and computed
+      :ref:`constraint_values <constraint-values>`
    :rtype: ConstraintResult
 
 .. py:method:: evaluate_batch(ephemeris, target_ras, target_decs, times=None, indices=None, target_rolls=None, n_roll_samples=DEFAULT_N_ROLL_SAMPLES)
@@ -1554,7 +1557,8 @@ All Pydantic constraint models inherit these methods:
    :param int n_roll_samples: Number of roll angles to sweep when a target has ``target_roll=None``
       and the constraint is roll-dependent. Default
       :data:`~rust_ephem.constraints.DEFAULT_N_ROLL_SAMPLES` (360 ≈ 1° resolution).
-   :returns: List of ``ConstraintResult`` objects, one per input target
+   :returns: List of ``ConstraintResult`` objects, one per input target, each with
+      its own computed :ref:`constraint_values <constraint-values>`
    :rtype: list[ConstraintResult]
 
 .. py:method:: in_constraint_batch(ephemeris, target_ras, target_decs, times=None, indices=None, target_rolls=None, n_roll_samples=DEFAULT_N_ROLL_SAMPLES)
@@ -1729,12 +1733,15 @@ Result of constraint evaluation containing all violation information.
 
    **Attributes:**
 
-   - ``violations`` (list[ConstraintViolation]) — List of violation time windows
-   - ``all_satisfied`` (bool) — True if constraint was satisfied for entire time range
-   - ``constraint_name`` (str) — Name/description of the constraint
-   - ``timestamps`` (numpy.ndarray | list[datetime]) — Evaluation times (cached, lazy)
-   - ``constraint_array`` (list[bool]) — Boolean array where True = violated (cached, lazy)
-   - ``visibility`` (list[VisibilityWindow]) — Contiguous windows when target is visible
+   - ``violations`` (list[ConstraintViolation]): List of violation time windows
+   - ``all_satisfied`` (bool): True if constraint was satisfied for entire time range
+   - ``constraint_name`` (str): Name/description of the constraint
+   - ``timestamps`` (numpy.ndarray | list[datetime]): Evaluation times (cached, lazy)
+   - ``constraint_array`` (list[bool]): Boolean array where True = violated (cached, lazy)
+   - ``constraint_values`` (dict[str, list[float]]): Named continuous values computed
+     during evaluation (e.g. ``sun_angle_deg``), one array per key, aligned with
+     ``timestamps``. See :ref:`constraint-values` below.
+   - ``visibility`` (list[VisibilityWindow]): Contiguous windows when target is visible
 
    **Methods:**
 
@@ -1773,6 +1780,110 @@ Result of constraint evaluation containing all violation information.
            if not violated:
               print(f"Target visible at {time}")
 
+      # Inspect the underlying continuous value(s) the constraint thresholds
+      print(result.constraint_values["sun_angle_deg"][:5])
+
+.. _constraint-values:
+
+Constraint Values
+^^^^^^^^^^^^^^^^^
+
+Most constraints compute a continuous quantity (an angle, an airmass, an
+illumination fraction, ...) and then threshold it against a configured limit to
+decide violation. ``result.constraint_values`` exposes that underlying number
+under an obvious key name, so you can inspect *why* a constraint was violated
+(or how close it came to being violated) without re-deriving the geometry
+yourself.
+
+``constraint_values`` is a ``dict[str, list[float]]``: one array per named
+quantity, aligned index-for-index with ``result.timestamps``. It is populated
+by :py:meth:`evaluate`, :py:meth:`evaluate_batch`, and
+:py:meth:`evaluate_moving_body` - **not** by :py:meth:`in_constraint_batch` or
+:py:meth:`in_constraint`, which stay on the fast boolean-only path.
+
+**Key names by constraint type:**
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 35 35
+
+   * - Constraint
+     - Key(s)
+     - Notes
+   * - ``SunConstraint``
+     - ``sun_angle_deg``
+     -
+   * - ``MoonConstraint``
+     - ``moon_angle_deg``
+     -
+   * - ``BodyConstraint``
+     - ``body_angle_deg``
+     - Circle mode only (``min_angle``); omitted in ``fov_polygon`` mode
+   * - ``EclipseConstraint``
+     - ``eclipse_depth_frac``
+     - 0 = fully sunlit, 1 = shadow-axis center, smooth through the
+       umbra/penumbra boundary
+   * - ``AirmassConstraint``
+     - ``airmass``
+     -
+   * - ``AltAzConstraint``
+     - ``altitude_deg``, ``azimuth_deg``
+     -
+   * - ``DaytimeConstraint``
+     - ``sun_altitude_deg``
+     -
+   * - ``MoonPhaseConstraint``
+     - ``moon_illumination_frac``, ``moon_distance_deg``
+     -
+   * - ``OrbitPoleConstraint``
+     - ``orbit_pole_angle_deg``
+     - Angle to the nearer of the north/south orbital pole
+   * - ``OrbitRamConstraint``
+     - ``orbit_ram_angle_deg``
+     -
+   * - ``EarthLimbConstraint``
+     - ``earth_limb_angle_deg``
+     -
+   * - ``BrightStarConstraint``
+     - ``nearest_bright_star_angle_deg``
+     - Circle mode only (``fov_radius``); omitted in ``fov_polygon`` mode
+   * - ``SolarRollConstraint``
+     - ``solar_optimal_roll_deg``
+     - The computed optimal roll itself: meaningful whether ``roll_deg`` is
+       fixed or swept
+   * - ``SAAConstraint``
+     - *(none)*
+     - Pure polygon membership has no natural scalar to report
+
+**Combinators namespace child keys.** ``AndConstraint``, ``OrConstraint``,
+``XorConstraint``, and ``AtLeastConstraint`` merge every child's
+``constraint_values`` under a short prefix derived from the child's
+constraint type, so composite constraints don't lose per-child detail or
+silently collide on identical key names:
+
+.. code-block:: python
+
+   from rust_ephem.constraints import SunConstraint, MoonConstraint
+
+   combined = SunConstraint(min_angle=45.0) & MoonConstraint(min_angle=10.0)
+   result = combined.evaluate(ephem, target_ra=83.63, target_dec=22.01)
+
+   print(sorted(result.constraint_values.keys()))
+   # ['moon.moon_angle_deg', 'sun.sun_angle_deg']
+
+If two children share the same type (e.g. ``AND`` of two ``BodyConstraint``
+instances for different bodies), the second and later occurrences get a
+numeric suffix: ``body.body_angle_deg``, ``body_2.body_angle_deg``, ....
+``NotConstraint`` has a single child and passes its values straight through
+unprefixed; ``.boresight_offset(...)`` also has a single child and reports
+that child's values evaluated at the rotated direction, unprefixed.
+
+**Roll-swept evaluation.** When ``target_roll=None`` and the constraint is
+roll-dependent, ``evaluate()``/``evaluate_batch()`` sweep spacecraft roll
+internally to decide violation, but ``constraint_values`` is always sourced
+from the roll = 0° evaluation - the geometric value itself doesn't depend on
+which discrete roll was swept for violation determination.
+
 ConstraintViolation
 ^^^^^^^^^^^^^^^^^^^
 
@@ -1782,10 +1893,10 @@ Information about a specific constraint violation time window.
 
    **Attributes:**
 
-   - ``start_time`` (datetime) — Start time of violation window
-   - ``end_time`` (datetime) — End time of violation window
-   - ``max_severity`` (float) — Maximum severity of violation (0.0 = just violated, 1.0+ = severe)
-   - ``description`` (str) — Human-readable description of the violation
+   - ``start_time`` (datetime): Start time of violation window
+   - ``end_time`` (datetime): End time of violation window
+   - ``max_severity`` (float): Maximum severity of violation (0.0 = just violated, 1.0+ = severe)
+   - ``description`` (str): Human-readable description of the violation
 
    **Example:**
 
@@ -1805,9 +1916,9 @@ Time window when the observation target is not constrained (visible).
 
    **Attributes:**
 
-   - ``start_time`` (datetime) — Start time of visibility window
-   - ``end_time`` (datetime) — End time of visibility window
-   - ``duration_seconds`` (float) — Duration of the window in seconds (computed property)
+   - ``start_time`` (datetime): Start time of visibility window
+   - ``end_time`` (datetime): End time of visibility window
+   - ``duration_seconds`` (float): Duration of the window in seconds (computed property)
 
    **Example:**
 
@@ -1881,6 +1992,7 @@ Time window when the observation target is not constrained (visible).
       print(result.constraint_array[0:5])              # per-sample satisfied flags
       print(len(result.visibility))                # merged visibility windows
       print(result.visibility)
+      print(result.constraint_values["sun_angle_deg"][0:5])  # underlying angle per sample
 
 
    Example (explicit RA/Dec arrays)
@@ -1913,8 +2025,9 @@ Time window when the observation target is not constrained (visible).
      body lookup, call ``ephemeris.get_body(body, spice_kernel="path_or_url", use_horizons=True)`` (local file or URL). Downloads
      are cached under ``~/.cache/rust_ephem``; reuse the cached path to avoid re-fetching.
    * If you already have a planetary kernel on disk, point ``spice_kernel`` at that path; this does not affect
-     telescope/observer geometry — only body positions.
+     telescope/observer geometry - only body positions.
    * Use ``use_horizons=True`` for bodies not available in your SPICE kernels; JPL Horizons covers all major and many minor solar system bodies.
+   * The returned result also carries ``constraint_values``: see :ref:`constraint-values`.
 
 
 Type Aliases

--- a/docs/planning_constraints.rst
+++ b/docs/planning_constraints.rst
@@ -119,6 +119,57 @@ Working with Results
         if is_satisfied:
             print(f"Visible at {result.timestamp[i]}")
 
+Inspecting the Underlying Constraint Values
+--------------------------------------------
+
+Most constraints compute a continuous quantity - an angle, an airmass, an
+illumination fraction - and threshold it against a configured limit to decide
+violation. ``result.constraint_values`` exposes that number directly, under an
+obvious name such as ``sun_angle_deg``, so you can see *why* a constraint was
+violated (or how close it came to it) without recomputing the geometry
+yourself.
+
+.. code-block:: python
+
+    sun_constraint = SunConstraint(min_angle=45.0)
+    result = sun_constraint.evaluate(ephem, target_ra, target_dec)
+
+    # dict[str, list[float]], one array per key, aligned with result.timestamp
+    sun_angles = result.constraint_values["sun_angle_deg"]
+    print(f"Sun angle at t0: {sun_angles[0]:.1f}°")
+
+Each constraint type exposes different key(s) - e.g. ``AirmassConstraint``
+exposes ``airmass``, ``AltAzConstraint`` exposes ``altitude_deg`` and
+``azimuth_deg``, ``MoonPhaseConstraint`` exposes ``moon_illumination_frac``
+and ``moon_distance_deg``. See the full table in
+:ref:`Constraints API Reference <constraint-values>`. A few geometry-only
+constraints (``SAAConstraint``, and ``BodyConstraint``/``BrightStarConstraint``
+in polygon mode) have no single natural scalar and report an empty dict.
+
+When constraints are combined with ``&``, ``|``, ``^``, or
+:py:meth:`~rust_ephem.constraints.RustConstraintMixin.at_least`, each child's
+keys are namespaced by a short type tag so nothing gets lost or collides:
+
+.. code-block:: python
+
+    combined = SunConstraint(min_angle=45.0) & MoonConstraint(min_angle=10.0)
+    result = combined.evaluate(ephem, target_ra, target_dec)
+
+    print(sorted(result.constraint_values.keys()))
+    # ['moon.moon_angle_deg', 'sun.sun_angle_deg']
+
+    print(result.constraint_values["sun.sun_angle_deg"][0])
+    print(result.constraint_values["moon.moon_angle_deg"][0])
+
+This also works with :py:meth:`~rust_ephem.constraints.RustConstraintMixin.evaluate_batch`
+(one ``constraint_values`` dict per target result) and
+:py:meth:`~rust_ephem.constraints.RustConstraintMixin.evaluate_moving_body`
+(arrays aligned with the moving body's per-timestamp positions). It is **not**
+available from :py:meth:`~rust_ephem.constraints.RustConstraintMixin.in_constraint_batch`
+or :py:meth:`~rust_ephem.constraints.RustConstraintMixin.in_constraint`, which
+stay on the fast boolean-only path used internally for roll-sweeping and
+field-of-regard computation.
+
 Available Constraint Types
 --------------------------
 
@@ -132,9 +183,9 @@ Hipparcos catalog so you do not have to manage the catalog yourself.
 
 Two FoV shapes are supported:
 
-- **Circular** — any star within ``fov_radius`` degrees of the boresight violates
+- **Circular**: any star within ``fov_radius`` degrees of the boresight violates
   the constraint.  Roll is irrelevant.
-- **Polygon** — a convex or non-convex polygon defined in *instrument frame*
+- **Polygon**: a convex or non-convex polygon defined in *instrument frame*
   coordinates ``(u_deg, v_deg)``.  At roll = 0° the +v axis points north and the
   +u axis points east.  The polygon rotates rigidly with spacecraft roll.
 
@@ -162,7 +213,7 @@ Two FoV shapes are supported:
 
 When ``target_roll`` is omitted (or ``None``) for a polygon FoV, the evaluator
 sweeps 72 roll angles (5° resolution) across [0°, 360°).  The constraint is
-violated only when **every** roll has at least one star inside the polygon — i.e.
+violated only when **every** roll has at least one star inside the polygon - i.e.
 it returns ``False`` as soon as a clear roll exists.  This answers the scheduling
 question *"is there any valid roll for this pointing?"*.
 
@@ -340,7 +391,7 @@ When ``target_roll`` is omitted (or ``None``) and the constraint contains a
 boresight offset with non-zero pitch/yaw, all three evaluation methods
 (``evaluate``, ``in_constraint``, ``in_constraint_batch``) automatically sweep
 roll angles and report a target as blocked only when **every** possible roll is
-blocked — i.e., no valid spacecraft orientation exists.  The sweep resolution is
+blocked - i.e., no valid spacecraft orientation exists.  The sweep resolution is
 controlled by the ``n_roll_samples`` parameter (default
 :data:`~rust_ephem.constraints.DEFAULT_N_ROLL_SAMPLES` = 360 ≈ 1° resolution).
 This is the conservative "is there any viable roll?" check.  Pass an explicit
@@ -418,8 +469,8 @@ Constraints can be serialized to/from JSON for configuration files:
 Performance Tips
 ----------------
 
-1. **Use batch evaluation** for multiple targets — 3-50x faster than loops
-2. **Reuse constraint objects** — they cache internal Rust objects
+1. **Use batch evaluation** for multiple targets: 3-50x faster than loops
+2. **Reuse constraint objects**: they cache internal Rust objects
 3. **Access ``constraint_array``** property for efficient iteration over times
 4. **Use ``times`` or ``indices``** parameters to evaluate only specific times
 
@@ -464,10 +515,10 @@ asteroids, comets, and spacecraft without requiring additional configuration.
 
 **Key Features:**
 
-- **SPICE-first lookup** — Uses fast cached SPICE kernels when available
-- **Automatic fallback** — Queries JPL Horizons only when SPICE lacks the body
-- **Constraint integration** — Works with all constraint types and combinations
-- **Full accuracy** — Returns observer-relative positions with proper frame conversions
+- **SPICE-first lookup**: Uses fast cached SPICE kernels when available
+- **Automatic fallback**: Queries JPL Horizons only when SPICE lacks the body
+- **Constraint integration**: Works with all constraint types and combinations
+- **Full accuracy**: Returns observer-relative positions with proper frame conversions
 
 For detailed Horizons documentation including asteroid tracking examples,
 constraint combinations, and troubleshooting, see :doc:`ephemeris_horizons`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,13 +50,15 @@ dependencies = [
     "astroquery>=0.4.11",
     "numpy>=1.16",
     "pydantic>=2.12.4",
+    "tomlkit>=0.13",
+    "duckdb>=0.10.0",
+    "pyarrow>=14.0",
 ]
 
 [project.optional-dependencies]
-test = ["pytest>=7.0", "astropy>=5.0", "pytest-cov>=7.0.0", "duckdb>=0.10.0", "pyarrow>=14.0"]
+test = ["pytest>=7.0", "astropy>=5.0", "pytest-cov>=7.0.0"]
 docs = ["sphinx>=6.0", "sphinx-rtd-theme"]
-dev = ["mypy", "ruff", "prek", "maturin"]
-parquet = ["duckdb>=0.10.0"]
+dev = ["mypy", "ruff", "prek", "maturin", "pyarrow-stubs"]
 all = [
     "pytest>=7.0",
     "astropy>=5.0",
@@ -67,8 +69,7 @@ all = [
     "ruff",
     "prek",
     "maturin",
-    "duckdb>=0.10.0",
-    "pyarrow>=14.0",
+    "pyarrow-stubs",
 ]
 
 [project.urls]

--- a/rust_ephem/_rust_ephem.pyi
+++ b/rust_ephem/_rust_ephem.pyi
@@ -80,6 +80,63 @@ class ConstraintViolation:
         """Duration of the violation window in seconds."""
         ...
 
+class ConstraintResult:
+    """Result of constraint evaluation containing all violations."""
+
+    @property
+    def violations(self) -> list["ConstraintViolation"]:
+        """List of time windows when constraint was violated."""
+        ...
+
+    @property
+    def all_satisfied(self) -> bool:
+        """True if constraint was satisfied at all timestamps."""
+        ...
+
+    @property
+    def constraint_name(self) -> str:
+        """Name/description of the constraint."""
+        ...
+
+    @property
+    def timestamp(self) -> list[datetime]:
+        """List of timestamps that were evaluated."""
+        ...
+
+    @property
+    def constraint_array(self) -> list[bool]:
+        """Boolean array where True indicates constraint violation at that timestamp."""
+        ...
+
+    @property
+    def visibility(self) -> list[VisibilityWindow]:
+        """List of time windows when constraint was satisfied (target was visible)."""
+        ...
+
+    def in_constraint(self, time: datetime) -> bool:
+        """Check if constraint was violated at a specific time.
+
+        Args:
+            time: The time to check (must exist in timestamps).
+
+        Returns:
+            True if constraint was violated at the given time.
+
+        Raises:
+            ValueError: If time is not found in timestamps.
+        """
+        ...
+
+    def total_violation_duration(self) -> float:
+        """Get total duration of all constraint violations in seconds.
+
+        Returns:
+            Sum of all violation window durations in seconds.
+        """
+        ...
+
+    def __repr__(self) -> str: ...
+
 class MovingBodyResult:
     """Result from evaluating a constraint against a moving body.
 
@@ -578,7 +635,7 @@ class Constraint:
         times: datetime | list[datetime] | None = None,
         indices: int | list[int] | None = None,
         target_roll: float | None = None,
-    ) -> Any:
+    ) -> ConstraintResult:
         """
         Evaluate constraint against ephemeris data.
 
@@ -616,7 +673,7 @@ class Constraint:
         times: datetime | list[datetime] | None = None,
         indices: int | list[int] | None = None,
         target_rolls: list[float] | None = None,
-    ) -> list[Any]:
+    ) -> list[ConstraintResult]:
         """
         Evaluate constraint against multiple targets and return one result per target.
 

--- a/rust_ephem/_rust_ephem.pyi
+++ b/rust_ephem/_rust_ephem.pyi
@@ -109,6 +109,15 @@ class ConstraintResult:
         ...
 
     @property
+    def constraint_values(self) -> dict[str, list[float]]:
+        """Named continuous values computed during evaluation (e.g. ``sun_angle_deg``).
+
+        One array per key, aligned with ``timestamp``. Empty for constraints that
+        don't expose a natural scalar (e.g. polygon-based constraints).
+        """
+        ...
+
+    @property
     def visibility(self) -> list[VisibilityWindow]:
         """List of time windows when constraint was satisfied (target was visible)."""
         ...
@@ -177,6 +186,15 @@ class MovingBodyResult:
     @property
     def constraint_array(self) -> list[bool]:
         """Boolean array where True indicates constraint violation at that timestamp."""
+        ...
+
+    @property
+    def constraint_values(self) -> dict[str, list[float]]:
+        """Named continuous values computed during evaluation (e.g. ``sun_angle_deg``).
+
+        One array per key, aligned with ``timestamp``. Empty for constraints that
+        don't expose a natural scalar (e.g. polygon-based constraints).
+        """
         ...
 
     @property

--- a/rust_ephem/constraints.py
+++ b/rust_ephem/constraints.py
@@ -65,21 +65,66 @@ class ConstraintResult(BaseModel):
     )
     constraint_name: str = Field(..., description="Name/description of the constraint")
 
-    # Backing store for lazy access to timestamps/constraint_array/visibility, set at
-    # construction time. Either a live Rust ConstraintResult (single-evaluation case)
-    # or precomputed swept arrays (roll-sweep case) is populated, never both.
+    # Backing store for lazy access to timestamps/constraint_array/visibility.
+    # Either a live Rust ConstraintResult (single-evaluation case) or precomputed
+    # swept arrays (roll-sweep case) is populated, never both. Set via the
+    # _from_rust_result/_from_swept factories below, not through __init__: pydantic
+    # (via PEP 681 dataclass_transform) synthesizes ConstraintResult's __init__
+    # signature from declared fields only, so mypy will always reject private-attr
+    # names passed as constructor kwargs regardless of any validator that accepts
+    # them at runtime.
     _rust_result_ref: _RustConstraintResult | None = PrivateAttr(default=None)
     _swept_timestamps: list[datetime] | None = PrivateAttr(default=None)
     _swept_array: list[bool] | None = PrivateAttr(default=None)
 
-    def __init__(self, **data: Any) -> None:
-        rust_result_ref = data.pop("_rust_result_ref", None)
-        swept_timestamps = data.pop("_swept_timestamps", None)
-        swept_array = data.pop("_swept_array", None)
-        super().__init__(**data)
-        self._rust_result_ref = rust_result_ref
-        self._swept_timestamps = swept_timestamps
-        self._swept_array = swept_array
+    @classmethod
+    def _from_rust_result(
+        cls, rust_result: _RustConstraintResult
+    ) -> "ConstraintResult":
+        """Wrap a single-evaluation Rust ``ConstraintResult``.
+
+        Keeps a lazy reference to it for timestamps/constraint_array/visibility
+        instead of eagerly copying those (potentially large) arrays into Python.
+        """
+        result = cls(
+            violations=[
+                ConstraintViolation(
+                    start_time=v.start_time,
+                    end_time=v.end_time,
+                    max_severity=v.max_severity,
+                    description=v.description,
+                )
+                for v in rust_result.violations
+            ],
+            all_satisfied=rust_result.all_satisfied,
+            constraint_name=rust_result.constraint_name,
+        )
+        result._rust_result_ref = rust_result
+        return result
+
+    @classmethod
+    def _from_swept(
+        cls,
+        *,
+        constraint_name: str,
+        violations: list[ConstraintViolation],
+        all_satisfied: bool,
+        timestamps: list[datetime],
+        constraint_array: list[bool],
+    ) -> "ConstraintResult":
+        """Build a result from arrays swept across multiple roll angles.
+
+        Used when no single Rust ``ConstraintResult`` backs the result (the
+        combined outcome was computed by ORing per-roll boolean masks in Python).
+        """
+        result = cls(
+            violations=violations,
+            all_satisfied=all_satisfied,
+            constraint_name=constraint_name,
+        )
+        result._swept_timestamps = timestamps
+        result._swept_array = constraint_array
+        return result
 
     @property
     def timestamps(self) -> npt.NDArray[np.datetime64] | list[datetime]:
@@ -223,12 +268,12 @@ class RustConstraintMixin(BaseModel):
                 )
             )
 
-        return ConstraintResult(
+        return ConstraintResult._from_swept(
+            constraint_name=constraint_name,
             violations=violations,
             all_satisfied=not bool(violation_flags.any()),
-            constraint_name=constraint_name,
-            _swept_timestamps=timestamps,
-            _swept_array=violation_flags.tolist(),
+            timestamps=timestamps,
+            constraint_array=violation_flags.tolist(),
         )
 
     @staticmethod
@@ -314,20 +359,7 @@ class RustConstraintMixin(BaseModel):
             indices,
         )
         return [
-            ConstraintResult(
-                violations=[
-                    ConstraintViolation(
-                        start_time=v.start_time,
-                        end_time=v.end_time,
-                        max_severity=v.max_severity,
-                        description=v.description,
-                    )
-                    for v in rust_result.violations
-                ],
-                all_satisfied=rust_result.all_satisfied,
-                constraint_name=rust_result.constraint_name,
-                _rust_result_ref=rust_result,
-            )
+            ConstraintResult._from_rust_result(rust_result)
             for rust_result in rust_results
         ]
 
@@ -564,20 +596,7 @@ class RustConstraintMixin(BaseModel):
         )
 
         # Convert to Pydantic model - Rust now returns datetime objects directly
-        return ConstraintResult(
-            violations=[
-                ConstraintViolation(
-                    start_time=v.start_time,
-                    end_time=v.end_time,
-                    max_severity=v.max_severity,
-                    description=v.description,
-                )
-                for v in rust_result.violations
-            ],
-            all_satisfied=rust_result.all_satisfied,
-            constraint_name=rust_result.constraint_name,
-            _rust_result_ref=rust_result,
-        )
+        return ConstraintResult._from_rust_result(rust_result)
 
     def evaluate_batch(
         self,

--- a/rust_ephem/constraints.py
+++ b/rust_ephem/constraints.py
@@ -15,10 +15,18 @@ from typing import TYPE_CHECKING, Any, Literal, Union, cast
 
 import numpy as np
 import numpy.typing as npt
-from pydantic import BaseModel, ConfigDict, Field, TypeAdapter, model_validator
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    PrivateAttr,
+    TypeAdapter,
+    model_validator,
+)
 
 import rust_ephem
 
+from ._rust_ephem import ConstraintResult as _RustConstraintResult
 from .ephemeris import Ephemeris
 
 #: Default number of roll-angle samples used when sweeping spacecraft roll in
@@ -57,26 +65,29 @@ class ConstraintResult(BaseModel):
     )
     constraint_name: str = Field(..., description="Name/description of the constraint")
 
-    # Store reference to Rust result for lazy access to timestamps/constraint_array
+    # Backing store for lazy access to timestamps/constraint_array/visibility, set at
+    # construction time. Either a live Rust ConstraintResult (single-evaluation case)
+    # or precomputed swept arrays (roll-sweep case) is populated, never both.
+    _rust_result_ref: _RustConstraintResult | None = PrivateAttr(default=None)
+    _swept_timestamps: list[datetime] | None = PrivateAttr(default=None)
+    _swept_array: list[bool] | None = PrivateAttr(default=None)
+
     def __init__(self, **data: Any) -> None:
+        rust_result_ref = data.pop("_rust_result_ref", None)
+        swept_timestamps = data.pop("_swept_timestamps", None)
+        swept_array = data.pop("_swept_array", None)
         super().__init__(**data)
-        self._rust_result_ref = data.get("_rust_result_ref", None)
-        # Populated when evaluate() sweeps all roll angles instead of a single Rust result.
-        self._swept_timestamps: list[datetime] | None = data.get(
-            "_swept_timestamps", None
-        )
-        self._swept_array: list[bool] | None = data.get("_swept_array", None)
+        self._rust_result_ref = rust_result_ref
+        self._swept_timestamps = swept_timestamps
+        self._swept_array = swept_array
 
     @property
     def timestamps(self) -> npt.NDArray[np.datetime64] | list[datetime]:
         """Evaluation timestamps (lazily accessed from Rust result)."""
         if self._swept_timestamps is not None:
             return self._swept_timestamps
-        if hasattr(self, "_rust_result_ref") and self._rust_result_ref is not None:
-            return cast(
-                npt.NDArray[np.datetime64] | list[datetime],
-                self._rust_result_ref.timestamp,
-            )
+        if self._rust_result_ref is not None:
+            return self._rust_result_ref.timestamp
         return []
 
     @property
@@ -92,17 +103,15 @@ class ConstraintResult(BaseModel):
         """
         if self._swept_array is not None:
             return self._swept_array
-        if hasattr(self, "_rust_result_ref") and self._rust_result_ref is not None:
-            return cast(list[bool], self._rust_result_ref.constraint_array)
+        if self._rust_result_ref is not None:
+            return self._rust_result_ref.constraint_array
         return []
 
     @property
     def visibility(self) -> list["rust_ephem.VisibilityWindow"]:
         """Visibility windows when the constraint is satisfied (target visible)."""
-        if hasattr(self, "_rust_result_ref") and self._rust_result_ref is not None:
-            return cast(
-                list["rust_ephem.VisibilityWindow"], self._rust_result_ref.visibility
-            )
+        if self._rust_result_ref is not None:
+            return self._rust_result_ref.visibility
         return []
 
     def total_violation_duration(self) -> float:
@@ -134,8 +143,8 @@ class ConstraintResult(BaseModel):
                 return self._swept_array[idx]
             except ValueError:
                 raise ValueError(f"Time {time} not found in evaluated timestamps")
-        if hasattr(self, "_rust_result_ref") and self._rust_result_ref is not None:
-            return cast(bool, self._rust_result_ref.in_constraint(time))
+        if self._rust_result_ref is not None:
+            return self._rust_result_ref.in_constraint(time)
         raise ValueError(
             "ConstraintResult has no evaluated timestamps (was not created from evaluate())"
         )

--- a/rust_ephem/constraints.py
+++ b/rust_ephem/constraints.py
@@ -76,6 +76,7 @@ class ConstraintResult(BaseModel):
     _rust_result_ref: _RustConstraintResult | None = PrivateAttr(default=None)
     _swept_timestamps: list[datetime] | None = PrivateAttr(default=None)
     _swept_array: list[bool] | None = PrivateAttr(default=None)
+    _swept_constraint_values: dict[str, list[float]] | None = PrivateAttr(default=None)
 
     @classmethod
     def _from_rust_result(
@@ -111,6 +112,7 @@ class ConstraintResult(BaseModel):
         all_satisfied: bool,
         timestamps: list[datetime],
         constraint_array: list[bool],
+        constraint_values: dict[str, list[float]] | None = None,
     ) -> "ConstraintResult":
         """Build a result from arrays swept across multiple roll angles.
 
@@ -124,6 +126,7 @@ class ConstraintResult(BaseModel):
         )
         result._swept_timestamps = timestamps
         result._swept_array = constraint_array
+        result._swept_constraint_values = constraint_values
         return result
 
     @property
@@ -151,6 +154,19 @@ class ConstraintResult(BaseModel):
         if self._rust_result_ref is not None:
             return self._rust_result_ref.constraint_array
         return []
+
+    @property
+    def constraint_values(self) -> dict[str, list[float]]:
+        """Named continuous values computed during evaluation (e.g. ``sun_angle_deg``).
+
+        One array per key, aligned with ``timestamps``. Empty for constraints that
+        don't expose a natural scalar (e.g. polygon-based constraints).
+        """
+        if self._swept_constraint_values is not None:
+            return self._swept_constraint_values
+        if self._rust_result_ref is not None:
+            return self._rust_result_ref.constraint_values
+        return {}
 
     @property
     def visibility(self) -> list["rust_ephem.VisibilityWindow"]:
@@ -236,6 +252,7 @@ class RustConstraintMixin(BaseModel):
         constraint_name: str,
         timestamps: list[datetime],
         violated: npt.NDArray[np.bool_] | list[bool],
+        constraint_values: dict[str, list[float]] | None = None,
     ) -> ConstraintResult:
         """Build a ConstraintResult from a boolean violation mask."""
         violation_flags = np.asarray(violated, dtype=bool)
@@ -274,6 +291,7 @@ class RustConstraintMixin(BaseModel):
             all_satisfied=not bool(violation_flags.any()),
             timestamps=timestamps,
             constraint_array=violation_flags.tolist(),
+            constraint_values=constraint_values,
         )
 
     @staticmethod
@@ -331,21 +349,30 @@ class RustConstraintMixin(BaseModel):
                 target_roll=target_roll,
                 n_roll_samples=n_roll_samples,
             )
-            # Get timestamps/constraint_name from a single fixed roll (0°) to avoid
-            # redundant roll sweep. The metadata is the same regardless of roll.
-            first_result = self._resolve_rust_constraint(target_roll=0.0).evaluate(
+            # Get metadata and per-target values from a single fixed roll (0°) to
+            # avoid redundant roll sweep. The geometric values themselves don't
+            # depend on which discrete roll was swept for violation determination.
+            reference_results = self._resolve_rust_constraint(
+                target_roll=0.0
+            ).evaluate_batch(
                 ephemeris,
-                target_ras[0],
-                target_decs[0],
-                times=times,
-                indices=indices,
+                target_ras,
+                target_decs,
+                times,
+                indices,
             )
-            timestamps = self._coerce_timestamps(first_result.timestamp)
-            constraint_name = first_result.constraint_name
+            timestamps = self._coerce_timestamps(reference_results[0].timestamp)
 
             return [
-                self._build_constraint_result(constraint_name, timestamps, row)
-                for row in np.asarray(batch, dtype=bool)
+                self._build_constraint_result(
+                    reference_result.constraint_name,
+                    timestamps,
+                    row,
+                    constraint_values=reference_result.constraint_values,
+                )
+                for reference_result, row in zip(
+                    reference_results, np.asarray(batch, dtype=bool)
+                )
             ]
 
         rust_constraint = self._resolve_rust_constraint(
@@ -580,6 +607,7 @@ class RustConstraintMixin(BaseModel):
                 rust_results[0].constraint_name,
                 swept_timestamps,
                 combined,
+                constraint_values=rust_results[0].constraint_values,
             )
 
         rust_constraint = self._resolve_rust_constraint(
@@ -999,6 +1027,7 @@ class RustConstraintMixin(BaseModel):
             visibility=visibility_windows,
             all_satisfied=rust_result.all_satisfied,
             constraint_name=rust_result.constraint_name,
+            constraint_values=rust_result.constraint_values,
         )
 
     def and_(self, other: ConstraintConfig) -> AndConstraint:
@@ -1830,3 +1859,4 @@ class MovingVisibilityResult(BaseModel):
     visibility: list[VisibilityWindowResult]
     all_satisfied: bool
     constraint_name: str
+    constraint_values: dict[str, list[float]] = Field(default_factory=dict)

--- a/src/constraints/airmass.rs
+++ b/src/constraints/airmass.rs
@@ -5,6 +5,7 @@ use chrono::{DateTime, Utc};
 use ndarray::Array2;
 use pyo3::PyResult;
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 
 /// Configuration for Airmass constraint
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -135,6 +136,20 @@ impl ConstraintEvaluator for AirmassEvaluator {
         });
 
         Ok(result)
+    }
+
+    fn compute_named_values(
+        &self,
+        ephemeris: &dyn crate::ephemeris::ephemeris_common::EphemerisBase,
+        target_ras: &[f64],
+        target_decs: &[f64],
+        time_indices: Option<&[usize]>,
+    ) -> PyResult<HashMap<String, Array2<f64>>> {
+        let airmass_values =
+            calculate_airmass_batch_fast(target_ras, target_decs, ephemeris, time_indices);
+        let mut values = HashMap::new();
+        values.insert("airmass".to_string(), airmass_values);
+        Ok(values)
     }
 
     fn name(&self) -> String {

--- a/src/constraints/alt_az.rs
+++ b/src/constraints/alt_az.rs
@@ -5,6 +5,7 @@ use chrono::{DateTime, Utc};
 use ndarray::Array2;
 use pyo3::PyResult;
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 
 /// Configuration for Altitude/Azimuth constraint
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -242,6 +243,37 @@ impl ConstraintEvaluator for AltAzEvaluator {
         }
 
         Ok(result)
+    }
+
+    fn compute_named_values(
+        &self,
+        ephemeris: &dyn crate::ephemeris::ephemeris_common::EphemerisBase,
+        target_ras: &[f64],
+        target_decs: &[f64],
+        time_indices: Option<&[usize]>,
+    ) -> PyResult<HashMap<String, Array2<f64>>> {
+        let n_targets = target_ras.len();
+        let altaz_list: Vec<_> = target_ras
+            .iter()
+            .zip(target_decs.iter())
+            .map(|(&ra, &dec)| ephemeris.radec_to_altaz(ra, dec, time_indices))
+            .collect();
+
+        let n_times = altaz_list.first().map(|a| a.nrows()).unwrap_or(0);
+
+        let mut altitude_deg = Array2::<f64>::zeros((n_targets, n_times));
+        let mut azimuth_deg = Array2::<f64>::zeros((n_targets, n_times));
+        for (j, altaz) in altaz_list.iter().enumerate() {
+            for i in 0..n_times {
+                altitude_deg[[j, i]] = altaz[[i, 0]];
+                azimuth_deg[[j, i]] = altaz[[i, 1]];
+            }
+        }
+
+        let mut values = HashMap::new();
+        values.insert("altitude_deg".to_string(), altitude_deg);
+        values.insert("azimuth_deg".to_string(), azimuth_deg);
+        Ok(values)
     }
 
     fn name(&self) -> String {

--- a/src/constraints/body_proximity.rs
+++ b/src/constraints/body_proximity.rs
@@ -671,6 +671,41 @@ impl ConstraintEvaluator for BodyProximityEvaluator {
         Ok(result)
     }
 
+    fn compute_named_values(
+        &self,
+        ephemeris: &dyn crate::ephemeris::ephemeris_common::EphemerisBase,
+        target_ras: &[f64],
+        target_decs: &[f64],
+        time_indices: Option<&[usize]>,
+    ) -> pyo3::PyResult<std::collections::HashMap<String, Array2<f64>>> {
+        // Only circle mode has a single natural scalar; polygon mode is roll-swept
+        // and has no canonical angle to report.
+        if self.fov_polygon.is_some() {
+            return Ok(std::collections::HashMap::new());
+        }
+
+        let body_all = self.body_positions(ephemeris)?;
+        let obs_all = ephemeris.get_gcrs_positions()?;
+        let (body_positions_slice, observer_positions_slice) = if let Some(indices) = time_indices {
+            (
+                body_all.select(ndarray::Axis(0), indices),
+                obs_all.select(ndarray::Axis(0), indices),
+            )
+        } else {
+            (body_all, obs_all)
+        };
+
+        let angle_deg = super::core::compute_angle_deg_batch(
+            target_ras,
+            target_decs,
+            &body_positions_slice,
+            &observer_positions_slice,
+        );
+        let mut values = std::collections::HashMap::new();
+        values.insert("body_angle_deg".to_string(), angle_deg);
+        Ok(values)
+    }
+
     fn name(&self) -> String {
         self.format_name()
     }

--- a/src/constraints/bright_star.rs
+++ b/src/constraints/bright_star.rs
@@ -9,6 +9,7 @@ use ndarray::Array2;
 use pyo3::PyResult;
 use rayon::prelude::*;
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 use std::f64::consts::PI;
 
 /// Number of roll samples when sweeping all rolls (5° resolution)
@@ -130,6 +131,32 @@ impl BrightStarEvaluator {
             }
         }
         false
+    }
+
+    /// Angular separation (degrees) to the nearest catalog star. Empty catalogs report
+    /// 180° (no star anywhere nearby).
+    fn nearest_star_angle_deg(&self, target_ra_deg: f64, target_dec_deg: f64) -> f64 {
+        let target_dec_rad = target_dec_deg.to_radians();
+        let target_ra_rad = target_ra_deg.to_radians();
+        let (sin_dec, cos_dec) = target_dec_rad.sin_cos();
+        let (sin_ra, cos_ra) = target_ra_rad.sin_cos();
+        let target_unit = [cos_dec * cos_ra, cos_dec * sin_ra, sin_dec];
+
+        let max_cos_sep = self
+            .stars
+            .iter()
+            .map(|star| {
+                target_unit[0] * star.unit[0]
+                    + target_unit[1] * star.unit[1]
+                    + target_unit[2] * star.unit[2]
+            })
+            .fold(f64::NEG_INFINITY, f64::max);
+
+        if max_cos_sep.is_finite() {
+            max_cos_sep.clamp(-1.0, 1.0).acos().to_degrees()
+        } else {
+            180.0
+        }
     }
 
     // ── Polygon helpers ───────────────────────────────────────────────────────
@@ -665,6 +692,42 @@ impl ConstraintEvaluator for BrightStarEvaluator {
                     .collect())
             }
         }
+    }
+
+    fn compute_named_values(
+        &self,
+        ephemeris: &dyn crate::ephemeris::ephemeris_common::EphemerisBase,
+        target_ras: &[f64],
+        target_decs: &[f64],
+        time_indices: Option<&[usize]>,
+    ) -> PyResult<HashMap<String, Array2<f64>>> {
+        // Only circle mode has a single natural scalar; polygon mode is roll-swept
+        // and has no canonical angle to report.
+        if !matches!(self.fov, FovDefinition::Circle { .. }) {
+            return Ok(HashMap::new());
+        }
+
+        let all_times = ephemeris.get_times()?;
+        let n_times = time_indices.map(|idx| idx.len()).unwrap_or(all_times.len());
+        let n_targets = target_ras.len();
+
+        // Result is time-invariant (fixed ICRS catalog vs. fixed target direction);
+        // compute once per target and broadcast across times.
+        let nearest_deg: Vec<f64> = target_ras
+            .iter()
+            .zip(target_decs.iter())
+            .map(|(&ra, &dec)| self.nearest_star_angle_deg(ra, dec))
+            .collect();
+
+        let nearest_bright_star_angle_deg =
+            Array2::from_shape_fn((n_targets, n_times), |(j, _)| nearest_deg[j]);
+
+        let mut values = HashMap::new();
+        values.insert(
+            "nearest_bright_star_angle_deg".to_string(),
+            nearest_bright_star_angle_deg,
+        );
+        Ok(values)
     }
 
     fn name(&self) -> String {

--- a/src/constraints/constraint_wrapper/boresight.rs
+++ b/src/constraints/constraint_wrapper/boresight.rs
@@ -2,6 +2,7 @@ use crate::constraints::core::{track_violations, ConstraintEvaluator, Constraint
 use crate::utils::vector_math::unit_vectors_to_radec_batch;
 use ndarray::Array2;
 use pyo3::PyResult;
+use std::collections::HashMap;
 
 /// Threshold below which a vector norm or angle (in degrees) is treated as zero.
 const NEAR_ZERO: f64 = 1.0e-12;
@@ -749,6 +750,97 @@ impl ConstraintEvaluator for BoresightOffsetEvaluator {
         };
 
         Ok((0..n_targets).map(|i| violated_col[[i, 0]]).collect())
+    }
+
+    fn compute_named_values(
+        &self,
+        ephemeris: &dyn crate::ephemeris::ephemeris_common::EphemerisBase,
+        target_ras: &[f64],
+        target_decs: &[f64],
+        time_indices: Option<&[usize]>,
+    ) -> PyResult<HashMap<String, Array2<f64>>> {
+        let params = self.rotation_params();
+        let n_targets = target_ras.len();
+        let target_units: Vec<[f64; 3]> = target_ras
+            .iter()
+            .zip(target_decs.iter())
+            .map(|(&ra, &dec)| crate::utils::vector_math::radec_to_unit_vector(ra, dec))
+            .collect();
+
+        // Single child, evaluated at the rotated direction — pass through unprefixed.
+        if matches!(self.roll_reference, RollReference::North) {
+            // Rotation is time-invariant for the north reference: rotate once per
+            // target and delegate directly, letting the child broadcast over times.
+            let mut rotated_units = Array2::<f64>::zeros((n_targets, 3));
+            for (i, target_unit) in target_units.iter().enumerate() {
+                let rotated = self.rotated_target_for_time_with_params(
+                    target_unit,
+                    &[0.0, 0.0, 0.0],
+                    params,
+                )?;
+                rotated_units[[i, 0]] = rotated[0];
+                rotated_units[[i, 1]] = rotated[1];
+                rotated_units[[i, 2]] = rotated[2];
+            }
+            let (rotated_ras, rotated_decs) = unit_vectors_to_radec_batch(&rotated_units);
+            return self.constraint.compute_named_values(
+                ephemeris,
+                &rotated_ras,
+                &rotated_decs,
+                time_indices,
+            );
+        }
+
+        // Sun reference: the rotation depends on the Sun direction at each timestamp,
+        // so evaluate one time column at a time (same cost pattern already used by
+        // in_constraint_batch for this reference mode).
+        let all_times = ephemeris.get_times()?;
+        let indices: Vec<usize> = if let Some(subset) = time_indices {
+            subset.to_vec()
+        } else {
+            (0..all_times.len()).collect()
+        };
+
+        let sun_positions = ephemeris.get_sun_positions()?;
+        let observer_positions = ephemeris.get_gcrs_positions()?;
+
+        let mut merged: HashMap<String, Array2<f64>> = HashMap::new();
+        let mut rotated_units = Array2::<f64>::zeros((n_targets, 3));
+
+        for (col, &time_idx) in indices.iter().enumerate() {
+            let sun_rel = [
+                sun_positions[[time_idx, 0]] - observer_positions[[time_idx, 0]],
+                sun_positions[[time_idx, 1]] - observer_positions[[time_idx, 1]],
+                sun_positions[[time_idx, 2]] - observer_positions[[time_idx, 2]],
+            ];
+
+            for (i, target_unit) in target_units.iter().enumerate() {
+                let rotated =
+                    self.rotated_target_for_time_with_params(target_unit, &sun_rel, params)?;
+                rotated_units[[i, 0]] = rotated[0];
+                rotated_units[[i, 1]] = rotated[1];
+                rotated_units[[i, 2]] = rotated[2];
+            }
+
+            let (rotated_ras, rotated_decs) = unit_vectors_to_radec_batch(&rotated_units);
+            let column_values = self.constraint.compute_named_values(
+                ephemeris,
+                &rotated_ras,
+                &rotated_decs,
+                Some(&[time_idx]),
+            )?;
+
+            for (key, arr) in column_values {
+                let entry = merged
+                    .entry(key)
+                    .or_insert_with(|| Array2::<f64>::zeros((n_targets, indices.len())));
+                for row in 0..n_targets {
+                    entry[[row, col]] = arr[[row, 0]];
+                }
+            }
+        }
+
+        Ok(merged)
     }
 
     fn name(&self) -> String {

--- a/src/constraints/constraint_wrapper/combinators.rs
+++ b/src/constraints/constraint_wrapper/combinators.rs
@@ -5,6 +5,82 @@ use crate::constraints::core::{
 use crate::utils::vector_math::unit_vectors_to_radec_batch;
 use ndarray::Array2;
 use pyo3::PyResult;
+use std::collections::HashMap;
+
+/// Short, stable tag for a leaf/combinator constraint's `values` key prefix, derived
+/// from the text before the first `(` in its `name()`. Falls back to a sanitized
+/// version of the head for anything unmapped, so new constraint types don't panic
+/// or silently collide — they just get a slightly uglier (but unique-ish) prefix.
+fn value_key_prefix(name: &str) -> String {
+    let head = name.split('(').next().unwrap_or(name).trim();
+    let tag = match head {
+        "SunProximity" => "sun",
+        "MoonProximity" => "moon",
+        "BodyProximity" => "body",
+        "Eclipse" => "eclipse",
+        "AirmassConstraint" => "airmass",
+        "AltAzConstraint" => "alt_az",
+        "SAAConstraint" => "saa",
+        "DaytimeConstraint" => "daytime",
+        "MoonPhaseConstraint" => "moon_phase",
+        "OrbitPoleConstraint" => "orbit_pole",
+        "OrbitRamConstraint" => "orbit_ram",
+        "EarthLimb" => "earth_limb",
+        "BrightStar" => "bright_star",
+        "SolarRollConstraint" => "solar_roll",
+        "AND" => "and",
+        "OR" => "or",
+        "NOT" => "not",
+        "XOR" => "xor",
+        "AT_LEAST" => "at_least",
+        "BoresightOffset" => "boresight_offset",
+        other => {
+            return other
+                .to_lowercase()
+                .replace(|c: char| !c.is_alphanumeric(), "_")
+        }
+    };
+    tag.to_string()
+}
+
+/// Merge named-value maps from a set of child evaluators, namespacing each child's
+/// keys under a short type tag (e.g. `sun.sun_angle_deg`) so composite constraints
+/// don't lose per-child detail or silently collide on identical key names. On tag
+/// collision (two children of the same type), the 2nd+ occurrence gets a numeric
+/// suffix (`sun_2`, `sun_3`, ...).
+fn merge_children_named_values(
+    children: &[Box<dyn ConstraintEvaluator>],
+    ephemeris: &dyn crate::ephemeris::ephemeris_common::EphemerisBase,
+    target_ras: &[f64],
+    target_decs: &[f64],
+    time_indices: Option<&[usize]>,
+) -> PyResult<HashMap<String, Array2<f64>>> {
+    let mut merged = HashMap::new();
+    let mut tag_counts: HashMap<String, usize> = HashMap::new();
+
+    for child in children {
+        let child_values =
+            child.compute_named_values(ephemeris, target_ras, target_decs, time_indices)?;
+        if child_values.is_empty() {
+            continue;
+        }
+
+        let base_tag = value_key_prefix(&child.name());
+        let count = tag_counts.entry(base_tag.clone()).or_insert(0);
+        *count += 1;
+        let prefix = if *count == 1 {
+            base_tag
+        } else {
+            format!("{base_tag}_{count}")
+        };
+
+        for (key, arr) in child_values {
+            merged.insert(format!("{prefix}.{key}"), arr);
+        }
+    }
+
+    Ok(merged)
+}
 
 fn validate_unit_vector_shape(target_unit_vectors: &Array2<f64>) -> PyResult<()> {
     if target_unit_vectors.ncols() != 3 {
@@ -488,6 +564,22 @@ impl ConstraintEvaluator for AndEvaluator {
         Ok(result)
     }
 
+    fn compute_named_values(
+        &self,
+        ephemeris: &dyn crate::ephemeris::ephemeris_common::EphemerisBase,
+        target_ras: &[f64],
+        target_decs: &[f64],
+        time_indices: Option<&[usize]>,
+    ) -> PyResult<HashMap<String, Array2<f64>>> {
+        merge_children_named_values(
+            &self.constraints,
+            ephemeris,
+            target_ras,
+            target_decs,
+            time_indices,
+        )
+    }
+
     fn name(&self) -> String {
         format!(
             "AND({})",
@@ -957,6 +1049,22 @@ impl ConstraintEvaluator for OrEvaluator {
             .collect())
     }
 
+    fn compute_named_values(
+        &self,
+        ephemeris: &dyn crate::ephemeris::ephemeris_common::EphemerisBase,
+        target_ras: &[f64],
+        target_decs: &[f64],
+        time_indices: Option<&[usize]>,
+    ) -> PyResult<HashMap<String, Array2<f64>>> {
+        merge_children_named_values(
+            &self.constraints,
+            ephemeris,
+            target_ras,
+            target_decs,
+            time_indices,
+        )
+    }
+
     fn name(&self) -> String {
         format!(
             "OR({})",
@@ -1177,6 +1285,18 @@ impl ConstraintEvaluator for NotEvaluator {
         )?;
         // NOTE: Do not negate here: inner result is already aggregated over roll freedom.
         Ok(sub)
+    }
+
+    fn compute_named_values(
+        &self,
+        ephemeris: &dyn crate::ephemeris::ephemeris_common::EphemerisBase,
+        target_ras: &[f64],
+        target_decs: &[f64],
+        time_indices: Option<&[usize]>,
+    ) -> PyResult<HashMap<String, Array2<f64>>> {
+        // Single child, no collision risk - pass its values straight through unprefixed.
+        self.constraint
+            .compute_named_values(ephemeris, target_ras, target_decs, time_indices)
     }
 
     fn name(&self) -> String {
@@ -1455,6 +1575,22 @@ impl ConstraintEvaluator for XorEvaluator {
             result.push(count == 1);
         }
         Ok(result)
+    }
+
+    fn compute_named_values(
+        &self,
+        ephemeris: &dyn crate::ephemeris::ephemeris_common::EphemerisBase,
+        target_ras: &[f64],
+        target_decs: &[f64],
+        time_indices: Option<&[usize]>,
+    ) -> PyResult<HashMap<String, Array2<f64>>> {
+        merge_children_named_values(
+            &self.constraints,
+            ephemeris,
+            target_ras,
+            target_decs,
+            time_indices,
+        )
     }
 
     fn name(&self) -> String {
@@ -1744,6 +1880,22 @@ impl ConstraintEvaluator for AtLeastEvaluator {
             result.push(count >= self.min_violated);
         }
         Ok(result)
+    }
+
+    fn compute_named_values(
+        &self,
+        ephemeris: &dyn crate::ephemeris::ephemeris_common::EphemerisBase,
+        target_ras: &[f64],
+        target_decs: &[f64],
+        time_indices: Option<&[usize]>,
+    ) -> PyResult<HashMap<String, Array2<f64>>> {
+        merge_children_named_values(
+            &self.constraints,
+            ephemeris,
+            target_ras,
+            target_decs,
+            time_indices,
+        )
     }
 
     fn name(&self) -> String {

--- a/src/constraints/constraint_wrapper/py_api.rs
+++ b/src/constraints/constraint_wrapper/py_api.rs
@@ -2148,6 +2148,12 @@ impl PyConstraint {
 
         let all_satisfied = !constraint_vec.iter().any(|&v| v);
 
+        // Compute named continuous values (diagonal: target_i paired with time_i).
+        let values = self.with_ephemeris(bound, |ephem_ref| {
+            self.evaluator
+                .compute_named_values_diagonal(ephem_ref, &ras, &decs)
+        })?;
+
         Ok(MovingBodyResult::new(
             violations,
             all_satisfied,
@@ -2156,7 +2162,8 @@ impl PyConstraint {
             ras,
             decs,
             constraint_vec,
-        ))
+        )
+        .with_constraint_values(values))
     }
 
     /// Get constraint configuration as JSON string

--- a/src/constraints/constraint_wrapper/py_api_helpers.rs
+++ b/src/constraints/constraint_wrapper/py_api_helpers.rs
@@ -7,6 +7,7 @@ use crate::ephemeris::ParquetEphemeris;
 use crate::ephemeris::SPICEEphemeris;
 use crate::ephemeris::TLEEphemeris;
 use pyo3::prelude::*;
+use std::collections::HashMap;
 
 use super::PyConstraint;
 use crate::constraints::constraint_wrapper::field_of_regard::DEFAULT_N_ROLL_SAMPLES;
@@ -144,6 +145,21 @@ impl PyConstraint {
             time_indices,
             n_roll_samples,
         )
+    }
+
+    /// Slice out a single target's row from each named-value matrix returned by
+    /// `compute_named_values` (shape M x N, targets x times).
+    pub(super) fn extract_target_values(
+        values_map: &HashMap<String, ndarray::Array2<f64>>,
+        target_index: usize,
+    ) -> HashMap<String, Vec<f64>> {
+        values_map
+            .iter()
+            .map(|(key, arr)| {
+                let row: Vec<f64> = (0..arr.ncols()).map(|i| arr[[target_index, i]]).collect();
+                (key.clone(), row)
+            })
+            .collect()
     }
 
     pub(super) fn with_effective_evaluator<T, F>(
@@ -286,12 +302,20 @@ impl PyConstraint {
         );
 
         let all_satisfied = violations.is_empty();
-        Ok(ConstraintResult::new(
-            violations,
-            all_satisfied,
-            evaluator.name(),
-            times,
-        ))
+
+        // Compute named continuous values once (not swept across roll angles).
+        let values_map = evaluator.compute_named_values(
+            ephemeris,
+            &[target_ra],
+            &[target_dec],
+            time_indices.as_deref(),
+        )?;
+        let values = Self::extract_target_values(&values_map, 0);
+
+        Ok(
+            ConstraintResult::new(violations, all_satisfied, evaluator.name(), times)
+                .with_constraint_values(values),
+        )
     }
 
     pub(super) fn eval_batch_with_ephemeris(
@@ -318,6 +342,14 @@ impl PyConstraint {
             all_times.to_vec()
         };
 
+        // Compute named continuous values once for all targets (not swept across roll angles).
+        let values_map = evaluator.compute_named_values(
+            ephemeris,
+            target_ras,
+            target_decs,
+            time_indices.as_deref(),
+        )?;
+
         let mut results = Vec::with_capacity(target_ras.len());
         for target_index in 0..target_ras.len() {
             let violated: Vec<bool> = (0..violation_array.ncols())
@@ -331,12 +363,11 @@ impl PyConstraint {
             );
 
             let all_satisfied = violations.is_empty();
-            results.push(ConstraintResult::new(
-                violations,
-                all_satisfied,
-                evaluator.name(),
-                times.clone(),
-            ));
+            let values = Self::extract_target_values(&values_map, target_index);
+            results.push(
+                ConstraintResult::new(violations, all_satisfied, evaluator.name(), times.clone())
+                    .with_constraint_values(values),
+            );
         }
 
         Ok(results)

--- a/src/constraints/core.rs
+++ b/src/constraints/core.rs
@@ -13,6 +13,7 @@ use crate::utils::time_utils::{python_datetime_to_utc, utc_to_python_datetime};
 use chrono::{DateTime, Utc};
 use ndarray::Array2;
 use pyo3::prelude::*;
+use std::collections::HashMap;
 use std::fmt;
 use std::sync::OnceLock;
 
@@ -100,6 +101,10 @@ pub struct ConstraintResult {
     /// Constraint name/description
     #[pyo3(get)]
     pub constraint_name: String,
+    /// Named continuous values computed during evaluation (e.g. `sun_angle_deg`),
+    /// one array per key, aligned with `times`/`timestamp`.
+    #[pyo3(get)]
+    pub constraint_values: HashMap<String, Vec<f64>>,
     /// Evaluation times as Rust DateTime<Utc>, not directly exposed to Python
     pub times: Vec<DateTime<Utc>>,
     /// Step size in seconds between timestamps (for O(1) index lookup)
@@ -130,12 +135,19 @@ impl ConstraintResult {
             violations,
             all_satisfied,
             constraint_name,
+            constraint_values: HashMap::new(),
             times,
             step_seconds,
             timestamp_cache: OnceLock::new(),
             constraint_vec_cache: OnceLock::new(),
             constraint_array_cache: OnceLock::new(),
         }
+    }
+
+    /// Attach named continuous values computed during evaluation.
+    pub fn with_constraint_values(mut self, constraint_values: HashMap<String, Vec<f64>>) -> Self {
+        self.constraint_values = constraint_values;
+        self
     }
 }
 
@@ -368,6 +380,10 @@ pub struct MovingBodyResult {
     /// Declinations in degrees for each timestamp
     #[pyo3(get)]
     pub decs: Vec<f64>,
+    /// Named continuous values computed during evaluation (e.g. `sun_angle_deg`),
+    /// one array per key, aligned with `times`/`timestamp`.
+    #[pyo3(get)]
+    pub constraint_values: HashMap<String, Vec<f64>>,
     /// Evaluation times as Rust DateTime<Utc>, not directly exposed to Python
     pub times: Vec<DateTime<Utc>>,
     /// Step size in seconds between timestamps (for O(1) index lookup)
@@ -399,10 +415,17 @@ impl MovingBodyResult {
             constraint_name,
             ras,
             decs,
+            constraint_values: HashMap::new(),
             times,
             step_seconds,
             constraint_vec,
         }
+    }
+
+    /// Attach named continuous values computed during evaluation.
+    pub fn with_constraint_values(mut self, constraint_values: HashMap<String, Vec<f64>>) -> Self {
+        self.constraint_values = constraint_values;
+        self
     }
 }
 
@@ -561,6 +584,44 @@ pub trait ConstraintEvaluator: Send + Sync {
         target_dec: f64,
         time_indices: Option<&[usize]>,
     ) -> PyResult<ConstraintResult>;
+
+    /// Compute named continuous values (e.g. `sun_angle_deg`) for each target/time,
+    /// mirroring the geometry already computed by `in_constraint_batch` before it gets
+    /// thresholded into a boolean. Called once per `evaluate()`/`evaluate_batch()` call
+    /// (never inside a roll-sweep loop), so this can afford to recompute the underlying
+    /// scalar rather than sharing state with the boolean path.
+    ///
+    /// # Returns
+    /// Map from value name to an (M x N) array (targets x times), matching the shape of
+    /// `in_constraint_batch`. Default: no named values (constraint doesn't expose one).
+    fn compute_named_values(
+        &self,
+        _ephemeris: &dyn crate::ephemeris::ephemeris_common::EphemerisBase,
+        _target_ras: &[f64],
+        _target_decs: &[f64],
+        _time_indices: Option<&[usize]>,
+    ) -> PyResult<HashMap<String, Array2<f64>>> {
+        Ok(HashMap::new())
+    }
+
+    /// Diagonal variant of `compute_named_values` for moving-body evaluation: target_i
+    /// paired with time_i only. Default falls back to the full batch and extracts the
+    /// diagonal, mirroring `in_constraint_batch_diagonal`'s default.
+    fn compute_named_values_diagonal(
+        &self,
+        ephemeris: &dyn crate::ephemeris::ephemeris_common::EphemerisBase,
+        target_ras: &[f64],
+        target_decs: &[f64],
+    ) -> PyResult<HashMap<String, Vec<f64>>> {
+        let n = target_ras.len();
+        let time_indices: Vec<usize> = (0..n).collect();
+        let full =
+            self.compute_named_values(ephemeris, target_ras, target_decs, Some(&time_indices))?;
+        Ok(full
+            .into_iter()
+            .map(|(key, arr)| (key, (0..n).map(|i| arr[[i, i]]).collect()))
+            .collect())
+    }
 
     /// Check if targets are in-constraint for multiple RA/Dec positions (vectorized)
     ///
@@ -892,6 +953,72 @@ macro_rules! impl_proximity_evaluator {
             }
         }
     };
+}
+
+/// Compute the angular separation (degrees) between each target direction and a
+/// celestial body's apparent position (as seen from the observer), for every
+/// target/time combination. Mirrors the cosine-based geometry already computed
+/// inline by each proximity constraint's `in_constraint_batch`, minus the
+/// thresholding — used to populate `compute_named_values` (e.g. `sun_angle_deg`,
+/// `moon_angle_deg`, `body_angle_deg`) without duplicating that math.
+///
+/// # Returns
+/// (M x N) array (targets x times) of angles in degrees.
+pub(crate) fn compute_angle_deg_batch(
+    target_ras: &[f64],
+    target_decs: &[f64],
+    body_positions: &Array2<f64>,
+    observer_positions: &Array2<f64>,
+) -> Array2<f64> {
+    let n_targets = target_ras.len();
+    let n_times = body_positions.nrows();
+    let target_vectors =
+        crate::utils::vector_math::radec_to_unit_vectors_batch(target_ras, target_decs);
+
+    let mut result = Array2::<f64>::zeros((n_targets, n_times));
+
+    for t in 0..n_times {
+        let body_pos = [
+            body_positions[[t, 0]],
+            body_positions[[t, 1]],
+            body_positions[[t, 2]],
+        ];
+        let obs_pos = [
+            observer_positions[[t, 0]],
+            observer_positions[[t, 1]],
+            observer_positions[[t, 2]],
+        ];
+
+        let body_rel = [
+            body_pos[0] - obs_pos[0],
+            body_pos[1] - obs_pos[1],
+            body_pos[2] - obs_pos[2],
+        ];
+        let body_dist =
+            (body_rel[0] * body_rel[0] + body_rel[1] * body_rel[1] + body_rel[2] * body_rel[2])
+                .sqrt();
+        let body_unit = [
+            body_rel[0] / body_dist,
+            body_rel[1] / body_dist,
+            body_rel[2] / body_dist,
+        ];
+
+        for target_idx in 0..n_targets {
+            let target_vec = [
+                target_vectors[[target_idx, 0]],
+                target_vectors[[target_idx, 1]],
+                target_vectors[[target_idx, 2]],
+            ];
+
+            let cos_angle = target_vec[0] * body_unit[0]
+                + target_vec[1] * body_unit[1]
+                + target_vec[2] * body_unit[2];
+
+            result[[target_idx, t]] = cos_angle.clamp(-1.0, 1.0).acos().to_degrees();
+        }
+    }
+
+    result
 }
 
 // Helper function for tracking violation windows

--- a/src/constraints/core.rs
+++ b/src/constraints/core.rs
@@ -994,14 +994,19 @@ pub(crate) fn compute_angle_deg_batch(
             body_pos[1] - obs_pos[1],
             body_pos[2] - obs_pos[2],
         ];
-        let body_dist =
-            (body_rel[0] * body_rel[0] + body_rel[1] * body_rel[1] + body_rel[2] * body_rel[2])
-                .sqrt();
-        let body_unit = [
-            body_rel[0] / body_dist,
-            body_rel[1] / body_dist,
-            body_rel[2] / body_dist,
-        ];
+        let body_dist = (body_rel[0] * body_rel[0]
+            + body_rel[1] * body_rel[1]
+            + body_rel[2] * body_rel[2])
+            .sqrt();
+        let body_unit = if body_dist > 0.0 {
+            [
+                body_rel[0] / body_dist,
+                body_rel[1] / body_dist,
+                body_rel[2] / body_dist,
+            ]
+        } else {
+            [1.0, 0.0, 0.0]
+        };
 
         for target_idx in 0..n_targets {
             let target_vec = [

--- a/src/constraints/core.rs
+++ b/src/constraints/core.rs
@@ -994,10 +994,9 @@ pub(crate) fn compute_angle_deg_batch(
             body_pos[1] - obs_pos[1],
             body_pos[2] - obs_pos[2],
         ];
-        let body_dist = (body_rel[0] * body_rel[0]
-            + body_rel[1] * body_rel[1]
-            + body_rel[2] * body_rel[2])
-            .sqrt();
+        let body_dist =
+            (body_rel[0] * body_rel[0] + body_rel[1] * body_rel[1] + body_rel[2] * body_rel[2])
+                .sqrt();
         let body_unit = if body_dist > 0.0 {
             [
                 body_rel[0] / body_dist,

--- a/src/constraints/daytime.rs
+++ b/src/constraints/daytime.rs
@@ -3,6 +3,7 @@ use super::core::{track_violations, ConstraintConfig, ConstraintEvaluator, Const
 use ndarray::Array2;
 use pyo3::PyResult;
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 
 /// Twilight type for daytime constraint
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -175,6 +176,26 @@ impl ConstraintEvaluator for DaytimeEvaluator {
         }
 
         Ok(Some(result))
+    }
+
+    fn compute_named_values(
+        &self,
+        ephemeris: &dyn crate::ephemeris::ephemeris_common::EphemerisBase,
+        target_ras: &[f64],
+        _target_decs: &[f64],
+        time_indices: Option<&[usize]>,
+    ) -> PyResult<HashMap<String, Array2<f64>>> {
+        let sun_altitudes =
+            crate::utils::celestial::calculate_sun_altitudes_batch_fast(ephemeris, time_indices);
+
+        let n_targets = target_ras.len();
+        let n_times = sun_altitudes.len();
+        let sun_altitude_deg =
+            Array2::from_shape_fn((n_targets, n_times), |(_, t)| sun_altitudes[t]);
+
+        let mut values = HashMap::new();
+        values.insert("sun_altitude_deg".to_string(), sun_altitude_deg);
+        Ok(values)
     }
 
     fn name(&self) -> String {

--- a/src/constraints/earth_limb.rs
+++ b/src/constraints/earth_limb.rs
@@ -8,6 +8,7 @@ use chrono::{DateTime, Utc};
 use ndarray::Array2;
 use pyo3::PyResult;
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 
 /// Configuration for Earth limb avoidance constraint
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -199,6 +200,48 @@ impl ConstraintEvaluator for EarthLimbEvaluator {
 
     fn as_any(&self) -> &dyn std::any::Any {
         self
+    }
+
+    fn compute_named_values(
+        &self,
+        ephemeris: &dyn crate::ephemeris::ephemeris_common::EphemerisBase,
+        target_ras: &[f64],
+        target_decs: &[f64],
+        time_indices: Option<&[usize]>,
+    ) -> PyResult<HashMap<String, Array2<f64>>> {
+        let (times_filtered, obs_filtered) =
+            extract_observer_ephemeris_data!(ephemeris, time_indices);
+
+        let target_vectors = radec_to_unit_vectors_batch(target_ras, target_decs);
+        let n_targets = target_ras.len();
+        let n_times = times_filtered.len();
+
+        let mut center_units = vec![[0.0; 3]; n_times];
+        for t in 0..n_times {
+            let obs_pos = [
+                obs_filtered[[t, 0]],
+                obs_filtered[[t, 1]],
+                obs_filtered[[t, 2]],
+            ];
+            center_units[t] = normalize_vector(&[-obs_pos[0], -obs_pos[1], -obs_pos[2]]);
+        }
+
+        let mut earth_limb_angle_deg = Array2::<f64>::zeros((n_targets, n_times));
+        for i in 0..n_targets {
+            let target_vec = [
+                target_vectors[[i, 0]],
+                target_vectors[[i, 1]],
+                target_vectors[[i, 2]],
+            ];
+            for t in 0..n_times {
+                let cos_angle = dot_product(&target_vec, &center_units[t]);
+                earth_limb_angle_deg[[i, t]] = cos_angle.clamp(-1.0, 1.0).acos().to_degrees();
+            }
+        }
+
+        let mut values = HashMap::new();
+        values.insert("earth_limb_angle_deg".to_string(), earth_limb_angle_deg);
+        Ok(values)
     }
 
     /// Vectorized batch evaluation - MUCH faster than calling evaluate() in a loop

--- a/src/constraints/eclipse.rs
+++ b/src/constraints/eclipse.rs
@@ -6,6 +6,7 @@ use chrono::{DateTime, Utc};
 use ndarray::Array2;
 use pyo3::PyResult;
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 
 /// Configuration for eclipse constraint
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -92,6 +93,19 @@ impl EclipseEvaluator {
         }
 
         (false, 0.0)
+    }
+
+    /// Continuous shadow-depth proxy, independent of `umbra_only` and of whether the
+    /// point is actually violating the constraint: 0.0 = fully sunlit (or outside the
+    /// penumbra cone entirely), increasing smoothly through the penumbra and umbra to
+    /// 1.0 at the shadow axis (deepest point of the umbra).
+    fn shadow_depth_frac(obs_pos: [f64; 3], sun_pos: [f64; 3]) -> f64 {
+        match Self::shadow_geometry(obs_pos, sun_pos) {
+            Some((dist_to_axis, _umbra_radius, penumbra_radius)) if penumbra_radius > 0.0 => {
+                (1.0 - dist_to_axis / penumbra_radius).clamp(0.0, 1.0)
+            }
+            _ => 0.0,
+        }
     }
 
     /// Compute eclipse mask for all times (returns true where eclipse occurs)
@@ -252,6 +266,42 @@ impl ConstraintEvaluator for EclipseEvaluator {
         Ok(Some(result))
     }
 
+    fn compute_named_values(
+        &self,
+        ephemeris: &dyn crate::ephemeris::ephemeris_common::EphemerisBase,
+        target_ras: &[f64],
+        _target_decs: &[f64],
+        time_indices: Option<&[usize]>,
+    ) -> PyResult<HashMap<String, Array2<f64>>> {
+        let (times_filtered, sun_filtered, obs_filtered) =
+            extract_standard_ephemeris_data!(ephemeris, time_indices);
+
+        let n_targets = target_ras.len();
+        let n_times = times_filtered.len();
+        let depths: Vec<f64> = (0..n_times)
+            .map(|i| {
+                let obs_pos = [
+                    obs_filtered[[i, 0]],
+                    obs_filtered[[i, 1]],
+                    obs_filtered[[i, 2]],
+                ];
+                let sun_pos = [
+                    sun_filtered[[i, 0]],
+                    sun_filtered[[i, 1]],
+                    sun_filtered[[i, 2]],
+                ];
+                Self::shadow_depth_frac(obs_pos, sun_pos)
+            })
+            .collect();
+
+        // Eclipse is target-independent - broadcast to all targets.
+        let eclipse_depth_frac = Array2::from_shape_fn((n_targets, n_times), |(_, t)| depths[t]);
+
+        let mut values = HashMap::new();
+        values.insert("eclipse_depth_frac".to_string(), eclipse_depth_frac);
+        Ok(values)
+    }
+
     fn name(&self) -> String {
         format!(
             "Eclipse({})",
@@ -304,5 +354,42 @@ mod tests {
 
         assert!(!in_umbra_only, "point should be outside umbra");
         assert!(in_penumbra, "point should be inside penumbra");
+    }
+
+    #[test]
+    fn test_shadow_depth_frac_fully_sunlit_is_zero() {
+        let sun_pos = [AU_TO_KM, 0.0, 0.0];
+        // Observer on the sunlit side of Earth (same side as the Sun) - never in shadow.
+        let obs_pos = [7000.0, 0.0, 0.0];
+        assert_eq!(EclipseEvaluator::shadow_depth_frac(obs_pos, sun_pos), 0.0);
+    }
+
+    #[test]
+    fn test_shadow_depth_frac_peaks_on_axis_and_decreases_outward() {
+        let sun_pos = [AU_TO_KM, 0.0, 0.0];
+        let s = 7000.0;
+        let on_axis = [-s, 0.0, 0.0];
+        let (_dist_to_axis, umbra_radius, penumbra_radius) =
+            EclipseEvaluator::shadow_geometry(on_axis, sun_pos).expect("shadow geometry");
+
+        let depth_on_axis = EclipseEvaluator::shadow_depth_frac(on_axis, sun_pos);
+        assert!(
+            (depth_on_axis - 1.0).abs() < 1e-9,
+            "depth on shadow axis should be 1.0, got {depth_on_axis}"
+        );
+
+        let mid_penumbra = [-s, 0.5 * (umbra_radius + penumbra_radius), 0.0];
+        let depth_mid = EclipseEvaluator::shadow_depth_frac(mid_penumbra, sun_pos);
+        assert!(
+            depth_mid > 0.0 && depth_mid < depth_on_axis,
+            "depth should decrease moving outward from the shadow axis, got {depth_mid}"
+        );
+
+        let outside = [-s, penumbra_radius * 1.5, 0.0];
+        let depth_outside = EclipseEvaluator::shadow_depth_frac(outside, sun_pos);
+        assert_eq!(
+            depth_outside, 0.0,
+            "depth should be zero outside the penumbra cone"
+        );
     }
 }

--- a/src/constraints/moon_phase.rs
+++ b/src/constraints/moon_phase.rs
@@ -561,6 +561,48 @@ impl ConstraintEvaluator for MoonPhaseEvaluator {
         Ok(result)
     }
 
+    fn compute_named_values(
+        &self,
+        ephemeris: &dyn crate::ephemeris::ephemeris_common::EphemerisBase,
+        target_ras: &[f64],
+        target_decs: &[f64],
+        time_indices: Option<&[usize]>,
+    ) -> PyResult<HashMap<String, Array2<f64>>> {
+        let (times_filtered,) = extract_time_data!(ephemeris, time_indices);
+
+        let n_targets = target_ras.len();
+        let n_times = times_filtered.len();
+
+        let illuminations = ephemeris.moon_illumination(time_indices)?;
+        let moon_positions_all = ephemeris.get_moon_positions()?;
+        let observer_positions_all = ephemeris.get_gcrs_positions()?;
+
+        let moon_positions = if let Some(indices) = time_indices {
+            moon_positions_all.select(ndarray::Axis(0), indices)
+        } else {
+            moon_positions_all
+        };
+        let observer_positions = if let Some(indices) = time_indices {
+            observer_positions_all.select(ndarray::Axis(0), indices)
+        } else {
+            observer_positions_all
+        };
+
+        let moon_units = self.compute_moon_unit_vectors(&moon_positions, &observer_positions)?;
+        let target_vectors = radec_to_unit_vectors_batch(target_ras, target_decs);
+        let cos_angles = target_vectors.dot(&moon_units.t());
+        let moon_distance_deg =
+            cos_angles.mapv(|cos_angle| cos_angle.clamp(-1.0, 1.0).acos().to_degrees());
+
+        let moon_illumination_frac =
+            Array2::from_shape_fn((n_targets, n_times), |(_, t)| illuminations[t]);
+
+        let mut values = HashMap::new();
+        values.insert("moon_illumination_frac".to_string(), moon_illumination_frac);
+        values.insert("moon_distance_deg".to_string(), moon_distance_deg);
+        Ok(values)
+    }
+
     fn name(&self) -> String {
         self.format_name()
     }

--- a/src/constraints/moon_proximity.rs
+++ b/src/constraints/moon_proximity.rs
@@ -1,10 +1,14 @@
 /// Moon proximity constraint implementation
-use super::core::{track_violations, ConstraintConfig, ConstraintEvaluator, ConstraintResult};
+use super::core::{
+    compute_angle_deg_batch, track_violations, ConstraintConfig, ConstraintEvaluator,
+    ConstraintResult,
+};
 use crate::utils::vector_math::radec_to_unit_vectors_batch;
 use chrono::{DateTime, Utc};
 use ndarray::Array2;
 use pyo3::PyResult;
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 
 /// Configuration for Moon proximity constraint
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -332,6 +336,26 @@ impl ConstraintEvaluator for MoonProximityEvaluator {
         }
 
         Ok(result)
+    }
+
+    fn compute_named_values(
+        &self,
+        ephemeris: &dyn crate::ephemeris::ephemeris_common::EphemerisBase,
+        target_ras: &[f64],
+        target_decs: &[f64],
+        time_indices: Option<&[usize]>,
+    ) -> PyResult<HashMap<String, Array2<f64>>> {
+        let (_times_slice, moon_positions_slice, observer_positions_slice) =
+            extract_body_ephemeris_data!(ephemeris, time_indices, get_moon_positions);
+        let angle_deg = compute_angle_deg_batch(
+            target_ras,
+            target_decs,
+            &moon_positions_slice,
+            &observer_positions_slice,
+        );
+        let mut values = HashMap::new();
+        values.insert("moon_angle_deg".to_string(), angle_deg);
+        Ok(values)
     }
 
     fn name(&self) -> String {

--- a/src/constraints/orbit_pole.rs
+++ b/src/constraints/orbit_pole.rs
@@ -4,6 +4,7 @@ use crate::utils::vector_math::radec_to_unit_vectors_batch;
 use ndarray::Array2;
 use pyo3::PyResult;
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 
 /// Configuration for Orbit Pole constraint
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -518,6 +519,87 @@ impl ConstraintEvaluator for OrbitPoleEvaluator {
         }
 
         Ok(Some(result))
+    }
+
+    fn compute_named_values(
+        &self,
+        ephemeris: &dyn crate::ephemeris::ephemeris_common::EphemerisBase,
+        target_ras: &[f64],
+        target_decs: &[f64],
+        time_indices: Option<&[usize]>,
+    ) -> PyResult<HashMap<String, Array2<f64>>> {
+        let (times_filtered,) = extract_time_data!(ephemeris, time_indices);
+
+        let n_targets = target_ras.len();
+        let n_times = times_filtered.len();
+        let mut orbit_pole_angle_deg = Array2::<f64>::zeros((n_targets, n_times));
+
+        let target_vectors = radec_to_unit_vectors_batch(target_ras, target_decs);
+
+        let gcrs_data = ephemeris.data().gcrs.as_ref().ok_or_else(|| {
+            pyo3::exceptions::PyValueError::new_err("GCRS data not available in ephemeris")
+        })?;
+        if gcrs_data.ncols() < 6 {
+            return Ok(HashMap::new());
+        }
+
+        let mut north_pole_directions = Array2::<f64>::zeros((n_times, 3));
+        let mut south_pole_directions = Array2::<f64>::zeros((n_times, 3));
+        for i in 0..n_times {
+            let source_i = if let Some(indices) = time_indices {
+                indices[i]
+            } else {
+                i
+            };
+            let position = [
+                gcrs_data[[source_i, 0]],
+                gcrs_data[[source_i, 1]],
+                gcrs_data[[source_i, 2]],
+            ];
+            let velocity = [
+                gcrs_data[[source_i, 3]],
+                gcrs_data[[source_i, 4]],
+                gcrs_data[[source_i, 5]],
+            ];
+            let (north_pole, south_pole) = self.calculate_orbital_poles(&position, &velocity);
+            north_pole_directions[[i, 0]] = north_pole[0];
+            north_pole_directions[[i, 1]] = north_pole[1];
+            north_pole_directions[[i, 2]] = north_pole[2];
+            south_pole_directions[[i, 0]] = south_pole[0];
+            south_pole_directions[[i, 1]] = south_pole[1];
+            south_pole_directions[[i, 2]] = south_pole[2];
+        }
+
+        for j in 0..n_targets {
+            let target_vec = [
+                target_vectors[[j, 0]],
+                target_vectors[[j, 1]],
+                target_vectors[[j, 2]],
+            ];
+            for i in 0..n_times {
+                let north_pole_vec = [
+                    north_pole_directions[[i, 0]],
+                    north_pole_directions[[i, 1]],
+                    north_pole_directions[[i, 2]],
+                ];
+                let south_pole_vec = [
+                    south_pole_directions[[i, 0]],
+                    south_pole_directions[[i, 1]],
+                    south_pole_directions[[i, 2]],
+                ];
+                let cos_angle_north =
+                    crate::utils::vector_math::dot_product(&target_vec, &north_pole_vec);
+                let cos_angle_south =
+                    crate::utils::vector_math::dot_product(&target_vec, &south_pole_vec);
+                // Nearer pole = larger cosine.
+                let max_cos_angle = cos_angle_north.max(cos_angle_south);
+                orbit_pole_angle_deg[[j, i]] = max_cos_angle.clamp(-1.0, 1.0).acos().to_degrees();
+            }
+        }
+
+        let mut values = HashMap::new();
+        values.insert("orbit_pole_angle_deg".to_string(), orbit_pole_angle_deg);
+        Ok(values)
     }
 
     fn name(&self) -> String {

--- a/src/constraints/orbit_ram.rs
+++ b/src/constraints/orbit_ram.rs
@@ -4,6 +4,7 @@ use crate::utils::vector_math::radec_to_unit_vectors_batch;
 use ndarray::Array2;
 use pyo3::PyResult;
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 
 /// Configuration for Orbit RAM constraint
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -318,6 +319,68 @@ impl ConstraintEvaluator for OrbitRamEvaluator {
         }
 
         Ok(Some(result))
+    }
+
+    fn compute_named_values(
+        &self,
+        ephemeris: &dyn crate::ephemeris::ephemeris_common::EphemerisBase,
+        target_ras: &[f64],
+        target_decs: &[f64],
+        time_indices: Option<&[usize]>,
+    ) -> PyResult<HashMap<String, Array2<f64>>> {
+        let (times_filtered,) = extract_time_data!(ephemeris, time_indices);
+
+        let n_targets = target_ras.len();
+        let n_times = times_filtered.len();
+        let mut orbit_ram_angle_deg = Array2::<f64>::zeros((n_targets, n_times));
+
+        let target_vectors = radec_to_unit_vectors_batch(target_ras, target_decs);
+
+        let gcrs_data = ephemeris.data().gcrs.as_ref().ok_or_else(|| {
+            pyo3::exceptions::PyValueError::new_err("GCRS data not available in ephemeris")
+        })?;
+        if gcrs_data.ncols() < 6 {
+            return Ok(HashMap::new());
+        }
+
+        let mut ram_directions = Array2::<f64>::zeros((n_times, 3));
+        for i in 0..n_times {
+            let source_i = if let Some(indices) = time_indices {
+                indices[i]
+            } else {
+                i
+            };
+            let velocity = [
+                gcrs_data[[source_i, 3]],
+                gcrs_data[[source_i, 4]],
+                gcrs_data[[source_i, 5]],
+            ];
+            let ram_unit = crate::utils::vector_math::normalize_vector(&velocity);
+            ram_directions[[i, 0]] = ram_unit[0];
+            ram_directions[[i, 1]] = ram_unit[1];
+            ram_directions[[i, 2]] = ram_unit[2];
+        }
+
+        for j in 0..n_targets {
+            let target_vec = [
+                target_vectors[[j, 0]],
+                target_vectors[[j, 1]],
+                target_vectors[[j, 2]],
+            ];
+            for i in 0..n_times {
+                let ram_vec = [
+                    ram_directions[[i, 0]],
+                    ram_directions[[i, 1]],
+                    ram_directions[[i, 2]],
+                ];
+                let cos_angle = crate::utils::vector_math::dot_product(&target_vec, &ram_vec);
+                orbit_ram_angle_deg[[j, i]] = cos_angle.clamp(-1.0, 1.0).acos().to_degrees();
+            }
+        }
+
+        let mut values = HashMap::new();
+        values.insert("orbit_ram_angle_deg".to_string(), orbit_ram_angle_deg);
+        Ok(values)
     }
 
     fn name(&self) -> String {

--- a/src/constraints/solar_roll.rs
+++ b/src/constraints/solar_roll.rs
@@ -6,9 +6,11 @@
 /// body frame convention shared with `boresight_rotate` in roll_range.rs.
 use super::core::{track_violations, ConstraintConfig, ConstraintEvaluator, ConstraintResult};
 use crate::ephemeris::ephemeris_common::EphemerisBase;
+use crate::utils::vector_math::radec_to_unit_vectors_batch;
 use ndarray::Array2;
 use pyo3::PyResult;
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 
 pub fn default_panel_normal() -> [f64; 3] {
     [0.0, 1.0, 0.0]
@@ -558,6 +560,58 @@ impl ConstraintEvaluator for SolarRollEvaluator {
             }
         }
         Ok(result)
+    }
+
+    fn compute_named_values(
+        &self,
+        ephemeris: &dyn EphemerisBase,
+        target_ras: &[f64],
+        target_decs: &[f64],
+        time_indices: Option<&[usize]>,
+    ) -> PyResult<HashMap<String, Array2<f64>>> {
+        let (times_filtered,) = extract_time_data!(ephemeris, time_indices);
+        let n_targets = target_ras.len();
+        let n_times = times_filtered.len();
+
+        let sun = ephemeris.get_sun_positions()?;
+        let obs = ephemeris.get_gcrs_positions()?;
+        let sun_units: Vec<[f64; 3]> = (0..n_times)
+            .map(|i| {
+                let idx = time_indices.map_or(i, |indices| indices[i]);
+                let v = [
+                    sun[[idx, 0]] - obs[[idx, 0]],
+                    sun[[idx, 1]] - obs[[idx, 1]],
+                    sun[[idx, 2]] - obs[[idx, 2]],
+                ];
+                let n = norm3(v);
+                if n < NEAR_ZERO {
+                    [1.0, 0.0, 0.0]
+                } else {
+                    [v[0] / n, v[1] / n, v[2] / n]
+                }
+            })
+            .collect();
+
+        let target_vectors = radec_to_unit_vectors_batch(target_ras, target_decs);
+        let mut solar_optimal_roll_deg_arr = Array2::<f64>::zeros((n_targets, n_times));
+        for j in 0..n_targets {
+            let target = [
+                target_vectors[[j, 0]],
+                target_vectors[[j, 1]],
+                target_vectors[[j, 2]],
+            ];
+            for i in 0..n_times {
+                solar_optimal_roll_deg_arr[[j, i]] =
+                    solar_optimal_roll_deg(&target, &sun_units[i], self.panel_normal);
+            }
+        }
+
+        let mut values = HashMap::new();
+        values.insert(
+            "solar_optimal_roll_deg".to_string(),
+            solar_optimal_roll_deg_arr,
+        );
+        Ok(values)
     }
 
     fn name(&self) -> String {

--- a/src/constraints/sun_proximity.rs
+++ b/src/constraints/sun_proximity.rs
@@ -1,10 +1,14 @@
 /// Sun proximity constraint implementation
-use super::core::{track_violations, ConstraintConfig, ConstraintEvaluator, ConstraintResult};
+use super::core::{
+    compute_angle_deg_batch, track_violations, ConstraintConfig, ConstraintEvaluator,
+    ConstraintResult,
+};
 use crate::utils::vector_math::radec_to_unit_vectors_batch;
 use chrono::{DateTime, Utc};
 use ndarray::Array2;
 use pyo3::PyResult;
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 
 /// Configuration for Sun proximity constraint
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -314,6 +318,22 @@ impl ConstraintEvaluator for SunProximityEvaluator {
         }
 
         Ok(result)
+    }
+
+    fn compute_named_values(
+        &self,
+        ephemeris: &dyn crate::ephemeris::ephemeris_common::EphemerisBase,
+        target_ras: &[f64],
+        target_decs: &[f64],
+        time_indices: Option<&[usize]>,
+    ) -> PyResult<HashMap<String, Array2<f64>>> {
+        let (_times_filtered, sun_filtered, obs_filtered) =
+            extract_standard_ephemeris_data!(ephemeris, time_indices);
+        let angle_deg =
+            compute_angle_deg_batch(target_ras, target_decs, &sun_filtered, &obs_filtered);
+        let mut values = HashMap::new();
+        values.insert("sun_angle_deg".to_string(), angle_deg);
+        Ok(values)
     }
 
     fn name(&self) -> String {

--- a/tests/constraints/conftest.py
+++ b/tests/constraints/conftest.py
@@ -345,8 +345,8 @@ def constraint_result_with_rust_ref(
         ],
         all_satisfied=False,
         constraint_name="test",
-        _rust_result_ref=dummy_rust_result,  # type: ignore
     )
+    result._rust_result_ref = dummy_rust_result  # type: ignore
     return result, dummy_rust_result
 
 

--- a/tests/constraints/conftest.py
+++ b/tests/constraints/conftest.py
@@ -54,6 +54,7 @@ class DummyRustResult:
                 },
             )()
         ]
+        self.constraint_values: dict[str, list[float]] = {}
 
     def in_constraint(self, time: datetime) -> bool:
         self._in_constraint_calls.append(time)
@@ -70,6 +71,7 @@ class DummyMovingBodyResult:
         self.visibility: List[str] = []
         self.all_satisfied: bool = False
         self.constraint_name: str = "DummyMovingBody"
+        self.constraint_values: dict[str, list[float]] = {}
 
 
 @pytest.fixture

--- a/tests/constraints/constraint_result/conftest.py
+++ b/tests/constraints/constraint_result/conftest.py
@@ -47,8 +47,8 @@ def constraint_result_with_rust_ref(
         ],
         all_satisfied=False,
         constraint_name="test",
-        _rust_result_ref=dummy_rust_result,  # type: ignore
     )
+    result._rust_result_ref = dummy_rust_result  # type: ignore
     return result, dummy_rust_result
 
 

--- a/tests/constraints/constraint_result/conftest.py
+++ b/tests/constraints/constraint_result/conftest.py
@@ -15,6 +15,7 @@ class DummyRustResult:
         self.constraint_name: str = "DummyConstraint"
         self._in_constraint_calls: list[datetime] = []
         self._in_constraint_return: bool = True
+        self.constraint_values: dict[str, list[float]] = {}
 
     def in_constraint(self, time: datetime) -> bool:
         self._in_constraint_calls.append(time)

--- a/tests/constraints/sun_moon_angle_constraint/test_sun_moon_angle_constraint.py
+++ b/tests/constraints/sun_moon_angle_constraint/test_sun_moon_angle_constraint.py
@@ -357,9 +357,8 @@ class TestConstraintValues:
             target_dec=target_dec,
         )
 
-        assert list(result.constraint_values.keys()) == ["sun_angle_deg"]
+        assert set(result.constraint_values) == {"sun_angle_deg"}
         assert len(result.constraint_values["sun_angle_deg"]) == 1
-
         expected_deg = sun.separation(SkyCoord(target_ra, target_dec, unit="deg")).deg
         # Loose tolerance: astropy's GCRS separation and the Rust geometric angle
         # differ slightly due to frame/light-time handling, not a real discrepancy.

--- a/tests/constraints/sun_moon_angle_constraint/test_sun_moon_angle_constraint.py
+++ b/tests/constraints/sun_moon_angle_constraint/test_sun_moon_angle_constraint.py
@@ -341,3 +341,57 @@ class TestAndConstraints:
         assert len(earth_cons.visibility) == len(earth_earth_cons.visibility), (
             "Both arrays should be equal"
         )
+
+
+class TestConstraintValues:
+    """Verify evaluate() records the underlying continuous value(s) it thresholds."""
+
+    def test_sun_angle_deg_matches_independent_computation(
+        self, sun_constraint: Any, tle_ephem: Any, timestamp: Any, sun: Any
+    ) -> None:
+        target_ra, target_dec = 10.0, 20.0
+        result = sun_constraint.evaluate(
+            ephemeris=tle_ephem,
+            times=[timestamp],
+            target_ra=target_ra,
+            target_dec=target_dec,
+        )
+
+        assert list(result.constraint_values.keys()) == ["sun_angle_deg"]
+        assert len(result.constraint_values["sun_angle_deg"]) == 1
+
+        expected_deg = sun.separation(SkyCoord(target_ra, target_dec, unit="deg")).deg
+        # Loose tolerance: astropy's GCRS separation and the Rust geometric angle
+        # differ slightly due to frame/light-time handling, not a real discrepancy.
+        assert result.constraint_values["sun_angle_deg"][0] == pytest.approx(
+            expected_deg, abs=0.01
+        )
+
+    def test_moon_angle_deg_matches_independent_computation(
+        self, moon_constraint: Any, tle_ephem: Any, timestamp: Any, moon: Any
+    ) -> None:
+        target_ra, target_dec = 250.0, -23.0
+        result = moon_constraint.evaluate(
+            ephemeris=tle_ephem,
+            times=[timestamp],
+            target_ra=target_ra,
+            target_dec=target_dec,
+        )
+
+        assert list(result.constraint_values.keys()) == ["moon_angle_deg"]
+        expected_deg = moon.separation(SkyCoord(target_ra, target_dec, unit="deg")).deg
+        assert result.constraint_values["moon_angle_deg"][0] == pytest.approx(
+            expected_deg, abs=0.01
+        )
+
+    def test_and_combinator_namespaces_child_values(
+        self, sun_constraint: Any, moon_constraint: Any, tle_ephem: Any
+    ) -> None:
+        combined = sun_constraint & moon_constraint
+        result = combined.evaluate(ephemeris=tle_ephem, target_ra=10, target_dec=20)
+
+        assert "sun.sun_angle_deg" in result.constraint_values
+        assert "moon.moon_angle_deg" in result.constraint_values
+        assert len(result.constraint_values["sun.sun_angle_deg"]) == len(
+            result.constraint_values["moon.moon_angle_deg"]
+        )

--- a/tests/ephemeris/parquet_ephemeris/conftest.py
+++ b/tests/ephemeris/parquet_ephemeris/conftest.py
@@ -69,7 +69,7 @@ def _write_parquet(path: str, schema_overrides: dict[str, str] | None = None) ->
     }
     renamed = {overrides.get(k, k): v for k, v in cols.items()}
     table = pa.table(renamed)
-    pq.write_table(table, path)  # type: ignore[no-untyped-call]
+    pq.write_table(table, path)
 
 
 @pytest.fixture
@@ -113,5 +113,5 @@ def meters_parquet(tmp_path: Any) -> str:
         "vy": [r[5] * 1000.0 for r in rows],
         "vz": [r[6] * 1000.0 for r in rows],
     }
-    pq.write_table(pa.table(cols), str(p))  # type: ignore[no-untyped-call]
+    pq.write_table(pa.table(cols), str(p))
     return str(p)


### PR DESCRIPTION
This pull request introduces a new system for exposing named continuous values (such as airmass, altitude, and azimuth) computed during constraint evaluation, and refactors how constraint results are constructed and returned throughout the Python and Rust codebases. The changes improve extensibility, enable access to these values in Python, and streamline the interface between Rust and Python. It also updates the relevant Pydantic models and batch evaluation logic to support these enhancements.

**Major features and API changes:**

* Added a new `constraint_values` property to both the Rust and Python `ConstraintResult` types, making arrays of named continuous values (e.g., `airmass`, `altitude_deg`, `azimuth_deg`) available for each constraint evaluation. [[1]](diffhunk://#diff-7ed8034838678ab42bb592e27c3315872651998aec8719d99640b9bdd2ade077R83-R148) [[2]](diffhunk://#diff-7ed8034838678ab42bb592e27c3315872651998aec8719d99640b9bdd2ade077R191-R199) [[3]](diffhunk://#diff-3dba367a5f087cea43ad0c5fbf3566683f951c8c54401173472d5b6bf22c07b3L95-R175) [[4]](diffhunk://#diff-3dba367a5f087cea43ad0c5fbf3566683f951c8c54401173472d5b6bf22c07b3R1030) [[5]](diffhunk://#diff-3dba367a5f087cea43ad0c5fbf3566683f951c8c54401173472d5b6bf22c07b3R1862)
* Updated the Rust `ConstraintEvaluator` trait and its implementations (`AirmassEvaluator`, `AltAzEvaluator`) to compute and return these named values in a generic way, using a `HashMap<String, Array2<f64>>`. [[1]](diffhunk://#diff-6fe92523964da662eae10f873dbdf349ae4f634f52fd07d4335c33b3afd479f0R141-R154) [[2]](diffhunk://#diff-fb958a3f42500d52170e71340210fabfc8c5ecd073c7470a27fec2400045a4c0R248-R278)

**Refactoring and interface improvements:**

* Refactored the Python `ConstraintResult` model to use factory methods (`_from_rust_result`, `_from_swept`) for construction, ensuring that private attributes and lazy access to Rust results are handled cleanly and type-safely. [[1]](diffhunk://#diff-3dba367a5f087cea43ad0c5fbf3566683f951c8c54401173472d5b6bf22c07b3L60-R138) [[2]](diffhunk://#diff-3dba367a5f087cea43ad0c5fbf3566683f951c8c54401173472d5b6bf22c07b3L308-R389)
* Updated all Python evaluation methods to use the new construction pattern and to pass along `constraint_values` where appropriate, both for single and batch evaluations. [[1]](diffhunk://#diff-3dba367a5f087cea43ad0c5fbf3566683f951c8c54401173472d5b6bf22c07b3R255) [[2]](diffhunk://#diff-3dba367a5f087cea43ad0c5fbf3566683f951c8c54401173472d5b6bf22c07b3L217-R294) [[3]](diffhunk://#diff-3dba367a5f087cea43ad0c5fbf3566683f951c8c54401173472d5b6bf22c07b3L280-R375) [[4]](diffhunk://#diff-3dba367a5f087cea43ad0c5fbf3566683f951c8c54401173472d5b6bf22c07b3R610) [[5]](diffhunk://#diff-3dba367a5f087cea43ad0c5fbf3566683f951c8c54401173472d5b6bf22c07b3L558-R627)

**Type annotations and interface updates:**

* Updated type annotations in Rust and Python to reflect that constraint evaluation now returns `ConstraintResult` (or a list thereof), not generic `Any`. [[1]](diffhunk://#diff-7ed8034838678ab42bb592e27c3315872651998aec8719d99640b9bdd2ade077L581-R656) [[2]](diffhunk://#diff-7ed8034838678ab42bb592e27c3315872651998aec8719d99640b9bdd2ade077L619-R694)
* Updated the Python import logic to bring in the new Rust-side `ConstraintResult` type.

These changes make it much easier to access and utilize continuous-valued constraint diagnostics in downstream analysis and visualization, and improve maintainability by unifying the result construction interface.