### PR TITLE
fix: use WGS-72 for reference TLE propagation

### DIFF
--- a/docs/ephemeris_tle.rst
+++ b/docs/ephemeris_tle.rst
@@ -4,6 +4,10 @@ Using TLEEphemeris
 This example shows how to propagate a satellite from a Two-Line Element (TLE)
 set and obtain positions in different frames.
 
+TLE propagation follows the reference AFSPC SGP4 convention and uses the
+WGS-72 geopotential constants. This is independent of the WGS-84 ellipsoid
+used for geodetic latitude, longitude, and height.
+
 .. code-block:: python
 
     import datetime as dt

--- a/docs/ephemeris_tle.rst
+++ b/docs/ephemeris_tle.rst
@@ -4,9 +4,15 @@ Using TLEEphemeris
 This example shows how to propagate a satellite from a Two-Line Element (TLE)
 set and obtain positions in different frames.
 
-TLE propagation follows the reference AFSPC SGP4 convention and uses the
-WGS-72 geopotential constants. This is independent of the WGS-84 ellipsoid
-used for geodetic latitude, longitude, and height.
+TLE propagation uses the WGS-72 geopotential constants and improved SGP4
+operation mode, matching the defaults used by Python SGP4 and Skyfield. The
+AFSPC TLE epoch and sidereal-time expressions are used when initializing the
+propagator. These choices are independent of the WGS-84 ellipsoid used for
+geodetic latitude, longitude, and height.
+
+``TLEEphemeris`` exposes these choices through the read-only ``propagator``,
+``gravity_model``, and ``sgp4_operation_mode`` properties so serialized
+products can record the actual implementation rather than duplicating labels.
 
 .. code-block:: python
 

--- a/rust_ephem/_rust_ephem.pyi
+++ b/rust_ephem/_rust_ephem.pyi
@@ -988,6 +988,21 @@ class TLEEphemeris(Ephemeris):
         ...
 
     @property
+    def propagator(self) -> Literal["SGP4"]:
+        """Propagation model used for TLE states"""
+        ...
+
+    @property
+    def gravity_model(self) -> Literal["WGS-72"]:
+        """Geopotential model used by SGP4"""
+        ...
+
+    @property
+    def sgp4_operation_mode(self) -> Literal["improved"]:
+        """SGP4 operation mode"""
+        ...
+
+    @property
     def begin(self) -> datetime:
         """Start time of the ephemeris"""
         ...

--- a/src/ephemeris/tle_ephemeris.rs
+++ b/src/ephemeris/tle_ephemeris.rs
@@ -643,10 +643,11 @@ impl TLEEphemeris {
         }
         let elements = elements_vec.into_iter().next().unwrap();
 
-        // Create SGP4 constants
-        let constants = Constants::from_elements(&elements).map_err(|e| {
-            pyo3::exceptions::PyRuntimeError::new_err(format!("SGP4 constants error: {e:?}"))
-        })?;
+        // TLEs use the reference AFSPC SGP4 convention, including WGS-72.
+        let constants =
+            Constants::from_elements_afspc_compatibility_mode(&elements).map_err(|e| {
+                pyo3::exceptions::PyRuntimeError::new_err(format!("SGP4 constants error: {e:?}"))
+            })?;
 
         // Prepare output array
         let n = times.len();
@@ -661,9 +662,11 @@ impl TLEEphemeris {
             let minutes_since_epoch = elements.datetime_to_minutes_since_epoch(&naive_dt).unwrap();
 
             // Propagate to get position and velocity in TEME
-            let pred = constants.propagate(minutes_since_epoch).map_err(|e| {
-                pyo3::exceptions::PyRuntimeError::new_err(format!("Propagation error: {e:?}"))
-            })?;
+            let pred = constants
+                .propagate_afspc_compatibility_mode(minutes_since_epoch)
+                .map_err(|e| {
+                    pyo3::exceptions::PyRuntimeError::new_err(format!("Propagation error: {e:?}"))
+                })?;
 
             // Store results - use direct assignment for better performance
             let mut row = out.row_mut(i);

--- a/src/ephemeris/tle_ephemeris.rs
+++ b/src/ephemeris/tle_ephemeris.rs
@@ -230,6 +230,24 @@ impl TLEEphemeris {
         &self.tle2
     }
 
+    /// Get the propagation model used for TLE states
+    #[getter]
+    fn propagator(&self) -> &'static str {
+        "SGP4"
+    }
+
+    /// Get the geopotential model used by SGP4
+    #[getter]
+    fn gravity_model(&self) -> &'static str {
+        "WGS-72"
+    }
+
+    /// Get the SGP4 operation mode
+    #[getter]
+    fn sgp4_operation_mode(&self) -> &'static str {
+        "improved"
+    }
+
     /// Get the TLERecord used to generate this ephemeris
     #[getter]
     fn tle_record(&self, py: Python) -> PyResult<Py<PyAny>> {
@@ -662,11 +680,9 @@ impl TLEEphemeris {
             let minutes_since_epoch = elements.datetime_to_minutes_since_epoch(&naive_dt).unwrap();
 
             // Propagate to get position and velocity in TEME
-            let pred = constants
-                .propagate_afspc_compatibility_mode(minutes_since_epoch)
-                .map_err(|e| {
-                    pyo3::exceptions::PyRuntimeError::new_err(format!("Propagation error: {e:?}"))
-                })?;
+            let pred = constants.propagate(minutes_since_epoch).map_err(|e| {
+                pyo3::exceptions::PyRuntimeError::new_err(format!("Propagation error: {e:?}"))
+            })?;
 
             // Store results - use direct assignment for better performance
             let mut row = out.row_mut(i);

--- a/tests/ephemeris/tle_reading/test_tle_reading.py
+++ b/tests/ephemeris/tle_reading/test_tle_reading.py
@@ -50,7 +50,7 @@ class TestLegacyTLEMethod:
         assert tle_record.source == "direct"
 
     def test_teme_state_matches_afspc_wgs72_reference(self, legacy_ephem) -> None:
-        """TLE propagation uses the reference AFSPC/WGS-72 convention."""
+        """TLE propagation uses reference WGS-72 constants."""
         import numpy as np
 
         assert legacy_ephem.teme_pv is not None
@@ -65,6 +65,49 @@ class TestLegacyTLEMethod:
             [4.013365806388614, 6.490615877545802, 0.6420202312262405],
             rtol=0.0,
             atol=1.0e-10,
+        )
+
+    def test_exposes_authoritative_propagation_metadata(self, legacy_ephem) -> None:
+        assert legacy_ephem.propagator == "SGP4"
+        assert legacy_ephem.gravity_model == "WGS-72"
+        assert legacy_ephem.sgp4_operation_mode == "improved"
+
+    def test_deep_space_teme_state_matches_improved_mode_reference(self) -> None:
+        """Low-inclination deep-space propagation matches Python SGP4 mode i."""
+        import numpy as np
+
+        line1 = "1 23599U 95029B   06171.76535463  .00085586  12891-6  12956-2 0  2905"
+        line2 = "2 23599   6.9327   0.2849 5782022 274.4436  25.2425  4.47796565123555"
+        epoch = datetime(
+            2006,
+            6,
+            21,
+            2,
+            3,
+            6,
+            640031,
+            tzinfo=timezone.utc,
+        )
+        ephemeris = rust_ephem.TLEEphemeris(
+            line1,
+            line2,
+            epoch,
+            epoch,
+            60,
+        )
+
+        assert ephemeris.teme_pv is not None
+        np.testing.assert_allclose(
+            ephemeris.teme_pv.position[0],
+            [-2341.197623553257, 24245.804332004496, 2948.1857961154833],
+            rtol=0.0,
+            atol=1.0e-5,
+        )
+        np.testing.assert_allclose(
+            ephemeris.teme_pv.velocity[0],
+            [-2.603407349049543, -0.2761757405958612, -0.03390750870872316],
+            rtol=0.0,
+            atol=1.0e-9,
         )
 
 

--- a/tests/ephemeris/tle_reading/test_tle_reading.py
+++ b/tests/ephemeris/tle_reading/test_tle_reading.py
@@ -49,6 +49,24 @@ class TestLegacyTLEMethod:
         assert tle_record.epoch == legacy_ephem.tle_epoch
         assert tle_record.source == "direct"
 
+    def test_teme_state_matches_afspc_wgs72_reference(self, legacy_ephem) -> None:
+        """TLE propagation uses the reference AFSPC/WGS-72 convention."""
+        import numpy as np
+
+        assert legacy_ephem.teme_pv is not None
+        np.testing.assert_allclose(
+            legacy_ephem.teme_pv.position[0],
+            [5334.444330496902, -3532.8016179466867, 2318.3789513323654],
+            rtol=0.0,
+            atol=1.0e-7,
+        )
+        np.testing.assert_allclose(
+            legacy_ephem.teme_pv.velocity[0],
+            [4.013365806388614, 6.490615877545802, 0.6420202312262405],
+            rtol=0.0,
+            atol=1.0e-10,
+        )
+
 
 class TestFileReading:
     """Test reading TLEs from files."""


### PR DESCRIPTION
## Problem

`TLEEphemeris` initialized TLE mean elements with the `sgp4` crate's default WGS-84 constants. Reference SGP4 implementations used by Skyfield and Python `sgp4` initialize TLEs with WGS-72 and use improved operation mode. That mismatch produced a 31.8 m state difference at the external-simulator initialization epoch.

## Solution

- initialize TLE constants with `from_elements_afspc_compatibility_mode()` to select the WGS-72 model
- propagate with the normal `propagate()` path, which matches improved SGP4 operation mode
- expose read-only `TLEEphemeris` provenance: `propagator`, `gravity_model`, and `sgp4_operation_mode`
- add LEO and low-inclination deep-space regression vectors against Python `sgp4`
- document that SGP4 uses WGS-72 dynamics while terrestrial/geodetic conversions continue using the WGS-84 ellipsoid

This is stacked on #180 so one immutable rust-ephem commit provides both the osculating-state conversion and corrected TLE propagation required by the integration plan.

## Validation

- `cargo test --all-targets`: passed
- repository hooks passed, including fmt, cargo check, clippy, docs, Ruff, and mypy
- changed Python regression tests passed
- GitHub Python/Rust test and lint jobs passed
- Tam comparison state is within 0.343 m and 0.00212 m/s of the AD Skyfield state; the prior 31.8 m gravity-model mismatch is removed
