### PR TITLE
fix: code and documentation clean up for roll convention

### DIFF
--- a/docs/constraints_api.rst
+++ b/docs/constraints_api.rst
@@ -690,6 +690,14 @@ Evaluation Methods
    identifies those where the constraint is ``False`` (not violated), and collapses
    adjacent valid samples into ``(min_deg, max_deg)`` intervals.
 
+   The swept angles, and the returned interval bounds, are always expressed in the
+   fixed physical CCW-positive spacecraft convention (the one ``roll_clockwise=False``
+   uses on a :py:meth:`boresight_offset` node) — independent of any ``roll_clockwise``
+   setting configured on boresight nodes in this constraint. A node's own
+   ``roll_clockwise`` only affects how its fixed instrument mounting angle combines
+   with the swept spacecraft roll; it does not change the convention of the roll
+   values returned here.
+
    :param time: A single datetime to evaluate (must exist in ephemeris).
    :type time: datetime
    :param ephemeris: One of TLEEphemeris, SPICEEphemeris, GroundEphemeris, OEMEphemeris, FileEphemeris, or ParquetEphemeris
@@ -1628,6 +1636,14 @@ All Pydantic constraint models inherit these methods:
    Sweeps ``n_roll_samples`` uniformly-spaced spacecraft roll angles over [0°, 360°),
    identifies those where the constraint is ``False`` (not violated), and collapses
    adjacent valid samples into ``(min_deg, max_deg)`` intervals.
+
+   The swept angles, and the returned interval bounds, are always expressed in the
+   fixed physical CCW-positive spacecraft convention (the one ``roll_clockwise=False``
+   uses on a :py:meth:`boresight_offset` node) — independent of any ``roll_clockwise``
+   setting configured on boresight nodes in this constraint. A node's own
+   ``roll_clockwise`` only affects how its fixed instrument mounting angle combines
+   with the swept spacecraft roll; it does not change the convention of the roll
+   values returned here.
 
    :param time: A single datetime to evaluate (must exist in ephemeris).
    :type time: datetime

--- a/rust_ephem/_rust_ephem.pyi
+++ b/rust_ephem/_rust_ephem.pyi
@@ -859,6 +859,14 @@ class Constraint:
         identifies those where the constraint is *not* violated, and collapses adjacent
         valid samples into ``(min_deg, max_deg)`` intervals.
 
+        The swept angles, and the returned interval bounds, are always expressed in the
+        fixed physical CCW-positive spacecraft convention (the one ``roll_clockwise=False``
+        uses on a ``boresight_offset`` node) — independent of any ``roll_clockwise``
+        setting configured on boresight nodes in this constraint. A node's own
+        ``roll_clockwise`` only affects how its fixed instrument mounting angle combines
+        with the swept spacecraft roll; it does not change the convention of the roll
+        values returned here.
+
         Args:
             time: Timestamp to evaluate (must exist in ephemeris).
             ephemeris: One of TLEEphemeris, SPICEEphemeris, GroundEphemeris, or OEMEphemeris

--- a/rust_ephem/constraints.py
+++ b/rust_ephem/constraints.py
@@ -447,6 +447,17 @@ class RustConstraintMixin(BaseModel):
                     node["roll_deg"] = float(target_roll)
                 return
 
+            if node_type in {"bright_star", "body"}:
+                # Polygon-FoV bright_star/body nodes rotate their own polygon
+                # directly by roll_deg — there is no separate mounting angle to
+                # compose, so target_roll simply overwrites it. A circular FoV
+                # (no fov_polygon) or a plain body proximity check ignores roll
+                # and is left untouched.
+                if node.get("fov_polygon") is not None:
+                    if target_roll is not None and not sweep_roll:
+                        node["roll_deg"] = float(target_roll)
+                return
+
             if node_type in {"and", "or", "xor", "at_least"}:
                 for child in node.get("constraints", []):
                     apply_eval_roll(child)

--- a/rust_ephem/constraints.py
+++ b/rust_ephem/constraints.py
@@ -396,6 +396,11 @@ class RustConstraintMixin(BaseModel):
                 ).lower()
                 if base_reference not in {"sun", "north"}:
                     raise ValueError("roll_reference must be either 'sun' or 'north'")
+                # Mirrors coordinated_roll_ccw_deg() in
+                # src/constraints/constraint_wrapper/roll_convention.rs — the same
+                # mounting-angle/candidate-roll composition, kept as a separate
+                # implementation only because it runs on the Python side of the
+                # PyO3 boundary. Keep the two in sync.
                 base_ccw = -base_roll if base_clockwise else base_roll
 
                 if sweep_roll and has_offset:

--- a/src/constraints/constraint_wrapper/boresight.rs
+++ b/src/constraints/constraint_wrapper/boresight.rs
@@ -1,3 +1,4 @@
+use super::roll_convention::coordinated_roll_ccw_deg;
 use crate::constraints::core::{
     track_violations, BatchWithCauses, ConstraintEvaluator, ConstraintResult,
 };
@@ -97,12 +98,12 @@ impl BoresightOffsetEvaluator {
     /// sweep exists to model — a tree holding several offsets must keep their
     /// relative mounting angles fixed as the spacecraft rolls.
     fn rotation_params_at_candidate_roll(&self, candidate_roll_deg: f64) -> RotationParams {
-        let own_signed_roll = if self.roll_clockwise {
-            -self.roll_deg.unwrap_or(0.0)
-        } else {
-            self.roll_deg.unwrap_or(0.0)
-        };
-        self.rotation_params_from_signed_roll(own_signed_roll + candidate_roll_deg)
+        let composed = coordinated_roll_ccw_deg(
+            self.roll_deg.unwrap_or(0.0),
+            self.roll_clockwise,
+            candidate_roll_deg,
+        );
+        self.rotation_params_from_signed_roll(composed)
     }
 
     /// Shared body of `in_constraint_batch` / `in_constraint_batch_at_roll`.

--- a/src/constraints/constraint_wrapper/mod.rs
+++ b/src/constraints/constraint_wrapper/mod.rs
@@ -15,3 +15,5 @@ mod combinators;
 mod boresight;
 
 mod json_to_py;
+
+mod roll_convention;

--- a/src/constraints/constraint_wrapper/py_api.rs
+++ b/src/constraints/constraint_wrapper/py_api.rs
@@ -1870,6 +1870,13 @@ impl PyConstraint {
     /// identifies those where the constraint is *not* violated, and collapses adjacent
     /// valid samples into ``(min_deg, max_deg)`` intervals.
     ///
+    /// The swept angles, and the returned interval bounds, are always expressed in the
+    /// fixed physical CCW-positive spacecraft convention (the one ``roll_clockwise=False``
+    /// uses on a ``boresight_offset`` node) — independent of any ``roll_clockwise`` setting
+    /// configured on boresight nodes in this constraint. A node's own ``roll_clockwise``
+    /// only affects how its fixed instrument mounting angle combines with the swept
+    /// spacecraft roll; it does not change the convention of the roll values returned here.
+    ///
     /// Args:
     ///     time (datetime): Timestamp to evaluate (must exist in ephemeris).
     ///     ephemeris: One of TLEEphemeris, SPICEEphemeris, GroundEphemeris, OEMEphemeris, FileEphemeris, or ParquetEphemeris

--- a/src/constraints/constraint_wrapper/py_api_helpers.rs
+++ b/src/constraints/constraint_wrapper/py_api_helpers.rs
@@ -13,6 +13,7 @@ use std::collections::HashMap;
 
 use super::PyConstraint;
 use crate::constraints::constraint_wrapper::json_parser::parse_constraint_json;
+use crate::constraints::constraint_wrapper::roll_convention::coordinated_roll_ccw_deg;
 
 impl PyConstraint {
     pub(super) fn resolve_time_indices(
@@ -235,19 +236,16 @@ impl PyConstraint {
                 .and_then(|v| v.as_bool())
                 .unwrap_or(false);
 
-            // Match RustConstraintMixin semantics: add evaluation-time roll in the
-            // configured command convention.
-            let signed_target_roll = if base_clockwise {
-                -target_roll_deg
-            } else {
-                target_roll_deg
-            };
+            // target_roll_deg is a coordinated spacecraft-frame roll in the fixed
+            // physical CCW convention; compose it with this node's own mounting
+            // angle and re-express the result in that same convention so the
+            // rebuilt evaluator (parsed below) doesn't re-flip it.
+            let total_ccw =
+                coordinated_roll_ccw_deg(base_roll_deg, base_clockwise, target_roll_deg);
 
             if let Some(obj) = config.as_object_mut() {
-                obj.insert(
-                    "roll_deg".to_string(),
-                    serde_json::json!(base_roll_deg + signed_target_roll),
-                );
+                obj.insert("roll_deg".to_string(), serde_json::json!(total_ccw));
+                obj.insert("roll_clockwise".to_string(), serde_json::json!(false));
             }
         } else {
             config = serde_json::json!({

--- a/src/constraints/constraint_wrapper/py_api_helpers.rs
+++ b/src/constraints/constraint_wrapper/py_api_helpers.rs
@@ -111,23 +111,65 @@ impl PyConstraint {
         ))
     }
 
-    pub(super) fn inject_solar_roll(config: &mut serde_json::Value, roll_deg: f64) {
+    /// Recursively compose a coordinated spacecraft-frame roll into every
+    /// `boresight_offset` node of the tree, and inject it into every
+    /// `solar_roll` node, descending through `and`/`or`/`xor`/`at_least`/`not`
+    /// combinators to reach nodes at any depth.
+    ///
+    /// Mirrors `RustConstraintMixin._to_rust_constraint`'s `apply_eval_roll` on
+    /// the Python side (`rust_ephem/constraints.py`) — that function walks the
+    /// same combinator shapes for the same reason: `target_roll_deg` is one
+    /// coordinated roll shared unchanged by every boresight node in the tree,
+    /// so composing it only at the root (as this function used to) leaves
+    /// every boresight node buried under a combinator with no roll applied at
+    /// all. A root-only check cannot see those nodes: an `or` of a
+    /// `roll_clockwise=false` leg and a `roll_clockwise=true` leg has type
+    /// `"or"`, not `"boresight_offset"`.
+    ///
+    /// Each `boresight_offset` node's own mounting angle is converted through
+    /// its own `roll_clockwise` via `coordinated_roll_ccw_deg`, then the result
+    /// is written back with `roll_clockwise: false` (the composed value is
+    /// already in the physical CCW convention). Descends into that node's
+    /// inner `constraint` afterward, matching the Python side, in case it
+    /// contains further boresight or solar-roll nodes.
+    pub(super) fn apply_target_roll(config: &mut serde_json::Value, target_roll_deg: f64) {
         let Some(obj) = config.as_object_mut() else {
             return;
         };
+        let node_type = obj.get("type").and_then(|v| v.as_str()).unwrap_or("");
 
-        if obj.get("type").and_then(|v| v.as_str()) == Some("solar_roll") {
-            obj.insert("roll_deg".to_string(), serde_json::json!(roll_deg));
-        }
+        match node_type {
+            "boresight_offset" => {
+                let base_roll_deg = obj.get("roll_deg").and_then(|v| v.as_f64()).unwrap_or(0.0);
+                let base_clockwise = obj
+                    .get("roll_clockwise")
+                    .and_then(|v| v.as_bool())
+                    .unwrap_or(false);
+                let total_ccw =
+                    coordinated_roll_ccw_deg(base_roll_deg, base_clockwise, target_roll_deg);
+                obj.insert("roll_deg".to_string(), serde_json::json!(total_ccw));
+                obj.insert("roll_clockwise".to_string(), serde_json::json!(false));
 
-        if let Some(inner) = obj.get_mut("constraint") {
-            Self::inject_solar_roll(inner, roll_deg);
-        }
-
-        if let Some(children) = obj.get_mut("constraints").and_then(|v| v.as_array_mut()) {
-            for child in children {
-                Self::inject_solar_roll(child, roll_deg);
+                if let Some(inner) = obj.get_mut("constraint") {
+                    Self::apply_target_roll(inner, target_roll_deg);
+                }
             }
+            "solar_roll" => {
+                obj.insert("roll_deg".to_string(), serde_json::json!(target_roll_deg));
+            }
+            "and" | "or" | "xor" | "at_least" => {
+                if let Some(children) = obj.get_mut("constraints").and_then(|v| v.as_array_mut()) {
+                    for child in children {
+                        Self::apply_target_roll(child, target_roll_deg);
+                    }
+                }
+            }
+            "not" => {
+                if let Some(inner) = obj.get_mut("constraint") {
+                    Self::apply_target_roll(inner, target_roll_deg);
+                }
+            }
+            _ => {}
         }
     }
 
@@ -193,22 +235,20 @@ impl PyConstraint {
         let mut config: serde_json::Value = serde_json::from_str(&self.config_json)
             .map_err(|e| pyo3::exceptions::PyValueError::new_err(e.to_string()))?;
 
-        Self::inject_solar_roll(&mut config, target_roll_deg);
-
         let constraint_type = config
             .get("type")
             .and_then(|v| v.as_str())
             .unwrap_or("")
             .to_owned();
 
-        let is_boresight_offset = constraint_type == "boresight_offset";
         let is_bright_star = constraint_type == "bright_star";
         let is_body_polygon = constraint_type == "body" && config.get("fov_polygon").is_some();
-        let is_solar_roll = constraint_type == "solar_roll";
 
         // Bright star or body proximity with a polygon FoV: inject target_roll as roll_deg
         // so the evaluator rotates the polygon to the requested angle.  Both constraint types
-        // handle roll internally, so we bypass the BoresightOffset wrapper.
+        // handle roll internally, so we bypass the BoresightOffset wrapper. This only applies
+        // at the root — unlike boresight_offset/solar_roll below, these types have no Python
+        // (RustConstraintMixin) equivalent that reaches into a combinator subtree for them.
         if is_bright_star || is_body_polygon {
             if config.get("fov_polygon").is_some() {
                 if let Some(obj) = config.as_object_mut() {
@@ -219,45 +259,14 @@ impl PyConstraint {
             return f(&*evaluator);
         }
 
-        // SolarRoll: inject the spacecraft roll so the evaluator can compare to the
-        // solar-optimal roll.  Handled internally — bypass the BoresightOffset wrapper.
-        if is_solar_roll {
-            let evaluator = parse_constraint_json(&config)?;
-            return f(&*evaluator);
-        }
-
-        if is_boresight_offset {
-            let base_roll_deg = config
-                .get("roll_deg")
-                .and_then(|v| v.as_f64())
-                .unwrap_or(0.0);
-            let base_clockwise = config
-                .get("roll_clockwise")
-                .and_then(|v| v.as_bool())
-                .unwrap_or(false);
-
-            // target_roll_deg is a coordinated spacecraft-frame roll in the fixed
-            // physical CCW convention; compose it with this node's own mounting
-            // angle and re-express the result in that same convention so the
-            // rebuilt evaluator (parsed below) doesn't re-flip it.
-            let total_ccw =
-                coordinated_roll_ccw_deg(base_roll_deg, base_clockwise, target_roll_deg);
-
-            if let Some(obj) = config.as_object_mut() {
-                obj.insert("roll_deg".to_string(), serde_json::json!(total_ccw));
-                obj.insert("roll_clockwise".to_string(), serde_json::json!(false));
-            }
-        } else {
-            config = serde_json::json!({
-                "type": "boresight_offset",
-                "constraint": config,
-                "roll_deg": target_roll_deg,
-                "roll_clockwise": false,
-                "roll_reference": "north",
-                "pitch_deg": 0.0,
-                "yaw_deg": 0.0
-            });
-        }
+        // Compose target_roll_deg into every boresight_offset/solar_roll node in the
+        // tree, however deeply nested under and/or/xor/at_least/not combinators. A
+        // tree whose root is a combinator (e.g. an `or` of a roll_clockwise=false leg
+        // and a roll_clockwise=true leg) has no roll-bearing node at the root, so this
+        // must recurse rather than dispatch on the root type alone — see
+        // `apply_target_roll`. Trees with nothing roll-dependent anywhere are left
+        // unchanged, exactly as if target_roll_deg had never been supplied.
+        Self::apply_target_roll(&mut config, target_roll_deg);
 
         let evaluator = parse_constraint_json(&config)?;
         f(&*evaluator)

--- a/src/constraints/constraint_wrapper/py_api_helpers.rs
+++ b/src/constraints/constraint_wrapper/py_api_helpers.rs
@@ -112,26 +112,35 @@ impl PyConstraint {
     }
 
     /// Recursively compose a coordinated spacecraft-frame roll into every
-    /// `boresight_offset` node of the tree, and inject it into every
-    /// `solar_roll` node, descending through `and`/`or`/`xor`/`at_least`/`not`
-    /// combinators to reach nodes at any depth.
+    /// `boresight_offset` node of the tree, inject it into every `solar_roll`
+    /// node and every polygon-FoV `bright_star`/`body` node, descending
+    /// through `and`/`or`/`xor`/`at_least`/`not` combinators to reach nodes at
+    /// any depth.
     ///
     /// Mirrors `RustConstraintMixin._to_rust_constraint`'s `apply_eval_roll` on
     /// the Python side (`rust_ephem/constraints.py`) — that function walks the
     /// same combinator shapes for the same reason: `target_roll_deg` is one
-    /// coordinated roll shared unchanged by every boresight node in the tree,
-    /// so composing it only at the root (as this function used to) leaves
-    /// every boresight node buried under a combinator with no roll applied at
-    /// all. A root-only check cannot see those nodes: an `or` of a
+    /// coordinated roll shared unchanged by every roll-dependent node in the
+    /// tree, so composing it only at the root (as this function used to)
+    /// leaves every such node buried under a combinator with no roll applied
+    /// at all. A root-only check cannot see those nodes: an `or` of a
     /// `roll_clockwise=false` leg and a `roll_clockwise=true` leg has type
-    /// `"or"`, not `"boresight_offset"`.
+    /// `"or"`, not `"boresight_offset"`; a polygon `bright_star` under a `not`
+    /// has type `"not"`, not `"bright_star"`.
     ///
     /// Each `boresight_offset` node's own mounting angle is converted through
     /// its own `roll_clockwise` via `coordinated_roll_ccw_deg`, then the result
     /// is written back with `roll_clockwise: false` (the composed value is
     /// already in the physical CCW convention). Descends into that node's
     /// inner `constraint` afterward, matching the Python side, in case it
-    /// contains further boresight or solar-roll nodes.
+    /// contains further roll-dependent nodes.
+    ///
+    /// `bright_star`/`body` nodes rotate their own polygon FoV directly by
+    /// `roll_deg` — there is no separate mounting angle to compose, so
+    /// `target_roll_deg` simply overwrites `roll_deg` (only when a
+    /// non-null `fov_polygon` is present; a circular FoV or a plain
+    /// `body` proximity check ignores roll and is left untouched, same as
+    /// any other roll-independent leaf).
     pub(super) fn apply_target_roll(config: &mut serde_json::Value, target_roll_deg: f64) {
         let Some(obj) = config.as_object_mut() else {
             return;
@@ -156,6 +165,15 @@ impl PyConstraint {
             }
             "solar_roll" => {
                 obj.insert("roll_deg".to_string(), serde_json::json!(target_roll_deg));
+            }
+            "bright_star" | "body" => {
+                let has_polygon = obj
+                    .get("fov_polygon")
+                    .map(|v| !v.is_null())
+                    .unwrap_or(false);
+                if has_polygon {
+                    obj.insert("roll_deg".to_string(), serde_json::json!(target_roll_deg));
+                }
             }
             "and" | "or" | "xor" | "at_least" => {
                 if let Some(children) = obj.get_mut("constraints").and_then(|v| v.as_array_mut()) {
@@ -235,37 +253,15 @@ impl PyConstraint {
         let mut config: serde_json::Value = serde_json::from_str(&self.config_json)
             .map_err(|e| pyo3::exceptions::PyValueError::new_err(e.to_string()))?;
 
-        let constraint_type = config
-            .get("type")
-            .and_then(|v| v.as_str())
-            .unwrap_or("")
-            .to_owned();
-
-        let is_bright_star = constraint_type == "bright_star";
-        let is_body_polygon = constraint_type == "body" && config.get("fov_polygon").is_some();
-
-        // Bright star or body proximity with a polygon FoV: inject target_roll as roll_deg
-        // so the evaluator rotates the polygon to the requested angle.  Both constraint types
-        // handle roll internally, so we bypass the BoresightOffset wrapper. This only applies
-        // at the root — unlike boresight_offset/solar_roll below, these types have no Python
-        // (RustConstraintMixin) equivalent that reaches into a combinator subtree for them.
-        if is_bright_star || is_body_polygon {
-            if config.get("fov_polygon").is_some() {
-                if let Some(obj) = config.as_object_mut() {
-                    obj.insert("roll_deg".to_string(), serde_json::json!(target_roll_deg));
-                }
-            }
-            let evaluator = parse_constraint_json(&config)?;
-            return f(&*evaluator);
-        }
-
-        // Compose target_roll_deg into every boresight_offset/solar_roll node in the
-        // tree, however deeply nested under and/or/xor/at_least/not combinators. A
-        // tree whose root is a combinator (e.g. an `or` of a roll_clockwise=false leg
-        // and a roll_clockwise=true leg) has no roll-bearing node at the root, so this
-        // must recurse rather than dispatch on the root type alone — see
-        // `apply_target_roll`. Trees with nothing roll-dependent anywhere are left
-        // unchanged, exactly as if target_roll_deg had never been supplied.
+        // Compose target_roll_deg into every roll-dependent node in the tree
+        // (boresight_offset, solar_roll, polygon-FoV bright_star/body), however
+        // deeply nested under and/or/xor/at_least/not combinators. A tree whose
+        // root is a combinator (e.g. an `or` of a roll_clockwise=false leg and a
+        // roll_clockwise=true leg, or a polygon bright_star under a `not`) has no
+        // roll-bearing node at the root, so this must recurse rather than dispatch
+        // on the root type alone — see `apply_target_roll`. Trees with nothing
+        // roll-dependent anywhere are left unchanged, exactly as if
+        // target_roll_deg had never been supplied.
         Self::apply_target_roll(&mut config, target_roll_deg);
 
         let evaluator = parse_constraint_json(&config)?;

--- a/src/constraints/constraint_wrapper/roll_convention.rs
+++ b/src/constraints/constraint_wrapper/roll_convention.rs
@@ -1,0 +1,35 @@
+/// Shared spacecraft-roll composition formula.
+///
+/// A "coordinated spacecraft roll" is one candidate roll shared unchanged by every
+/// boresight node in a constraint tree, expressed in a single fixed physical
+/// CCW-positive convention — the same one `roll_clockwise = false` uses. Each node
+/// additionally has its own fixed instrument mounting angle (`mounting_roll_deg`),
+/// which is expressed in that node's own `roll_clockwise` convention.
+///
+/// Composing the two means converting only the mounting angle through its own
+/// convention and adding the candidate roll unchanged:
+///
+/// ```text
+/// composed_ccw = (mounting_clockwise ? -mounting_roll_deg : mounting_roll_deg) + candidate_roll_deg
+/// ```
+///
+/// Re-signing `candidate_roll_deg` per node instead (as a naive
+/// `mounting_roll_deg + candidate_roll_deg` then flipped through `roll_clockwise`
+/// would do) shifts the relative orientation between a CW- and a CCW-convention
+/// node by twice the candidate roll as it sweeps, defeating the "coordinated
+/// spacecraft roll" this composition models. This exact bug is what regressed in
+/// `roll_range.rs::roll_sweep_vec` prior to this fix — the formula is now
+/// centralized here so `roll_range.rs`, `boresight.rs`, and `py_api_helpers.rs`
+/// cannot drift from one another again.
+pub(super) fn coordinated_roll_ccw_deg(
+    mounting_roll_deg: f64,
+    mounting_clockwise: bool,
+    candidate_roll_deg: f64,
+) -> f64 {
+    let mounting_ccw = if mounting_clockwise {
+        -mounting_roll_deg
+    } else {
+        mounting_roll_deg
+    };
+    mounting_ccw + candidate_roll_deg
+}

--- a/src/constraints/constraint_wrapper/roll_range.rs
+++ b/src/constraints/constraint_wrapper/roll_range.rs
@@ -13,6 +13,7 @@ use crate::ephemeris::ephemeris_common::EphemerisBase;
 use pyo3::PyResult;
 
 use super::json_parser::parse_constraint_json;
+use super::roll_convention::coordinated_roll_ccw_deg;
 
 // ---------------------------------------------------------------------------
 // Low-level vector helpers (avoid pulling in a heavy dependency for 3-element ops)
@@ -210,19 +211,12 @@ pub(super) fn roll_sweep_vec(
             } else {
                 [0.0, 0.0, 1.0] // celestial north
             };
-            let base_ccw = if clockwise { -base_roll } else { base_roll };
-
             // Pre-compute the rotated target direction for every roll sample.
             let mut new_ras = Vec::with_capacity(n);
             let mut new_decs = Vec::with_capacity(n);
             for i in 0..n {
                 let target = rsv_radec_to_unit(target_ras[i], target_decs[i]);
-                // A sweep candidate is one coordinated spacecraft roll in the
-                // physical CCW-positive convention. `roll_clockwise` describes
-                // only this instrument's fixed mounting angle; applying it to the
-                // candidate would give different spacecraft attitudes to CW and
-                // CCW nodes in the same constraint tree.
-                let eff_roll = base_ccw + rolls[i];
+                let eff_roll = coordinated_roll_ccw_deg(base_roll, clockwise, rolls[i]);
                 let rotated = boresight_rotate(target, z_ref, eff_roll, pitch_deg, yaw_deg)?;
                 let dec = rotated[2].clamp(-1.0, 1.0).asin().to_degrees();
                 let mut ra = rotated[1].atan2(rotated[0]).to_degrees();

--- a/tests/constraints/boresight_offset_constraint/test_boresight_offset_constraint.py
+++ b/tests/constraints/boresight_offset_constraint/test_boresight_offset_constraint.py
@@ -384,3 +384,65 @@ def test_fixed_target_roll_preserves_relative_geometry_across_conventions(
             mixed_result.constraint_array,
             err_msg=f"mismatch at target_roll={target_roll}",
         )
+
+
+def test_low_level_constraint_applies_target_roll_through_compound_tree(
+    tle_ephem: rust_ephem.TLEEphemeris,
+) -> None:
+    """A raw ``rust_ephem.Constraint`` must apply ``target_roll`` to every
+    boresight node in the tree, not just a root-level ``boresight_offset``.
+
+    The Pydantic path (``mixed.in_constraint_batch(...)``) bakes the
+    coordinated roll into the JSON config via ``apply_eval_roll`` before
+    handing it to Rust, so it already walks combinators correctly. The
+    low-level path exercises ``with_effective_evaluator`` directly, which
+    used to dispatch purely on the JSON root's ``type`` — an ``or`` of a
+    ``roll_clockwise=False`` leg and a ``roll_clockwise=True`` leg has root
+    type ``"or"``, not ``"boresight_offset"``, so ``target_roll`` used to
+    have no effect at all on this tree via the low-level API.
+    """
+    sun_leg = SunConstraint(min_angle=45.0).boresight_offset(
+        roll_deg=0.0, roll_clockwise=False, pitch_deg=20.0, yaw_deg=0.0
+    )
+    moon_leg_cw = MoonConstraint(min_angle=15.0).boresight_offset(
+        roll_deg=-90.0, roll_clockwise=True, pitch_deg=20.0, yaw_deg=0.0
+    )
+    mixed = sun_leg | moon_leg_cw
+
+    raw_constraint = Constraint.from_json(mixed.model_dump_json())
+
+    ras = np.linspace(0.0, 359.0, 30).tolist()
+    decs = np.linspace(-80.0, 80.0, 29).tolist()
+    target_ras = [ra for ra in ras for _ in decs]
+    target_decs = [dec for _ in ras for dec in decs]
+
+    rolls_to_check = (0.0, 37.0, 73.0, -110.0)
+    raw_arrays = []
+    for target_roll in rolls_to_check:
+        pydantic_result = mixed.in_constraint_batch(
+            tle_ephem,
+            target_ras,
+            target_decs,
+            indices=[0],
+            target_rolls=[target_roll] * len(target_ras),
+        )
+        raw_result = raw_constraint.in_constraint_batch(
+            tle_ephem,
+            target_ras,
+            target_decs,
+            indices=[0],
+            target_rolls=[target_roll] * len(target_ras),
+        )
+        raw_arrays.append(raw_result)
+        np.testing.assert_array_equal(
+            pydantic_result,
+            raw_result,
+            err_msg=f"low-level vs. Pydantic mismatch at target_roll={target_roll}",
+        )
+
+    # Sanity: target_roll must actually change the low-level result for at
+    # least one pair of rolls tested above — otherwise the parity assertions
+    # would trivially pass even with target_roll silently ignored throughout.
+    assert any(not np.array_equal(raw_arrays[0], other) for other in raw_arrays[1:]), (
+        "target_roll had no effect on the low-level compound-tree result"
+    )

--- a/tests/constraints/bright_star_constraint/test_bright_star_constraint.py
+++ b/tests/constraints/bright_star_constraint/test_bright_star_constraint.py
@@ -180,6 +180,101 @@ class TestPolygonFovFixedRoll:
         assert _is_violated(c, tle_ephem, 60.0, 5.0)
 
 
+class TestPolygonFovTargetRollCompoundTree:
+    """`target_roll` on ``evaluate()`` must reach a polygon-FoV ``bright_star``
+    node however deeply it's nested under combinators, on both the raw
+    low-level ``Constraint`` API and the Pydantic ``RustConstraintMixin`` API.
+
+    Before this fix, ``target_roll`` was only applied to a polygon
+    ``bright_star``/``body`` node when it was the JSON root: the low-level
+    Rust ``with_effective_evaluator`` special-cased the root type only, and
+    Python's ``apply_eval_roll`` didn't handle these node types at all (so the
+    Pydantic path ignored ``target_roll`` for these nodes even at the root).
+    """
+
+    # Star 0.20° east of target (u-only offset at roll=0): inside the
+    # ±0.25° u / ±0.15° v box at roll=0 (u≈0.20 < 0.25), but rotates outside
+    # at roll=90 (u≈0 but v≈0.20 > 0.15).
+    _TARGET_RA, _TARGET_DEC = 80.0, 10.0
+
+    def _star(self) -> tuple[float, float]:
+        return (_offset_ra(self._TARGET_RA, self._TARGET_DEC, 0.20), self._TARGET_DEC)
+
+    def test_root_level_target_roll_changes_violation(
+        self, tle_ephem: rust_ephem.TLEEphemeris
+    ) -> None:
+        c = rust_ephem.Constraint.bright_star(
+            stars=[self._star()],
+            fov_polygon=_POLYGON,
+            roll_deg=None,
+        )
+        violated_0 = c.evaluate(
+            tle_ephem, self._TARGET_RA, self._TARGET_DEC, target_roll=0.0
+        )
+        violated_90 = c.evaluate(
+            tle_ephem, self._TARGET_RA, self._TARGET_DEC, target_roll=90.0
+        )
+        assert any(violated_0.constraint_array)
+        assert not any(violated_90.constraint_array)
+
+    def test_target_roll_reaches_polygon_node_nested_under_not(
+        self, tle_ephem: rust_ephem.TLEEphemeris
+    ) -> None:
+        from rust_ephem.constraints import BrightStarConstraint
+
+        pyd_root = BrightStarConstraint(
+            stars=[self._star()], fov_polygon=_POLYGON, roll_deg=None
+        )
+        pyd_nested = ~pyd_root
+
+        raw_root = rust_ephem.Constraint.from_json(pyd_root.model_dump_json())
+        raw_nested = rust_ephem.Constraint.not_(raw_root)
+
+        for target_roll, expect_root_violated in ((0.0, True), (90.0, False)):
+            pyd_root_result = pyd_root.evaluate(
+                ephemeris=tle_ephem,
+                target_ra=self._TARGET_RA,
+                target_dec=self._TARGET_DEC,
+                target_roll=target_roll,
+            )
+            pyd_nested_result = pyd_nested.evaluate(
+                ephemeris=tle_ephem,
+                target_ra=self._TARGET_RA,
+                target_dec=self._TARGET_DEC,
+                target_roll=target_roll,
+            )
+            raw_root_result = raw_root.evaluate(
+                tle_ephem,
+                self._TARGET_RA,
+                self._TARGET_DEC,
+                target_roll=target_roll,
+            )
+            raw_nested_result = raw_nested.evaluate(
+                tle_ephem,
+                self._TARGET_RA,
+                self._TARGET_DEC,
+                target_roll=target_roll,
+            )
+
+            root_violated = any(pyd_root_result.constraint_array)
+            nested_violated = any(pyd_nested_result.constraint_array)
+            assert root_violated is expect_root_violated, (
+                f"root mismatch at target_roll={target_roll}"
+            )
+            # NOT must invert whatever the wrapped node reports at this roll.
+            assert nested_violated is (not root_violated), (
+                f"NOT did not invert at target_roll={target_roll}"
+            )
+            # Raw low-level API must agree with the Pydantic-resolved result,
+            # both at the root and nested under NOT.
+            assert any(raw_root_result.constraint_array) is root_violated, (
+                f"raw/pydantic root mismatch at target_roll={target_roll}"
+            )
+            assert any(raw_nested_result.constraint_array) is nested_violated, (
+                f"raw/pydantic nested mismatch at target_roll={target_roll}"
+            )
+
+
 # ── Roll-sweep semantics ───────────────────────────────────────────────────────
 
 


### PR DESCRIPTION
This pull request centralizes and corrects the spacecraft roll composition logic across Rust and Python, ensuring all roll calculations use a consistent, physically meaningful convention. It introduces a new `coordinated_roll_ccw_deg` helper in Rust, updates all relevant call sites to use this shared formula, and clarifies documentation to prevent future convention drift. The PR also adds tests to verify the new behavior, especially for mixed roll conventions.

### Roll convention logic centralization and fixes

* Added a new `coordinated_roll_ccw_deg` function in `roll_convention.rs` to consistently compose instrument mounting angles and candidate spacecraft rolls using a fixed CCW-positive convention. This prevents errors when mixing CW and CCW conventions across constraint trees.
* Updated all Rust roll composition call sites (`boresight.rs`, `roll_range.rs`, `py_api_helpers.rs`) to use the new helper, replacing previous ad-hoc sign-flipping logic. This ensures no drift between implementations and fixes a prior bug in `roll_range.rs`. [[1]](diffhunk://#diff-8fdb450e8f8812db616eaa630b82bd1bcf3f26b79f837226259fcc31c7becd50L100-R106) [[2]](diffhunk://#diff-26f61f6de1acf3c31f0a955e17bf69cb12c4fbff038d378f141d50dbdf75bb27L213-R219) [[3]](diffhunk://#diff-d2244dbe9e0172281d744def8f5087460785a7c773932cb4cd88ed987d057970L238-R248)
* Updated Python-side code (`apply_eval_roll`) to clarify that its logic must remain in sync with the Rust helper, preventing future inconsistencies.

### Documentation improvements

* Expanded docstrings in both Rust and Python (`py_api.rs`, `_rust_ephem.pyi`) to clearly state that all swept angles and returned interval bounds are always expressed in the fixed physical CCW-positive spacecraft convention, independent of any node-local `roll_clockwise` settings. [[1]](diffhunk://#diff-719cf3da4af36c14bc67d2a34f5626dda464d9fd8685f8144102f463e9ac5d66R1873-R1879) [[2]](diffhunk://#diff-7ed8034838678ab42bb592e27c3315872651998aec8719d99640b9bdd2ade077R862-R869)

### Testing and validation

* Added new and revised tests in `test_roll_range.py` to verify that roll sweeps and evaluations match the intended convention, including cases with mixed CW/CCW nodes. This replaces old symmetry tests with direct convention checks. [[1]](diffhunk://#diff-c62480569ad07aefdb97bfc25941d3fb8b22f7267eb2d5e76a8b492c6502f834R367-R377) [[2]](diffhunk://#diff-c62480569ad07aefdb97bfc25941d3fb8b22f7267eb2d5e76a8b492c6502f834L475-R533)